### PR TITLE
feat(storage): add storage exhaustion countermeasures (#123)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -283,7 +283,7 @@ gh auth login --with-token
 
 | Command                | Description                        |
 | ---------------------- | ---------------------------------- |
-| `nix run '.#switch'`   | Rebuild and activate configuration. On Linux and macOS it also prunes Nix generations older than 1 day after a successful switch |
+| `nix run '.#switch'`   | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day. Scheduled daemon GC remains separate |
 | `nix run '.#update'`   | Update flake inputs                |
 | `nix run '.#check'`    | Check flake configuration          |
 | `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage |

--- a/.github/README.md
+++ b/.github/README.md
@@ -283,7 +283,7 @@ gh auth login --with-token
 
 | Command                | Description                        |
 | ---------------------- | ---------------------------------- |
-| `nix run '.#switch'`   | Rebuild and activate configuration. On Linux it also prunes Nix generations older than 1 day after a successful switch |
+| `nix run '.#switch'`   | Rebuild and activate configuration. On Linux and macOS it also prunes Nix generations older than 1 day after a successful switch |
 | `nix run '.#update'`   | Update flake inputs                |
 | `nix run '.#check'`    | Check flake configuration          |
 | `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage |

--- a/.github/README.md
+++ b/.github/README.md
@@ -283,7 +283,7 @@ gh auth login --with-token
 
 | Command                | Description                        |
 | ---------------------- | ---------------------------------- |
-| `nix run '.#switch'`   | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day. Scheduled daemon GC remains separate |
+| `nix run '.#switch'`   | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day. Scheduled daemon GC remains separate and uses 1 day on both Linux and macOS |
 | `nix run '.#update'`   | Update flake inputs                |
 | `nix run '.#check'`    | Check flake configuration          |
 | `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage |

--- a/.github/README.md
+++ b/.github/README.md
@@ -283,7 +283,7 @@ gh auth login --with-token
 
 | Command                | Description                        |
 | ---------------------- | ---------------------------------- |
-| `nix run '.#switch'`   | Rebuild and activate configuration. On Linux it also prunes Nix generations older than 14 days after a successful switch |
+| `nix run '.#switch'`   | Rebuild and activate configuration. On Linux it also prunes Nix generations older than 1 day after a successful switch |
 | `nix run '.#update'`   | Update flake inputs                |
 | `nix run '.#check'`    | Check flake configuration          |
 | `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage |

--- a/.github/README.md
+++ b/.github/README.md
@@ -286,3 +286,4 @@ gh auth login --with-token
 | `nix run '.#switch'`   | Rebuild and activate configuration |
 | `nix run '.#update'`   | Update flake inputs                |
 | `nix run '.#check'`    | Check flake configuration          |
+| `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage |

--- a/.github/README.md
+++ b/.github/README.md
@@ -283,7 +283,7 @@ gh auth login --with-token
 
 | Command                | Description                        |
 | ---------------------- | ---------------------------------- |
-| `nix run '.#switch'`   | Rebuild and activate configuration |
+| `nix run '.#switch'`   | Rebuild and activate configuration. On Linux it also prunes Nix generations older than 14 days after a successful switch |
 | `nix run '.#update'`   | Update flake inputs                |
 | `nix run '.#check'`    | Check flake configuration          |
 | `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage |

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 set -o posix
 
-# What: classify auto-generated Nix GC roots and directly unlink current CANDIDATE roots.
+# What: classify auto-generated Nix GC roots and try direct current-user unlink for CANDIDATE roots.
 # When: run through gc-roots-delete before manual Nix store cleanup to remove only guarded stale candidates.
 # Example: nix run '.#gc-roots-delete'
 
@@ -14,13 +14,12 @@ Usage: list-stale-nix-gcroots.sh
 
 Behavior:
   Re-classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
-  Re-exec directly under sudo when deletion is needed
-  Unlink only current CANDIDATE symlink roots
+  Attempt current-user unlink of current CANDIDATE symlink roots
+  Warn and continue when a specific CANDIDATE root cannot be deleted
   Run nix-collect-garbage after candidate deletion
 
 Examples:
   nix run '.#gc-roots-delete'
-  sudo ./bin/ubuntu/list-stale-nix-gcroots.sh
 EOF
 }
 
@@ -58,11 +57,6 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-
-if [[ $EUID -ne 0 ]]; then
-  echo "INFO: gc-roots-delete re-executes this script via sudo so root-context Nix features are not required." >&2
-  exec sudo -- "$BASH" "$0" "$@"
-fi
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -227,8 +221,11 @@ EOF
 
   if [[ $state == CANDIDATE ]]; then
     echo "DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
-    unlink "$root_path"
-    delete_count=$((delete_count + 1))
+    if unlink "$root_path" 2>/dev/null; then
+      delete_count=$((delete_count + 1))
+    else
+      echo "WARNING root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=unlink-failed"
+    fi
   fi
 done <"$roots_file"
 

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -55,7 +55,6 @@ while [[ $# -gt 0 ]]; do
     exit 1
     ;;
   esac
-  shift
 done
 
 tmp_dir="$(mktemp -d)"

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -92,6 +92,10 @@ classify_root() {
   fi
 
   case "$link_path" in
+  */.local/state/home-manager/gcroots/current-home)
+    printf 'BLOCKED\tprotected-current-home-path'
+    return
+    ;;
   */.direnv/*)
     printf 'BLOCKED\tprotected-direnv-path'
     return

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -4,25 +4,24 @@ set -o nounset
 set -o pipefail
 set -o posix
 
-# What: classify auto-generated Nix GC roots and optionally delete current CANDIDATE roots.
-# When: run before manual Nix store cleanup to separate safe candidates from protected roots.
-# Example: nix run '.#gc-roots-delete' -- --dry-run
+# What: classify auto-generated Nix GC roots and delete current CANDIDATE roots.
+# When: run as root before manual Nix store cleanup to remove only guarded stale candidates.
+# Example: /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
 
 usage() {
   cat <<'EOF'
-Usage: list-stale-nix-gcroots.sh [--dry-run|--delete]
+Usage: list-stale-nix-gcroots.sh
 
-Modes:
-  --dry-run  Classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
-  --delete   Delete only current CANDIDATE roots, then run nix-collect-garbage
+Behavior:
+  Re-classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
+  Delete only current CANDIDATE roots
+  Run nix-collect-garbage after candidate deletion
 
 Examples:
-  nix run '.#gc-roots-delete' -- --dry-run
-  sudo nix run '.#gc-roots-delete' -- --delete
+  sudo /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
 EOF
 }
 
-MODE="dry-run"
 REAL_USER="${SUDO_USER:-$(id -un)}"
 
 safe_text() {
@@ -45,12 +44,6 @@ run_as_real_user() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-  --dry-run)
-    MODE="dry-run"
-    ;;
-  --delete)
-    MODE="delete"
-    ;;
   -h | --help)
     usage
     exit 0
@@ -64,8 +57,9 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-if [[ $MODE == delete && $EUID -ne 0 ]]; then
-  echo "ERROR: --delete requires root so only current CANDIDATE roots can be removed safely." >&2
+if [[ $EUID -ne 0 ]]; then
+  echo "ERROR: gc-roots-delete requires root so only current CANDIDATE roots can be removed safely." >&2
+  echo "HINT run as root: /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'" >&2
   exit 1
 fi
 
@@ -230,7 +224,7 @@ EOF
 
   printf '%s\t%s\t%s\t%s\t%s\n' "$state" "$reason" "$root_path" "$link_path" "$target_path" >>"$output_file"
 
-  if [[ $MODE == delete && $state == CANDIDATE ]]; then
+  if [[ $state == CANDIDATE ]]; then
     echo "DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
     rm -f "$root_path"
     delete_count=$((delete_count + 1))
@@ -247,14 +241,7 @@ while IFS=$'\t' read -r state reason root_path link_path target_path; do
     "$(safe_text "$target_path")"
 done <"$sorted_output_file"
 
-echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count} mode=${MODE}"
-
-if [[ $MODE == dry-run ]]; then
-  echo "HINT to delete CANDIDATEs run as root: nix run '.#gc-roots-delete' -- --delete"
-fi
-
-if [[ $MODE == delete ]]; then
-  echo "GC start deleted_roots=${delete_count}"
-  /nix/var/nix/profiles/default/bin/nix-collect-garbage
-  echo "GC done deleted_roots=${delete_count}"
-fi
+echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count}"
+echo "GC start deleted_roots=${delete_count}"
+/nix/var/nix/profiles/default/bin/nix-collect-garbage
+echo "GC done deleted_roots=${delete_count}"

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -170,6 +170,10 @@ sort -t $'\t' -k1,1 -k2,2 -k3,3 "$output_file" | awk -F '\t' '
 
 echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count} mode=${MODE}"
 
+if [[ $MODE == dry-run ]]; then
+  echo "HINT to delete CANDIDATEs run as root: nix run '.#gc-roots-review' -- --delete"
+fi
+
 if [[ $MODE == delete ]]; then
   echo "GC start deleted_roots=${delete_count}"
   nix-collect-garbage

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -4,9 +4,9 @@ set -o nounset
 set -o pipefail
 set -o posix
 
-# What: classify auto-generated Nix GC roots and delete current CANDIDATE roots.
-# When: run as root before manual Nix store cleanup to remove only guarded stale candidates.
-# Example: /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
+# What: classify auto-generated Nix GC roots and directly unlink current CANDIDATE roots.
+# When: run through gc-roots-delete before manual Nix store cleanup to remove only guarded stale candidates.
+# Example: nix run '.#gc-roots-delete'
 
 usage() {
   cat <<'EOF'
@@ -14,11 +14,13 @@ Usage: list-stale-nix-gcroots.sh
 
 Behavior:
   Re-classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
-  Delete only current CANDIDATE roots
+  Re-exec directly under sudo when deletion is needed
+  Unlink only current CANDIDATE symlink roots
   Run nix-collect-garbage after candidate deletion
 
 Examples:
-  sudo /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
+  nix run '.#gc-roots-delete'
+  sudo ./bin/ubuntu/list-stale-nix-gcroots.sh
 EOF
 }
 
@@ -58,9 +60,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $EUID -ne 0 ]]; then
-  echo "ERROR: gc-roots-delete requires root so only current CANDIDATE roots can be removed safely." >&2
-  echo "HINT run as root: /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'" >&2
-  exit 1
+  echo "INFO: gc-roots-delete re-executes this script via sudo so root-context Nix features are not required." >&2
+  exec sudo -- "$BASH" "$0" "$@"
 fi
 
 tmp_dir="$(mktemp -d)"
@@ -226,7 +227,7 @@ EOF
 
   if [[ $state == CANDIDATE ]]; then
     echo "DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
-    rm -f "$root_path"
+    unlink "$root_path"
     delete_count=$((delete_count + 1))
   fi
 done <"$roots_file"

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -25,6 +25,16 @@ EOF
 MODE="dry-run"
 REAL_USER="${SUDO_USER:-$(id -un)}"
 
+safe_text() {
+  value="$1"
+
+  if [[ -z $value ]]; then
+    return
+  fi
+
+  printf '%q' "$value"
+}
+
 run_as_real_user() {
   if [[ $EUID -eq 0 && $REAL_USER != root ]]; then
     runuser -u "$REAL_USER" -- "$@"
@@ -65,10 +75,12 @@ trap 'rm -rf "$tmp_dir"' EXIT
 active_paths_file="${tmp_dir}/active-paths.txt"
 roots_file="${tmp_dir}/roots.txt"
 output_file="${tmp_dir}/output.tsv"
+sorted_output_file="${tmp_dir}/sorted-output.tsv"
 
 : >"$active_paths_file"
 : >"$roots_file"
 : >"$output_file"
+: >"$sorted_output_file"
 
 find /nix/var/nix/gcroots/auto -maxdepth 1 -type l | sort >"$roots_file"
 
@@ -219,17 +231,21 @@ EOF
   printf '%s\t%s\t%s\t%s\t%s\n' "$state" "$reason" "$root_path" "$link_path" "$target_path" >>"$output_file"
 
   if [[ $MODE == delete && $state == CANDIDATE ]]; then
-    echo "DELETE root=${root_path} link=${link_path} reason=${reason}"
+    echo "DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
     rm -f "$root_path"
     delete_count=$((delete_count + 1))
   fi
 done <"$roots_file"
 
-sort -t $'\t' -k1,1 -k2,2 -k3,3 "$output_file" | awk -F '\t' '
-  {
-    printf "%s reason=%s root=%s link=%s target=%s\n", $1, $2, $3, $4, $5
-  }
-'
+sort -t $'\t' -k1,1 -k2,2 -k3,3 "$output_file" >"$sorted_output_file"
+while IFS=$'\t' read -r state reason root_path link_path target_path; do
+  printf '%s reason=%s root=%s link=%s target=%s\n' \
+    "$state" \
+    "$(safe_text "$reason")" \
+    "$(safe_text "$root_path")" \
+    "$(safe_text "$link_path")" \
+    "$(safe_text "$target_path")"
+done <"$sorted_output_file"
 
 echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count} mode=${MODE}"
 

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o posix
+
+usage() {
+  cat <<'EOF'
+Usage: list-stale-nix-gcroots.sh [--dry-run|--delete]
+
+Modes:
+  --dry-run  Classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
+  --delete   Delete only current CANDIDATE roots, then run nix-collect-garbage
+EOF
+}
+
+MODE="dry-run"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --dry-run)
+    MODE="dry-run"
+    ;;
+  --delete)
+    MODE="delete"
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: Unknown argument: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [[ $MODE == delete && $EUID -ne 0 ]]; then
+  echo "ERROR: --delete requires root so only current CANDIDATE roots can be removed safely." >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+active_paths_file="${tmp_dir}/active-paths.txt"
+roots_file="${tmp_dir}/roots.txt"
+output_file="${tmp_dir}/output.tsv"
+
+: >"$active_paths_file"
+: >"$roots_file"
+: >"$output_file"
+
+git worktree list --porcelain | awk '
+  /^worktree / { print substr($0, 10) }
+' >>"$active_paths_file"
+
+if command -v vde-worktree >/dev/null 2>&1; then
+  vde-worktree list --json 2>/dev/null | jq -r '.worktrees[]?.path // empty' >>"$active_paths_file" || true
+fi
+
+sort -u "$active_paths_file" -o "$active_paths_file"
+find /nix/var/nix/gcroots/auto -maxdepth 1 -type l | sort >"$roots_file"
+
+is_active_worktree_path() {
+  candidate_path="$1"
+
+  while IFS= read -r active_path; do
+    if [[ -z $active_path ]]; then
+      continue
+    fi
+
+    if [[ $candidate_path == "$active_path" || $candidate_path == "$active_path/"* ]]; then
+      return 0
+    fi
+  done <"$active_paths_file"
+
+  return 1
+}
+
+classify_root() {
+  root_path="$1"
+  link_path="$2"
+
+  base_name="$(basename "$link_path")"
+
+  if [[ $base_name == home-manager-* || $base_name == profile-* ]]; then
+    printf 'KEEP\tnix-profile-generation'
+    return
+  fi
+
+  case "$link_path" in
+  */.direnv/*)
+    printf 'BLOCKED\tprotected-direnv-path'
+    return
+    ;;
+  */result | */result-* | */result/*)
+    printf 'BLOCKED\tprotected-result-path'
+    return
+    ;;
+  /tmp/*)
+    printf 'BLOCKED\tprotected-temp-path'
+    return
+    ;;
+  esac
+
+  if [[ -n $link_path ]] && is_active_worktree_path "$link_path"; then
+    printf 'BLOCKED\tactive-worktree-path'
+    return
+  fi
+
+  if [[ -n $link_path && -e $link_path ]]; then
+    printf 'KEEP\tlive-link-path'
+    return
+  fi
+
+  if [[ $link_path == *"/.worktrees/"* ]]; then
+    printf 'CANDIDATE\tmissing-worktree-path'
+    return
+  fi
+
+  printf 'CANDIDATE\tmissing-link-path'
+}
+
+delete_count=0
+candidate_count=0
+keep_count=0
+blocked_count=0
+
+while IFS= read -r root_path; do
+  link_path="$(readlink "$root_path" 2>/dev/null || true)"
+  target_path="$(readlink -f "$root_path" 2>/dev/null || true)"
+
+  read -r state reason <<EOF
+$(classify_root "$root_path" "$link_path")
+EOF
+
+  case "$state" in
+  KEEP)
+    keep_count=$((keep_count + 1))
+    ;;
+  CANDIDATE)
+    candidate_count=$((candidate_count + 1))
+    ;;
+  BLOCKED)
+    blocked_count=$((blocked_count + 1))
+    ;;
+  esac
+
+  printf '%s\t%s\t%s\t%s\t%s\n' "$state" "$reason" "$root_path" "$link_path" "$target_path" >>"$output_file"
+
+  if [[ $MODE == delete && $state == CANDIDATE ]]; then
+    echo "DELETE root=${root_path} link=${link_path} reason=${reason}"
+    rm -f "$root_path"
+    delete_count=$((delete_count + 1))
+  fi
+done <"$roots_file"
+
+sort -t $'\t' -k1,1 -k2,2 -k3,3 "$output_file" | awk -F '\t' '
+  {
+    printf "%s reason=%s root=%s link=%s target=%s\n", $1, $2, $3, $4, $5
+  }
+'
+
+echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count} mode=${MODE}"
+
+if [[ $MODE == delete ]]; then
+  echo "GC start deleted_roots=${delete_count}"
+  nix-collect-garbage
+  echo "GC done deleted_roots=${delete_count}"
+fi

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -15,6 +15,7 @@ EOF
 }
 
 MODE="dry-run"
+REAL_USER="${SUDO_USER:-$(id -un)}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -53,12 +54,22 @@ output_file="${tmp_dir}/output.tsv"
 : >"$roots_file"
 : >"$output_file"
 
-git worktree list --porcelain | awk '
-  /^worktree / { print substr($0, 10) }
-' >>"$active_paths_file"
+if [[ $REAL_USER != root ]]; then
+  runuser -u "$REAL_USER" -- git worktree list --porcelain | awk '
+    /^worktree / { print substr($0, 10) }
+  ' >>"$active_paths_file"
+else
+  git worktree list --porcelain | awk '
+    /^worktree / { print substr($0, 10) }
+  ' >>"$active_paths_file"
+fi
 
 if command -v vde-worktree >/dev/null 2>&1; then
-  vde-worktree list --json 2>/dev/null | jq -r '.worktrees[]?.path // empty' >>"$active_paths_file" || true
+  if [[ $REAL_USER != root ]]; then
+    runuser -u "$REAL_USER" -- vde-worktree list --json 2>/dev/null | jq -r '.worktrees[]?.path // empty' >>"$active_paths_file" || true
+  else
+    vde-worktree list --json 2>/dev/null | jq -r '.worktrees[]?.path // empty' >>"$active_paths_file" || true
+  fi
 fi
 
 sort -u "$active_paths_file" -o "$active_paths_file"
@@ -176,6 +187,6 @@ fi
 
 if [[ $MODE == delete ]]; then
   echo "GC start deleted_roots=${delete_count}"
-  nix-collect-garbage
+  /nix/var/nix/profiles/default/bin/nix-collect-garbage
   echo "GC done deleted_roots=${delete_count}"
 fi

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -4,6 +4,10 @@ set -o nounset
 set -o pipefail
 set -o posix
 
+# What: classify auto-generated Nix GC roots and optionally delete current CANDIDATE roots.
+# When: run before manual Nix store cleanup to separate safe candidates from protected roots.
+# Example: nix run '.#gc-roots-review' -- --dry-run
+
 usage() {
   cat <<'EOF'
 Usage: list-stale-nix-gcroots.sh [--dry-run|--delete]
@@ -11,6 +15,10 @@ Usage: list-stale-nix-gcroots.sh [--dry-run|--delete]
 Modes:
   --dry-run  Classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
   --delete   Delete only current CANDIDATE roots, then run nix-collect-garbage
+
+Examples:
+  nix run '.#gc-roots-review' -- --dry-run
+  sudo nix run '.#gc-roots-review' -- --delete
 EOF
 }
 

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -6,7 +6,7 @@ set -o posix
 
 # What: classify auto-generated Nix GC roots and optionally delete current CANDIDATE roots.
 # When: run before manual Nix store cleanup to separate safe candidates from protected roots.
-# Example: nix run '.#gc-roots-review' -- --dry-run
+# Example: nix run '.#gc-roots-delete' -- --dry-run
 
 usage() {
   cat <<'EOF'
@@ -17,8 +17,8 @@ Modes:
   --delete   Delete only current CANDIDATE roots, then run nix-collect-garbage
 
 Examples:
-  nix run '.#gc-roots-review' -- --dry-run
-  sudo nix run '.#gc-roots-review' -- --delete
+  nix run '.#gc-roots-delete' -- --dry-run
+  sudo nix run '.#gc-roots-delete' -- --delete
 EOF
 }
 
@@ -250,7 +250,7 @@ done <"$sorted_output_file"
 echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count} mode=${MODE}"
 
 if [[ $MODE == dry-run ]]; then
-  echo "HINT to delete CANDIDATEs run as root: nix run '.#gc-roots-review' -- --delete"
+  echo "HINT to delete CANDIDATEs run as root: nix run '.#gc-roots-delete' -- --delete"
 fi
 
 if [[ $MODE == delete ]]; then

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -25,6 +25,14 @@ EOF
 MODE="dry-run"
 REAL_USER="${SUDO_USER:-$(id -un)}"
 
+run_as_real_user() {
+  if [[ $EUID -eq 0 && $REAL_USER != root ]]; then
+    runuser -u "$REAL_USER" -- "$@"
+  else
+    "$@"
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --dry-run)
@@ -62,26 +70,62 @@ output_file="${tmp_dir}/output.tsv"
 : >"$roots_file"
 : >"$output_file"
 
-if [[ $REAL_USER != root ]]; then
-  runuser -u "$REAL_USER" -- git worktree list --porcelain | awk '
-    /^worktree / { print substr($0, 10) }
-  ' >>"$active_paths_file"
-else
-  git worktree list --porcelain | awk '
-    /^worktree / { print substr($0, 10) }
-  ' >>"$active_paths_file"
-fi
+find /nix/var/nix/gcroots/auto -maxdepth 1 -type l | sort >"$roots_file"
 
-if command -v vde-worktree >/dev/null 2>&1; then
-  if [[ $REAL_USER != root ]]; then
-    runuser -u "$REAL_USER" -- vde-worktree list --json 2>/dev/null | jq -r '.worktrees[]?.path // empty' >>"$active_paths_file" || true
+discover_repo_root() {
+  candidate_repo=""
+
+  candidate_repo="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n $candidate_repo && -f $candidate_repo/config/vde/worktree/config.yml ]]; then
+    printf '%s\n' "$candidate_repo"
+    return 0
+  fi
+
+  while IFS= read -r root_path; do
+    candidate_link="$(readlink "$root_path" 2>/dev/null || true)"
+
+    case "$candidate_link" in
+    *"/.worktrees/"*)
+      candidate_repo="${candidate_link%%/.worktrees/*}"
+      if [[ -f $candidate_repo/config/vde/worktree/config.yml ]]; then
+        printf '%s\n' "$candidate_repo"
+        return 0
+      fi
+      ;;
+    esac
+  done <"$roots_file"
+
+  return 1
+}
+
+run_repo_vde_worktree_list() {
+  if [[ -z ${REPO_ROOT:-} ]]; then
+    return 1
+  fi
+
+  if [[ $EUID -eq 0 && $REAL_USER != root ]]; then
+    # shellcheck disable=SC2016
+    runuser -u "$REAL_USER" -- sh -c 'cd "$1" && vde-worktree list --json' sh "$REPO_ROOT"
   else
-    vde-worktree list --json 2>/dev/null | jq -r '.worktrees[]?.path // empty' >>"$active_paths_file" || true
+    { cd "$REPO_ROOT" && vde-worktree list --json; }
+  fi
+}
+
+REPO_ROOT="$(discover_repo_root || true)"
+
+if [[ -n $REPO_ROOT ]]; then
+  {
+    run_as_real_user git -C "$REPO_ROOT" worktree list --porcelain | awk '
+      /^worktree / { print substr($0, 10) }
+    '
+  } >>"$active_paths_file"
+
+  if command -v vde-worktree >/dev/null 2>&1; then
+    { run_repo_vde_worktree_list 2>/dev/null | jq -r '.worktrees[]?.path // empty'; } >>"$active_paths_file" || true
   fi
 fi
 
 sort -u "$active_paths_file" -o "$active_paths_file"
-find /nix/var/nix/gcroots/auto -maxdepth 1 -type l | sort >"$roots_file"
 
 is_active_worktree_path() {
   candidate_path="$1"

--- a/bin/ubuntu/setup-swap.sh
+++ b/bin/ubuntu/setup-swap.sh
@@ -20,6 +20,16 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
+# Guard: refuse to proceed if multiple swap devices are already active.
+# Two coexisting swapfiles waste disk space and must be resolved manually
+# before this script mutates swap configuration.
+active_swap_count=$(awk 'NR>1 {count++} END {print count+0}' /proc/swaps)
+if [[ $active_swap_count -gt 1 ]]; then
+  echo "ERROR: $active_swap_count swap devices active. Resolve duplicates before running setup-swap.sh." >&2
+  awk 'NR>1 {print "  " $1 " size=" $3 "kB priority=" $5}' /proc/swaps >&2
+  exit 1
+fi
+
 # Show current state
 echo "=== Current swap status ==="
 swapon --show || echo "(no active swap)"

--- a/bin/ubuntu/setup-swap.sh
+++ b/bin/ubuntu/setup-swap.sh
@@ -20,12 +20,15 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-# Detect swap devices other than SWAPFILE that are currently active.
-# These will be disabled and removed after SWAPFILE is confirmed active.
-other_swaps=()
-while IFS= read -r dev; do
-  other_swaps+=("$dev")
-done < <(awk -v target="$SWAPFILE" 'NR>1 && $1 != target {print $1}' /proc/swaps)
+# Guard: refuse to proceed if multiple swap devices are already active.
+# Two coexisting swapfiles waste disk space and must be resolved manually
+# before this script mutates swap configuration.
+active_swap_count=$(awk 'NR>1 {count++} END {print count+0}' /proc/swaps)
+if [[ $active_swap_count -gt 1 ]]; then
+  echo "ERROR: $active_swap_count swap devices active. Resolve duplicates before running setup-swap.sh." >&2
+  awk 'NR>1 {print "  " $1 " size=" $3 "kB priority=" $5}' /proc/swaps >&2
+  exit 1
+fi
 
 # Show current state
 echo "=== Current swap status ==="
@@ -65,10 +68,6 @@ fi
 if [[ "$(sysctl -n vm.swappiness)" -ne $SWAPPINESS_TARGET ]]; then
   actions+=("Set vm.swappiness=${SWAPPINESS_TARGET}")
 fi
-
-for dev in "${other_swaps[@]}"; do
-  actions+=("Disable and remove $dev (non-target swap)")
-done
 
 # If nothing to do, exit early
 if [[ ${#actions[@]} -eq 0 ]]; then
@@ -123,21 +122,6 @@ fi
 if ! swapon --show | grep -q "$SWAPFILE"; then
   swapon "$SWAPFILE"
   echo "* Swap enabled"
-fi
-
-# Remove other swap devices now that SWAPFILE is confirmed active
-if [[ ${#other_swaps[@]} -gt 0 ]] && swapon --show | grep -q "$SWAPFILE"; then
-  for dev in "${other_swaps[@]}"; do
-    echo "* Disabling $dev..."
-    swapoff "$dev"
-    sed -i "\|^${dev}[[:space:]]|d" /etc/fstab
-    if [[ -f $dev ]]; then
-      unlink "$dev"
-      echo "* Removed $dev"
-    else
-      echo "* $dev disabled (not a regular file, skipped deletion)"
-    fi
-  done
 fi
 
 # Add to /etc/fstab

--- a/bin/ubuntu/setup-swap.sh
+++ b/bin/ubuntu/setup-swap.sh
@@ -20,15 +20,12 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-# Guard: refuse to proceed if multiple swap devices are already active.
-# Two coexisting swapfiles waste disk space and must be resolved manually
-# before this script mutates swap configuration.
-active_swap_count=$(awk 'NR>1 {count++} END {print count+0}' /proc/swaps)
-if [[ $active_swap_count -gt 1 ]]; then
-  echo "ERROR: $active_swap_count swap devices active. Resolve duplicates before running setup-swap.sh." >&2
-  awk 'NR>1 {print "  " $1 " size=" $3 "kB priority=" $5}' /proc/swaps >&2
-  exit 1
-fi
+# Detect swap devices other than SWAPFILE that are currently active.
+# These will be disabled and removed after SWAPFILE is confirmed active.
+other_swaps=()
+while IFS= read -r dev; do
+  other_swaps+=("$dev")
+done < <(awk -v target="$SWAPFILE" 'NR>1 && $1 != target {print $1}' /proc/swaps)
 
 # Show current state
 echo "=== Current swap status ==="
@@ -68,6 +65,10 @@ fi
 if [[ "$(sysctl -n vm.swappiness)" -ne $SWAPPINESS_TARGET ]]; then
   actions+=("Set vm.swappiness=${SWAPPINESS_TARGET}")
 fi
+
+for dev in "${other_swaps[@]}"; do
+  actions+=("Disable and remove $dev (non-target swap)")
+done
 
 # If nothing to do, exit early
 if [[ ${#actions[@]} -eq 0 ]]; then
@@ -122,6 +123,21 @@ fi
 if ! swapon --show | grep -q "$SWAPFILE"; then
   swapon "$SWAPFILE"
   echo "* Swap enabled"
+fi
+
+# Remove other swap devices now that SWAPFILE is confirmed active
+if [[ ${#other_swaps[@]} -gt 0 ]] && swapon --show | grep -q "$SWAPFILE"; then
+  for dev in "${other_swaps[@]}"; do
+    echo "* Disabling $dev..."
+    swapoff "$dev"
+    sed -i "\|^${dev}[[:space:]]|d" /etc/fstab
+    if [[ -f $dev ]]; then
+      unlink "$dev"
+      echo "* Removed $dev"
+    else
+      echo "* $dev disabled (not a regular file, skipped deletion)"
+    fi
+  done
 fi
 
 # Add to /etc/fstab

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -4,6 +4,10 @@ set -o nounset
 set -o pipefail
 set -o posix
 
+# What: summarize Linux home-directory storage pressure for the current user or all users.
+# When: run before cleanup to see which homes and paths are driving disk usage.
+# Example: nix run '.#storage-report' -- --self --summary
+
 usage() {
   cat <<'EOF'
 Usage: storage-pressure-report.sh [--self|--all-users] [--summary|--full]
@@ -15,6 +19,10 @@ Modes:
 Output:
   --summary    Print the concise operator view (default)
   --full       Print all collected action rows instead of the top 5
+
+Examples:
+  nix run '.#storage-report' -- --self --summary
+  sudo nix run '.#storage-report' -- --all-users --summary
 EOF
 }
 

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -30,6 +30,16 @@ human_size() {
   numfmt --to=iec-i --suffix=B "$1"
 }
 
+safe_text() {
+  value="$1"
+
+  if [[ -z $value ]]; then
+    return
+  fi
+
+  printf '%q' "$value"
+}
+
 size_bytes() {
   target="$1"
 
@@ -160,6 +170,7 @@ append_action() {
   if [[ $category == user_local_data ]]; then
     display_path="${display_path} (other)"
   fi
+  display_path="$(safe_text "$display_path")"
 
   printf '%s\t%s\t%s\t%s\n' \
     "$bytes" \
@@ -286,8 +297,9 @@ while IFS=$'\t' read -r user_name home_dir; do
   find "$home_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null >"$top_level_paths_file"
   while IFS= read -r -d '' entry_path; do
     entry_name="$(basename "$entry_path")"
+    entry_label="$(safe_text "$entry_name")"
     entry_bytes="$(size_bytes "$entry_path")"
-    printf '%s\t%s\t%s\n' "$entry_bytes" "$entry_name" "$entry_path" >>"$top_level_sizes_file"
+    printf '%s\t%s\t%s\n' "$entry_bytes" "$entry_label" "$entry_path" >>"$top_level_sizes_file"
   done <"$top_level_paths_file"
 
   codex_bytes="$(size_bytes "$home_dir/.codex")"
@@ -351,12 +363,13 @@ EOF
 host_level="$(host_severity "$summary_fs_used_percent")"
 
 echo "SUMMARY"
-echo "mode=${MODE} host_severity=${host_level} fs_path=${summary_fs_path} fs_total=$(human_size "$summary_fs_size_bytes") fs_used=$(human_size "$summary_fs_used_bytes") fs_available=$(human_size "$summary_fs_avail_bytes") fs_used_percent=${summary_fs_used_percent}%"
+echo "mode=${MODE} host_severity=${host_level} fs_path=$(safe_text "$summary_fs_path") fs_total=$(human_size "$summary_fs_size_bytes") fs_used=$(human_size "$summary_fs_used_bytes") fs_available=$(human_size "$summary_fs_avail_bytes") fs_used_percent=${summary_fs_used_percent}%"
 echo "home_total=$(human_size "$total_home_bytes") scanned_users=${scanned_users} skipped_users=${skipped_users} unreadable_users=${unreadable_users}"
 echo ""
 
 echo "USERS"
 while IFS=$'\t' read -r state user_name home_dir reason_or_dash user_total_bytes; do
+  user_label="$(safe_text "$user_name")"
   if [[ $state == SCANNED ]]; then
     share_percent="$(percent_of "$user_total_bytes" "$total_home_bytes")"
     top_level_sizes_file="${tmp_dir}/${user_name}.top-level-sizes.tsv"
@@ -375,12 +388,12 @@ while IFS=$'\t' read -r state user_name home_dir reason_or_dash user_total_bytes
       END { print width + 0 }
     ' "$top_level_sizes_file")"
     sort -t $'\t' -k2,2 "$top_level_sizes_file" >"$top_level_sorted_file"
-    printf '  %s  %s  %s\n' "$user_name" "$(human_size "$user_total_bytes")" "${share_percent}%"
+    printf '  %s  %s  %s\n' "$user_label" "$(human_size "$user_total_bytes")" "${share_percent}%"
     while IFS=$'\t' read -r entry_bytes entry_name entry_path; do
       printf '    %-*s  %*s\n' "$max_name_width" "$entry_name" "$max_size_width" "$(human_size "$entry_bytes")"
     done <"$top_level_sorted_file"
   else
-    printf '  %s  %s  %s\n' "$user_name" "$state" "$reason_or_dash"
+    printf '  %s  %s  %s\n' "$user_label" "$state" "$(safe_text "$reason_or_dash")"
   fi
 done <"$scanned_users_file"
 echo ""

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -99,23 +99,6 @@ item_priority() {
   fi
 }
 
-item_severity() {
-  bytes="$1"
-  host_level="$2"
-
-  if [[ $host_level == critical && $bytes -ge 1073741824 ]]; then
-    echo critical
-  elif [[ $bytes -ge 2147483648 ]]; then
-    echo high
-  elif [[ $host_level == high && $bytes -ge 1073741824 ]]; then
-    echo high
-  elif [[ $bytes -ge 524288000 ]]; then
-    echo warn
-  else
-    echo info
-  fi
-}
-
 category_cleanup_mode() {
   category="$1"
 
@@ -126,17 +109,23 @@ category_cleanup_mode() {
   esac
 }
 
-category_note() {
-  category="$1"
+display_action_path() {
+  user_name="$1"
+  home_dir="$2"
+  path="$3"
 
-  case "$category" in
-  agent_state) echo "Session and agent history state. Review retention before cleanup." ;;
-  build_cache) echo "Large rebuildable cache. Cleanup candidate." ;;
-  tool_installs) echo "Installed runtimes and tool data. Review unused toolchains." ;;
-  repos) echo "Repository storage is large. Review stale clones and worktrees." ;;
-  user_local_data) echo "User application data. Preserve unless you know it is disposable." ;;
-  other_large_targets) echo "Unexpected large path. Review before cleanup." ;;
-  *) echo "Review before cleanup." ;;
+  case "$path" in
+  "$home_dir"/*)
+    relative_path="${path#"$home_dir"/}"
+    if [[ $MODE == self ]]; then
+      printf '%s/%s' "~" "$relative_path"
+    else
+      printf '~%s/%s' "$user_name" "$relative_path"
+    fi
+    ;;
+  *)
+    basename "$path"
+    ;;
   esac
 }
 
@@ -145,7 +134,7 @@ append_action() {
   user_name="$2"
   category="$3"
   path="$4"
-  host_level="$5"
+  home_dir="$5"
   user_total="$6"
   actions_file="$7"
 
@@ -158,23 +147,14 @@ append_action() {
     return
   fi
 
-  severity="$(item_severity "$bytes" "$host_level")"
-  priority="$(item_priority "$bytes" "$host_level")"
   cleanup_mode="$(category_cleanup_mode "$category")"
-  note="$(category_note "$category")"
+  display_path="$(display_action_path "$user_name" "$home_dir" "$path")"
 
-  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "$(severity_rank "$severity")" \
-    "$(cleanup_rank "$cleanup_mode")" \
+  printf '%s\t%s\t%s\t%s\n' \
     "$bytes" \
-    "$severity" \
-    "$priority" \
-    "$user_name" \
-    "$category" \
     "$(human_size "$bytes")" \
-    "$path" \
-    "$cleanup_mode" \
-    "$note" >>"$actions_file"
+    "$display_path" \
+    "$cleanup_mode" >>"$actions_file"
 }
 
 known_top_level() {
@@ -228,14 +208,10 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 users_file="${tmp_dir}/users.tsv"
-categories_file="${tmp_dir}/categories.tsv"
 actions_file="${tmp_dir}/actions.tsv"
-user_details_file="${tmp_dir}/user-details.txt"
 
 : >"$users_file"
-: >"$categories_file"
 : >"$actions_file"
-: >"$user_details_file"
 
 if command -v getent >/dev/null 2>&1; then
   passwd_source="$(getent passwd)"
@@ -304,28 +280,18 @@ while IFS=$'\t' read -r user_name home_dir; do
     printf '%s\t%s\t%s\n' "$entry_bytes" "$entry_name" "$entry_path" >>"$top_level_sizes_file"
   done <"$top_level_paths_file"
 
-  agent_state_bytes=0
-  build_cache_bytes=0
-  tool_installs_bytes=0
-  repos_bytes=0
-  user_local_data_bytes=0
-  other_large_targets_bytes=0
-
   codex_bytes="$(size_bytes "$home_dir/.codex")"
   claude_bytes="$(size_bytes "$home_dir/.claude")"
   postman_state_bytes="$(size_bytes "$home_dir/.local/state/tmux-a2a-postman")"
   vde_monitor_bytes="$(size_bytes "$home_dir/.vde-monitor")"
-  agent_state_bytes=$((codex_bytes + claude_bytes + postman_state_bytes + vde_monitor_bytes))
 
   cache_bytes="$(size_bytes "$home_dir/.cache")"
   npm_bytes="$(size_bytes "$home_dir/.npm")"
   go_pkg_bytes="$(size_bytes "$home_dir/go/pkg")"
-  build_cache_bytes=$((cache_bytes + npm_bytes + go_pkg_bytes))
 
   mise_bytes="$(size_bytes "$home_dir/.local/share/mise")"
   local_lib_bytes="$(size_bytes "$home_dir/.local/lib")"
   dot_net_bytes="$(size_bytes "$home_dir/.net")"
-  tool_installs_bytes=$((mise_bytes + local_lib_bytes + dot_net_bytes))
 
   repos_bytes="$(size_bytes "$home_dir/ghq")"
 
@@ -339,89 +305,25 @@ while IFS=$'\t' read -r user_name home_dir; do
     if known_top_level "$entry_name"; then
       continue
     fi
-    other_large_targets_bytes=$((other_large_targets_bytes + entry_bytes))
-    append_action "$entry_bytes" "$user_name" "other_large_targets" "$entry_path" "$host_level" "$user_total_bytes" "$actions_file"
+    append_action "$entry_bytes" "$user_name" "other_large_targets" "$entry_path" "$home_dir" "$user_total_bytes" "$actions_file"
   done <"$top_level_sizes_file"
 
-  {
-    printf '%s\tagent_state\t%s\t%s\n' "$user_name" "$agent_state_bytes" "$(category_cleanup_mode agent_state)"
-    printf '%s\tbuild_cache\t%s\t%s\n' "$user_name" "$build_cache_bytes" "$(category_cleanup_mode build_cache)"
-    printf '%s\ttool_installs\t%s\t%s\n' "$user_name" "$tool_installs_bytes" "$(category_cleanup_mode tool_installs)"
-    printf '%s\trepos\t%s\t%s\n' "$user_name" "$repos_bytes" "$(category_cleanup_mode repos)"
-    printf '%s\tuser_local_data\t%s\t%s\n' "$user_name" "$user_local_data_bytes" "$(category_cleanup_mode user_local_data)"
-    printf '%s\tother_large_targets\t%s\t%s\n' "$user_name" "$other_large_targets_bytes" "$(category_cleanup_mode other_large_targets)"
-  } >>"$categories_file"
-
-  append_action "$cache_bytes" "$user_name" "build_cache" "$home_dir/.cache" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$npm_bytes" "$user_name" "build_cache" "$home_dir/.npm" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$go_pkg_bytes" "$user_name" "build_cache" "$home_dir/go/pkg" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$codex_bytes" "$user_name" "agent_state" "$home_dir/.codex" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$claude_bytes" "$user_name" "agent_state" "$home_dir/.claude" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$postman_state_bytes" "$user_name" "agent_state" "$home_dir/.local/state/tmux-a2a-postman" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$vde_monitor_bytes" "$user_name" "agent_state" "$home_dir/.vde-monitor" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$mise_bytes" "$user_name" "tool_installs" "$home_dir/.local/share/mise" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$local_lib_bytes" "$user_name" "tool_installs" "$home_dir/.local/lib" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$dot_net_bytes" "$user_name" "tool_installs" "$home_dir/.net" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$repos_bytes" "$user_name" "repos" "$home_dir/ghq" "$host_level" "$user_total_bytes" "$actions_file"
-  append_action "$user_local_data_bytes" "$user_name" "user_local_data" "$home_dir/.local" "$host_level" "$user_total_bytes" "$actions_file"
-
-  top_level_summary="$(
-    sort -nr "$top_level_sizes_file" | head -n 5 | awk '
-      BEGIN { first = 1 }
-      {
-        cmd = "numfmt --to=iec-i --suffix=B " $1
-        cmd | getline human
-        close(cmd)
-        if (!first) {
-          printf ", "
-        }
-        printf "%s(%s)", $2, human
-        first = 0
-      }
-    '
-  )"
-
-  unexpected_summary="$(
-    sort -nr "$top_level_sizes_file" | awk '
-      $2 != ".cache" &&
-      $2 != ".claude" &&
-      $2 != ".codex" &&
-      $2 != ".local" &&
-      $2 != ".net" &&
-      $2 != ".npm" &&
-      $2 != ".vde-monitor" &&
-      $2 != "ghq" &&
-      $2 != "go" &&
-      ++count <= 3 {
-        cmd = "numfmt --to=iec-i --suffix=B " $1
-        cmd | getline human
-        close(cmd)
-        if (count > 1) {
-          printf ", "
-        }
-        printf "%s(%s)", $2, human
-      }
-    '
-  )"
-
-  if [[ -z $top_level_summary ]]; then
-    top_level_summary="none"
-  fi
-
-  if [[ -z $unexpected_summary ]]; then
-    unexpected_summary="none"
-  fi
-
-  {
-    printf 'user=%s top_level=%s\n' "$user_name" "$top_level_summary"
-    printf 'user=%s unexpected=%s\n' "$user_name" "$unexpected_summary"
-  } >>"$user_details_file"
+  append_action "$cache_bytes" "$user_name" "build_cache" "$home_dir/.cache" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$npm_bytes" "$user_name" "build_cache" "$home_dir/.npm" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$go_pkg_bytes" "$user_name" "build_cache" "$home_dir/go/pkg" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$codex_bytes" "$user_name" "agent_state" "$home_dir/.codex" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$claude_bytes" "$user_name" "agent_state" "$home_dir/.claude" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$postman_state_bytes" "$user_name" "agent_state" "$home_dir/.local/state/tmux-a2a-postman" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$vde_monitor_bytes" "$user_name" "agent_state" "$home_dir/.vde-monitor" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$mise_bytes" "$user_name" "tool_installs" "$home_dir/.local/share/mise" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$local_lib_bytes" "$user_name" "tool_installs" "$home_dir/.local/lib" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$dot_net_bytes" "$user_name" "tool_installs" "$home_dir/.net" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$repos_bytes" "$user_name" "repos" "$home_dir/ghq" "$home_dir" "$user_total_bytes" "$actions_file"
+  append_action "$user_local_data_bytes" "$user_name" "user_local_data" "$home_dir/.local" "$home_dir" "$user_total_bytes" "$actions_file"
 done <"$users_file"
 
 echo "SUMMARY"
-echo "mode=${MODE}"
-echo "host_severity=${host_level}"
-echo "root_fs total=$(human_size "$root_size_bytes") used=$(human_size "$root_used_bytes") available=$(human_size "$root_avail_bytes") used_percent=${root_used_percent}%"
+echo "mode=${MODE} host_severity=${host_level} root_total=$(human_size "$root_size_bytes") root_used=$(human_size "$root_used_bytes") root_available=$(human_size "$root_avail_bytes") root_used_percent=${root_used_percent}%"
 echo "home_total=$(human_size "$total_home_bytes") scanned_users=${scanned_users} skipped_users=${skipped_users} unreadable_users=${unreadable_users}"
 echo ""
 
@@ -429,34 +331,54 @@ echo "USERS"
 while IFS=$'\t' read -r state user_name home_dir reason_or_dash user_total_bytes; do
   if [[ $state == SCANNED ]]; then
     share_percent="$(percent_of "$user_total_bytes" "$total_home_bytes")"
-    echo "${state} user=${user_name} size=$(human_size "$user_total_bytes") home=${home_dir} share=${share_percent}%"
+    top_level_sizes_file="${tmp_dir}/${user_name}.top-level-sizes.tsv"
+    top_level_sorted_file="${tmp_dir}/${user_name}.top-level-sorted.tsv"
+    max_name_width="$(awk -F '\t' 'BEGIN { width = 0 } { if (length($2) > width) width = length($2) } END { print width + 0 }' "$top_level_sizes_file")"
+    max_size_width="$(awk -F '\t' '
+      BEGIN { width = 0 }
+      {
+        cmd = "numfmt --to=iec-i --suffix=B " $1
+        cmd | getline human
+        close(cmd)
+        if (length(human) > width) {
+          width = length(human)
+        }
+      }
+      END { print width + 0 }
+    ' "$top_level_sizes_file")"
+    sort -t $'\t' -k2,2 "$top_level_sizes_file" >"$top_level_sorted_file"
+    printf '  %s  %s  %s\n' "$user_name" "$(human_size "$user_total_bytes")" "${share_percent}%"
+    while IFS=$'\t' read -r entry_bytes entry_name entry_path; do
+      printf '    %-*s  %*s\n' "$max_name_width" "$entry_name" "$max_size_width" "$(human_size "$entry_bytes")"
+    done <"$top_level_sorted_file"
   else
-    echo "${state} user=${user_name} home=${home_dir} reason=${reason_or_dash}"
+    printf '  %s  %s  %s\n' "$user_name" "$state" "$reason_or_dash"
   fi
 done <"$scanned_users_file"
-cat "$user_details_file"
-echo ""
-
-echo "CATEGORIES"
-while IFS=$'\t' read -r user_name category bytes cleanup_mode; do
-  echo "user=${user_name} size=$(human_size "$bytes") category=${category} cleanup_mode=${cleanup_mode} note=$(category_note "$category")"
-done <"$categories_file"
 echo ""
 
 echo "TOP ACTIONS"
 if [[ -s $actions_file ]]; then
+  actions_output_file="${tmp_dir}/actions-output.tsv"
   if [[ $DETAIL == full ]]; then
-    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | awk -F '\t' '{ printf "%s %s user=%s size=%s category=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $8, $7, $9, $10, $11 }'
+    sort -t $'\t' -k1,1nr -k3,3 "$actions_file" >"$actions_output_file"
   else
-    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | head -n 5 | awk -F '\t' '{ printf "%s %s user=%s size=%s category=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $8, $7, $9, $10, $11 }'
+    sort -t $'\t' -k1,1nr -k3,3 "$actions_file" | head -n 5 >"$actions_output_file"
   fi
+
+  max_path_width="$(awk -F '\t' 'BEGIN { width = 0 } { if (length($3) > width) width = length($3) } END { print width + 0 }' "$actions_output_file")"
+  max_size_width="$(awk -F '\t' 'BEGIN { width = 0 } { if (length($2) > width) width = length($2) } END { print width + 0 }' "$actions_output_file")"
+
+  while IFS=$'\t' read -r _action_bytes action_size action_path cleanup_mode; do
+    printf '  %*s  %-*s  %s\n' "$max_size_width" "$action_size" "$max_path_width" "$action_path" "$cleanup_mode"
+  done <"$actions_output_file"
 else
   echo "none"
 fi
 echo ""
 
 echo "NOTES"
-echo "safe_cache=Large rebuildable cache. Cleanup candidate."
-echo "review_first=Review before cleanup."
-echo "preserve=Keep unless you know the data is disposable."
-echo "skipped_or_unreadable_homes_are_reported_explicitly=yes"
+printf '  %-29s = %s\n' "safe_cache" "Large rebuildable cache. Cleanup candidate."
+printf '  %-29s = %s\n' "review_first" "Review before cleanup."
+printf '  %-29s = %s\n' "preserve" "Keep unless you know the data is disposable."
+printf '  %-29s = %s\n' "skipped_or_unreadable_homes" "reported explicitly"

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -429,7 +429,7 @@ echo "USERS"
 while IFS=$'\t' read -r state user_name home_dir reason_or_dash user_total_bytes; do
   if [[ $state == SCANNED ]]; then
     share_percent="$(percent_of "$user_total_bytes" "$total_home_bytes")"
-    echo "${state} user=${user_name} home=${home_dir} size=$(human_size "$user_total_bytes") share=${share_percent}%"
+    echo "${state} user=${user_name} size=$(human_size "$user_total_bytes") home=${home_dir} share=${share_percent}%"
   else
     echo "${state} user=${user_name} home=${home_dir} reason=${reason_or_dash}"
   fi
@@ -439,16 +439,16 @@ echo ""
 
 echo "CATEGORIES"
 while IFS=$'\t' read -r user_name category bytes cleanup_mode; do
-  echo "user=${user_name} category=${category} size=$(human_size "$bytes") cleanup_mode=${cleanup_mode} note=$(category_note "$category")"
+  echo "user=${user_name} size=$(human_size "$bytes") category=${category} cleanup_mode=${cleanup_mode} note=$(category_note "$category")"
 done <"$categories_file"
 echo ""
 
 echo "TOP ACTIONS"
 if [[ -s $actions_file ]]; then
   if [[ $DETAIL == full ]]; then
-    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | awk -F '\t' '{ printf "%s %s user=%s category=%s size=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $7, $8, $9, $10, $11 }'
+    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | awk -F '\t' '{ printf "%s %s user=%s size=%s category=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $8, $7, $9, $10, $11 }'
   else
-    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | head -n 5 | awk -F '\t' '{ printf "%s %s user=%s category=%s size=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $7, $8, $9, $10, $11 }'
+    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | head -n 5 | awk -F '\t' '{ printf "%s %s user=%s size=%s category=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $8, $7, $9, $10, $11 }'
   fi
 else
   echo "none"

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -193,6 +193,10 @@ known_top_level() {
 MODE="self"
 DETAIL="summary"
 
+if [[ $# -eq 0 ]]; then
+  set -- --self --summary
+fi
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --self)

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -38,7 +38,7 @@ size_bytes() {
     return
   fi
 
-  du -sb --apparent-size "$target" 2>/dev/null | awk '{print $1}'
+  du -s -B1 "$target" 2>/dev/null | awk '{print $1}'
 }
 
 percent_of() {
@@ -157,6 +157,9 @@ append_action() {
 
   cleanup_mode="$(category_cleanup_mode "$category")"
   display_path="$(display_action_path "$user_name" "$home_dir" "$path")"
+  if [[ $category == user_local_data ]]; then
+    display_path="${display_path} (other)"
+  fi
 
   printf '%s\t%s\t%s\t%s\n' \
     "$bytes" \
@@ -235,15 +238,11 @@ else
   printf '%s\n' "$passwd_source" | awk -F: '$6 ~ "^/home/" { print $1 "\t" $6 }' >>"$users_file"
 fi
 
-read -r root_size_bytes root_used_bytes root_avail_bytes root_used_percent <<EOF
-$(df -B1 --output=size,used,avail,pcent / | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }')
-EOF
-
-host_level="$(host_severity "$root_used_percent")"
 total_home_bytes=0
 scanned_users=0
 skipped_users=0
 unreadable_users=0
+summary_fs_path=""
 
 scanned_users_file="${tmp_dir}/scanned-users.tsv"
 : >"$scanned_users_file"
@@ -274,6 +273,9 @@ while IFS=$'\t' read -r user_name home_dir; do
   user_total_bytes="$(size_bytes "$home_dir")"
   total_home_bytes=$((total_home_bytes + user_total_bytes))
   scanned_users=$((scanned_users + 1))
+  if [[ -z $summary_fs_path ]]; then
+    summary_fs_path="$home_dir"
+  fi
   printf 'SCANNED\t%s\t%s\t-\t%s\n' "$user_name" "$home_dir" "$user_total_bytes" >>"$scanned_users_file"
 
   top_level_paths_file="${tmp_dir}/${user_name}.top-level-paths"
@@ -330,8 +332,26 @@ while IFS=$'\t' read -r user_name home_dir; do
   append_action "$user_local_data_bytes" "$user_name" "user_local_data" "$home_dir/.local" "$home_dir" "$user_total_bytes" "$actions_file"
 done <"$users_file"
 
+if [[ -z $summary_fs_path ]]; then
+  if [[ $MODE == self ]]; then
+    summary_fs_path="${HOME:-/home/$(id -un)}"
+  else
+    summary_fs_path="/home"
+  fi
+fi
+
+if [[ ! -e $summary_fs_path ]]; then
+  summary_fs_path="/"
+fi
+
+read -r summary_fs_size_bytes summary_fs_used_bytes summary_fs_avail_bytes summary_fs_used_percent <<EOF
+$(df -B1 --output=size,used,avail,pcent "$summary_fs_path" | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }')
+EOF
+
+host_level="$(host_severity "$summary_fs_used_percent")"
+
 echo "SUMMARY"
-echo "mode=${MODE} host_severity=${host_level} root_total=$(human_size "$root_size_bytes") root_used=$(human_size "$root_used_bytes") root_available=$(human_size "$root_avail_bytes") root_used_percent=${root_used_percent}%"
+echo "mode=${MODE} host_severity=${host_level} fs_path=${summary_fs_path} fs_total=$(human_size "$summary_fs_size_bytes") fs_used=$(human_size "$summary_fs_used_bytes") fs_available=$(human_size "$summary_fs_avail_bytes") fs_used_percent=${summary_fs_used_percent}%"
 echo "home_total=$(human_size "$total_home_bytes") scanned_users=${scanned_users} skipped_users=${skipped_users} unreadable_users=${unreadable_users}"
 echo ""
 

--- a/bin/ubuntu/storage-pressure-report.sh
+++ b/bin/ubuntu/storage-pressure-report.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o posix
+
+usage() {
+  cat <<'EOF'
+Usage: storage-pressure-report.sh [--self|--all-users] [--summary|--full]
+
+Modes:
+  --self       Inspect the current user home directory
+  --all-users  Inspect Linux home directories under /home
+
+Output:
+  --summary    Print the concise operator view (default)
+  --full       Print all collected action rows instead of the top 5
+EOF
+}
+
+human_size() {
+  numfmt --to=iec-i --suffix=B "$1"
+}
+
+size_bytes() {
+  target="$1"
+
+  if [[ ! -e $target ]]; then
+    echo 0
+    return
+  fi
+
+  du -sb --apparent-size "$target" 2>/dev/null | awk '{print $1}'
+}
+
+percent_of() {
+  numerator="$1"
+  denominator="$2"
+
+  if [[ $denominator -le 0 ]]; then
+    echo 0
+    return
+  fi
+
+  echo $((numerator * 100 / denominator))
+}
+
+host_severity() {
+  used_percent="$1"
+
+  if [[ $used_percent -ge 90 ]]; then
+    echo critical
+  elif [[ $used_percent -ge 85 ]]; then
+    echo high
+  elif [[ $used_percent -ge 75 ]]; then
+    echo warn
+  else
+    echo ok
+  fi
+}
+
+severity_rank() {
+  severity="$1"
+
+  case "$severity" in
+  critical) echo 4 ;;
+  high) echo 3 ;;
+  warn) echo 2 ;;
+  info) echo 1 ;;
+  *) echo 0 ;;
+  esac
+}
+
+cleanup_rank() {
+  cleanup_mode="$1"
+
+  case "$cleanup_mode" in
+  safe_cache) echo 1 ;;
+  review_first) echo 2 ;;
+  preserve) echo 3 ;;
+  *) echo 9 ;;
+  esac
+}
+
+item_priority() {
+  bytes="$1"
+  host_level="$2"
+
+  if [[ $bytes -ge 2147483648 ]]; then
+    echo P1
+  elif [[ $host_level == critical && $bytes -ge 1073741824 ]]; then
+    echo P1
+  elif [[ $bytes -ge 1073741824 ]]; then
+    echo P2
+  elif [[ $bytes -ge 524288000 ]]; then
+    echo P3
+  else
+    echo observe
+  fi
+}
+
+item_severity() {
+  bytes="$1"
+  host_level="$2"
+
+  if [[ $host_level == critical && $bytes -ge 1073741824 ]]; then
+    echo critical
+  elif [[ $bytes -ge 2147483648 ]]; then
+    echo high
+  elif [[ $host_level == high && $bytes -ge 1073741824 ]]; then
+    echo high
+  elif [[ $bytes -ge 524288000 ]]; then
+    echo warn
+  else
+    echo info
+  fi
+}
+
+category_cleanup_mode() {
+  category="$1"
+
+  case "$category" in
+  build_cache) echo safe_cache ;;
+  user_local_data) echo preserve ;;
+  *) echo review_first ;;
+  esac
+}
+
+category_note() {
+  category="$1"
+
+  case "$category" in
+  agent_state) echo "Session and agent history state. Review retention before cleanup." ;;
+  build_cache) echo "Large rebuildable cache. Cleanup candidate." ;;
+  tool_installs) echo "Installed runtimes and tool data. Review unused toolchains." ;;
+  repos) echo "Repository storage is large. Review stale clones and worktrees." ;;
+  user_local_data) echo "User application data. Preserve unless you know it is disposable." ;;
+  other_large_targets) echo "Unexpected large path. Review before cleanup." ;;
+  *) echo "Review before cleanup." ;;
+  esac
+}
+
+append_action() {
+  bytes="$1"
+  user_name="$2"
+  category="$3"
+  path="$4"
+  host_level="$5"
+  user_total="$6"
+  actions_file="$7"
+
+  if [[ $bytes -le 0 ]]; then
+    return
+  fi
+
+  size_share=$(percent_of "$bytes" "$user_total")
+  if [[ $bytes -lt 524288000 && $size_share -lt 10 ]]; then
+    return
+  fi
+
+  severity="$(item_severity "$bytes" "$host_level")"
+  priority="$(item_priority "$bytes" "$host_level")"
+  cleanup_mode="$(category_cleanup_mode "$category")"
+  note="$(category_note "$category")"
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(severity_rank "$severity")" \
+    "$(cleanup_rank "$cleanup_mode")" \
+    "$bytes" \
+    "$severity" \
+    "$priority" \
+    "$user_name" \
+    "$category" \
+    "$(human_size "$bytes")" \
+    "$path" \
+    "$cleanup_mode" \
+    "$note" >>"$actions_file"
+}
+
+known_top_level() {
+  name="$1"
+
+  case "$name" in
+  .cache | .claude | .codex | .local | .net | .npm | .vde-monitor | ghq | go)
+    return 0
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+MODE="self"
+DETAIL="summary"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --self)
+    MODE="self"
+    ;;
+  --all-users)
+    MODE="all-users"
+    ;;
+  --summary)
+    DETAIL="summary"
+    ;;
+  --full)
+    DETAIL="full"
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: Unknown argument: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+users_file="${tmp_dir}/users.tsv"
+categories_file="${tmp_dir}/categories.tsv"
+actions_file="${tmp_dir}/actions.tsv"
+user_details_file="${tmp_dir}/user-details.txt"
+
+: >"$users_file"
+: >"$categories_file"
+: >"$actions_file"
+: >"$user_details_file"
+
+if command -v getent >/dev/null 2>&1; then
+  passwd_source="$(getent passwd)"
+else
+  passwd_source="$(cat /etc/passwd)"
+fi
+
+if [[ $MODE == self ]]; then
+  current_user="$(id -un)"
+  current_home="${HOME:-/home/${current_user}}"
+  printf '%s\t%s\n' "$current_user" "$current_home" >>"$users_file"
+else
+  printf '%s\n' "$passwd_source" | awk -F: '$6 ~ "^/home/" { print $1 "\t" $6 }' >>"$users_file"
+fi
+
+read -r root_size_bytes root_used_bytes root_avail_bytes root_used_percent <<EOF
+$(df -B1 --output=size,used,avail,pcent / | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }')
+EOF
+
+host_level="$(host_severity "$root_used_percent")"
+total_home_bytes=0
+scanned_users=0
+skipped_users=0
+unreadable_users=0
+
+scanned_users_file="${tmp_dir}/scanned-users.tsv"
+: >"$scanned_users_file"
+
+while IFS=$'\t' read -r user_name home_dir; do
+  if [[ -z $user_name || -z $home_dir ]]; then
+    continue
+  fi
+
+  if [[ ! -e $home_dir ]]; then
+    printf 'SKIPPED\t%s\t%s\tmissing-home\t0\n' "$user_name" "$home_dir" >>"$scanned_users_file"
+    skipped_users=$((skipped_users + 1))
+    continue
+  fi
+
+  if [[ ! -d $home_dir ]]; then
+    printf 'SKIPPED\t%s\t%s\tnot-a-directory\t0\n' "$user_name" "$home_dir" >>"$scanned_users_file"
+    skipped_users=$((skipped_users + 1))
+    continue
+  fi
+
+  if [[ ! -r $home_dir ]]; then
+    printf 'UNREADABLE\t%s\t%s\tpermission-denied\t0\n' "$user_name" "$home_dir" >>"$scanned_users_file"
+    unreadable_users=$((unreadable_users + 1))
+    continue
+  fi
+
+  user_total_bytes="$(size_bytes "$home_dir")"
+  total_home_bytes=$((total_home_bytes + user_total_bytes))
+  scanned_users=$((scanned_users + 1))
+  printf 'SCANNED\t%s\t%s\t-\t%s\n' "$user_name" "$home_dir" "$user_total_bytes" >>"$scanned_users_file"
+
+  top_level_paths_file="${tmp_dir}/${user_name}.top-level-paths"
+  top_level_sizes_file="${tmp_dir}/${user_name}.top-level-sizes.tsv"
+  : >"$top_level_paths_file"
+  : >"$top_level_sizes_file"
+
+  find "$home_dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null >"$top_level_paths_file"
+  while IFS= read -r -d '' entry_path; do
+    entry_name="$(basename "$entry_path")"
+    entry_bytes="$(size_bytes "$entry_path")"
+    printf '%s\t%s\t%s\n' "$entry_bytes" "$entry_name" "$entry_path" >>"$top_level_sizes_file"
+  done <"$top_level_paths_file"
+
+  agent_state_bytes=0
+  build_cache_bytes=0
+  tool_installs_bytes=0
+  repos_bytes=0
+  user_local_data_bytes=0
+  other_large_targets_bytes=0
+
+  codex_bytes="$(size_bytes "$home_dir/.codex")"
+  claude_bytes="$(size_bytes "$home_dir/.claude")"
+  postman_state_bytes="$(size_bytes "$home_dir/.local/state/tmux-a2a-postman")"
+  vde_monitor_bytes="$(size_bytes "$home_dir/.vde-monitor")"
+  agent_state_bytes=$((codex_bytes + claude_bytes + postman_state_bytes + vde_monitor_bytes))
+
+  cache_bytes="$(size_bytes "$home_dir/.cache")"
+  npm_bytes="$(size_bytes "$home_dir/.npm")"
+  go_pkg_bytes="$(size_bytes "$home_dir/go/pkg")"
+  build_cache_bytes=$((cache_bytes + npm_bytes + go_pkg_bytes))
+
+  mise_bytes="$(size_bytes "$home_dir/.local/share/mise")"
+  local_lib_bytes="$(size_bytes "$home_dir/.local/lib")"
+  dot_net_bytes="$(size_bytes "$home_dir/.net")"
+  tool_installs_bytes=$((mise_bytes + local_lib_bytes + dot_net_bytes))
+
+  repos_bytes="$(size_bytes "$home_dir/ghq")"
+
+  local_total_bytes="$(size_bytes "$home_dir/.local")"
+  user_local_data_bytes=$((local_total_bytes - postman_state_bytes - mise_bytes - local_lib_bytes))
+  if [[ $user_local_data_bytes -lt 0 ]]; then
+    user_local_data_bytes=0
+  fi
+
+  while IFS=$'\t' read -r entry_bytes entry_name entry_path; do
+    if known_top_level "$entry_name"; then
+      continue
+    fi
+    other_large_targets_bytes=$((other_large_targets_bytes + entry_bytes))
+    append_action "$entry_bytes" "$user_name" "other_large_targets" "$entry_path" "$host_level" "$user_total_bytes" "$actions_file"
+  done <"$top_level_sizes_file"
+
+  {
+    printf '%s\tagent_state\t%s\t%s\n' "$user_name" "$agent_state_bytes" "$(category_cleanup_mode agent_state)"
+    printf '%s\tbuild_cache\t%s\t%s\n' "$user_name" "$build_cache_bytes" "$(category_cleanup_mode build_cache)"
+    printf '%s\ttool_installs\t%s\t%s\n' "$user_name" "$tool_installs_bytes" "$(category_cleanup_mode tool_installs)"
+    printf '%s\trepos\t%s\t%s\n' "$user_name" "$repos_bytes" "$(category_cleanup_mode repos)"
+    printf '%s\tuser_local_data\t%s\t%s\n' "$user_name" "$user_local_data_bytes" "$(category_cleanup_mode user_local_data)"
+    printf '%s\tother_large_targets\t%s\t%s\n' "$user_name" "$other_large_targets_bytes" "$(category_cleanup_mode other_large_targets)"
+  } >>"$categories_file"
+
+  append_action "$cache_bytes" "$user_name" "build_cache" "$home_dir/.cache" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$npm_bytes" "$user_name" "build_cache" "$home_dir/.npm" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$go_pkg_bytes" "$user_name" "build_cache" "$home_dir/go/pkg" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$codex_bytes" "$user_name" "agent_state" "$home_dir/.codex" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$claude_bytes" "$user_name" "agent_state" "$home_dir/.claude" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$postman_state_bytes" "$user_name" "agent_state" "$home_dir/.local/state/tmux-a2a-postman" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$vde_monitor_bytes" "$user_name" "agent_state" "$home_dir/.vde-monitor" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$mise_bytes" "$user_name" "tool_installs" "$home_dir/.local/share/mise" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$local_lib_bytes" "$user_name" "tool_installs" "$home_dir/.local/lib" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$dot_net_bytes" "$user_name" "tool_installs" "$home_dir/.net" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$repos_bytes" "$user_name" "repos" "$home_dir/ghq" "$host_level" "$user_total_bytes" "$actions_file"
+  append_action "$user_local_data_bytes" "$user_name" "user_local_data" "$home_dir/.local" "$host_level" "$user_total_bytes" "$actions_file"
+
+  top_level_summary="$(
+    sort -nr "$top_level_sizes_file" | head -n 5 | awk '
+      BEGIN { first = 1 }
+      {
+        cmd = "numfmt --to=iec-i --suffix=B " $1
+        cmd | getline human
+        close(cmd)
+        if (!first) {
+          printf ", "
+        }
+        printf "%s(%s)", $2, human
+        first = 0
+      }
+    '
+  )"
+
+  unexpected_summary="$(
+    sort -nr "$top_level_sizes_file" | awk '
+      $2 != ".cache" &&
+      $2 != ".claude" &&
+      $2 != ".codex" &&
+      $2 != ".local" &&
+      $2 != ".net" &&
+      $2 != ".npm" &&
+      $2 != ".vde-monitor" &&
+      $2 != "ghq" &&
+      $2 != "go" &&
+      ++count <= 3 {
+        cmd = "numfmt --to=iec-i --suffix=B " $1
+        cmd | getline human
+        close(cmd)
+        if (count > 1) {
+          printf ", "
+        }
+        printf "%s(%s)", $2, human
+      }
+    '
+  )"
+
+  if [[ -z $top_level_summary ]]; then
+    top_level_summary="none"
+  fi
+
+  if [[ -z $unexpected_summary ]]; then
+    unexpected_summary="none"
+  fi
+
+  {
+    printf 'user=%s top_level=%s\n' "$user_name" "$top_level_summary"
+    printf 'user=%s unexpected=%s\n' "$user_name" "$unexpected_summary"
+  } >>"$user_details_file"
+done <"$users_file"
+
+echo "SUMMARY"
+echo "mode=${MODE}"
+echo "host_severity=${host_level}"
+echo "root_fs total=$(human_size "$root_size_bytes") used=$(human_size "$root_used_bytes") available=$(human_size "$root_avail_bytes") used_percent=${root_used_percent}%"
+echo "home_total=$(human_size "$total_home_bytes") scanned_users=${scanned_users} skipped_users=${skipped_users} unreadable_users=${unreadable_users}"
+echo ""
+
+echo "USERS"
+while IFS=$'\t' read -r state user_name home_dir reason_or_dash user_total_bytes; do
+  if [[ $state == SCANNED ]]; then
+    share_percent="$(percent_of "$user_total_bytes" "$total_home_bytes")"
+    echo "${state} user=${user_name} home=${home_dir} size=$(human_size "$user_total_bytes") share=${share_percent}%"
+  else
+    echo "${state} user=${user_name} home=${home_dir} reason=${reason_or_dash}"
+  fi
+done <"$scanned_users_file"
+cat "$user_details_file"
+echo ""
+
+echo "CATEGORIES"
+while IFS=$'\t' read -r user_name category bytes cleanup_mode; do
+  echo "user=${user_name} category=${category} size=$(human_size "$bytes") cleanup_mode=${cleanup_mode} note=$(category_note "$category")"
+done <"$categories_file"
+echo ""
+
+echo "TOP ACTIONS"
+if [[ -s $actions_file ]]; then
+  if [[ $DETAIL == full ]]; then
+    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | awk -F '\t' '{ printf "%s %s user=%s category=%s size=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $7, $8, $9, $10, $11 }'
+  else
+    sort -t $'\t' -k1,1nr -k2,2n -k3,3nr "$actions_file" | head -n 5 | awk -F '\t' '{ printf "%s %s user=%s category=%s size=%s path=%s cleanup_mode=%s note=%s\n", $4, $5, $6, $7, $8, $9, $10, $11 }'
+  fi
+else
+  echo "none"
+fi
+echo ""
+
+echo "NOTES"
+echo "safe_cache=Large rebuildable cache. Cleanup candidate."
+echo "review_first=Review before cleanup."
+echo "preserve=Keep unless you know the data is disposable."
+echo "skipped_or_unreadable_homes_are_reported_explicitly=yes"

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -60,6 +60,25 @@ The report is Linux-only by design. It targets `/home` usage and the current
 Ubuntu or WSL2 host. The `SUMMARY` line reports filesystem pressure for the
 filesystem backing the scanned homes.
 
+### 1.6. Low-Risk Cache Cleanup
+
+Use the cleanup app for rebuildable user caches that do not need manual review.
+
+```sh
+nix run '.#cleanup'
+```
+
+The cleanup app currently prunes:
+
+- the uv cache
+- `~/.cache/pre-commit`
+- `~/.cache/ruff`
+- `~/.cache/go-build`
+- `~/.cache/nix`
+- `~/.npm`
+
+This is the safest immediate reclaim path for user-owned cache pressure.
+
 ## 2. Guarded GC-Root Delete
 
 Use the single delete-focused command surface to remove stale auto GC roots.

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -57,3 +57,49 @@ silently.
 
 The report is Linux-only by design. It targets `/home` usage and the current
 Ubuntu or WSL2 host.
+
+## 2. Guarded GC-Root Review
+
+Use this review before deleting stale auto GC roots.
+
+### 2.1. Dry Run
+
+```sh
+nix run '.#gc-roots-review' -- --dry-run
+```
+
+This mode classifies roots as:
+
+- `KEEP`
+- `CANDIDATE`
+- `BLOCKED`
+
+Each line includes a reason, the auto-root path, the original linked path, and
+the resolved target.
+
+### 2.2. Delete Mode
+
+```sh
+sudo nix run '.#gc-roots-review' -- --delete
+```
+
+Delete mode is explicit and never scheduled. It re-runs the same classification
+checks at execution time, deletes only current `CANDIDATE` roots, and then runs
+`nix-collect-garbage`.
+
+### 2.3. Protected Root Classes
+
+These roots stay `BLOCKED` in issue `#123`:
+
+- `.direnv`
+- `result`
+- `/tmp`
+
+Home Manager and profile generation links stay `KEEP`.
+
+### 2.4. Operator Workflow
+
+1. Run `--dry-run`
+2. Review every `CANDIDATE`
+3. Confirm the path is absent from the active worktree inventories
+4. Run `--delete` only when the review is complete

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -103,3 +103,20 @@ Home Manager and profile generation links stay `KEEP`.
 2. Review every `CANDIDATE`
 3. Confirm the path is absent from the active worktree inventories
 4. Run `--delete` only when the review is complete
+
+## 3. Swap Consolidation
+
+The host has two swap devices: `/swapfile` (16G) and `/swap.img` (8G). Only
+one is needed. `setup-swap.sh` refuses to run when more than one swap device is
+active.
+
+Manual consolidation steps (all require root):
+
+1. Confirm active swap devices: `cat /proc/swaps`
+2. Choose the device to keep (prefer `/swapfile` at `16G`)
+3. Disable the unwanted device with `swapoff`
+4. Remove the unwanted device entry from `/etc/fstab`
+5. Delete the unwanted swapfile
+6. Verify: `cat /proc/swaps` should show exactly one device
+
+After consolidation, `setup-swap.sh` can run normally.

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -1,0 +1,59 @@
+# Storage Hygiene
+
+This document describes the Linux storage visibility and cleanup entrypoints for
+issue `#123`.
+
+## 1. Linux Home Storage Report
+
+Use the report to explain home-directory growth before you remove anything.
+
+### 1.1. Self Summary
+
+```sh
+nix run '.#storage-report' -- --self --summary
+```
+
+This mode is safe for regular daily visibility. It inspects only the current
+user home directory.
+
+### 1.2. All Linux Home Users
+
+```sh
+sudo nix run '.#storage-report' -- --all-users --summary
+```
+
+This mode enumerates Linux home directories under `/home`. It is intended for
+host triage.
+
+### 1.3. Output Sections
+
+The report prints these sections:
+
+- `SUMMARY`
+- `USERS`
+- `CATEGORIES`
+- `TOP ACTIONS`
+- `NOTES`
+
+### 1.4. User States
+
+Each user home is reported with one of these states:
+
+- `SCANNED`
+- `SKIPPED`
+- `UNREADABLE`
+
+`SKIPPED` and `UNREADABLE` homes include a reason. They are never omitted
+silently.
+
+### 1.5. Cleanup Modes
+
+- `safe_cache`
+  Meaning: normally rebuildable caches
+- `review_first`
+  Meaning: inspect before removal
+- `preserve`
+  Meaning: do not remove by default
+
+The report is Linux-only by design. It targets `/home` usage and the current
+Ubuntu or WSL2 host.

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -14,7 +14,9 @@ nix run '.#storage-report' -- --self --summary
 ```
 
 This mode is safe for regular daily visibility. It inspects only the current
-user home directory.
+user home directory. On the Ubuntu target, the daily `storage-report` timer
+rewrites the latest scheduled self report at
+`${XDG_STATE_HOME:-~/.local/state}/storage-report/latest.log`.
 
 ### 1.2. All Linux Home Users
 

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -111,15 +111,17 @@ links such as `profile-*` stay `KEEP`.
 
 The host has two swap devices: `/swapfile` (16G) and `/swap.img` (8G). Only
 one is needed. `setup-swap.sh` refuses to run when more than one swap device is
-active.
+active. It does not disable duplicate swap devices, rewrite `/etc/fstab`, or
+delete `/swap.img` automatically.
 
 Manual consolidation steps (all require root):
 
 1. Confirm active swap devices: `cat /proc/swaps`
 2. Choose the device to keep (prefer `/swapfile` at `16G`)
-3. Disable the unwanted device with `swapoff`
-4. Remove the unwanted device entry from `/etc/fstab`
-5. Delete the unwanted swapfile
+3. Disable `/swap.img` with `swapoff /swap.img`
+4. Remove the `/swap.img` entry from `/etc/fstab`
+5. Delete `/swap.img`
 6. Verify: `cat /proc/swaps` should show exactly one device
+7. Re-run `setup-swap.sh`
 
 After consolidation, `setup-swap.sh` can run normally.

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -62,35 +62,25 @@ filesystem backing the scanned homes.
 
 ## 2. Guarded GC-Root Delete
 
-Use the single delete-focused command surface to review stale auto GC roots
-before deleting them.
+Use the single delete-focused command surface to remove stale auto GC roots.
 
-### 2.1. Dry Run
+### 2.1. Command
 
 ```sh
-nix run '.#gc-roots-delete' -- --dry-run
+sudo /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
 ```
 
-This mode classifies roots as:
+The interface has no flags. Every invocation re-classifies roots as:
 
 - `KEEP`
 - `CANDIDATE`
 - `BLOCKED`
 
 Each line includes a reason, the auto-root path, the original linked path, and
-the resolved target.
+the resolved target. The command deletes only current `CANDIDATE` roots and
+then runs `nix-collect-garbage`.
 
-### 2.2. Delete Mode
-
-```sh
-sudo nix run '.#gc-roots-delete' -- --delete
-```
-
-Delete mode is explicit and never scheduled. It re-runs the same classification
-checks at execution time, deletes only current `CANDIDATE` roots, and then runs
-`nix-collect-garbage`.
-
-### 2.3. Protected Root Classes
+### 2.2. Protected Root Classes
 
 These roots stay `BLOCKED` in issue `#123`:
 
@@ -103,12 +93,11 @@ These roots stay `BLOCKED` in issue `#123`:
 Home Manager generation links such as `home-manager-*` and profile generation
 links such as `profile-*` stay `KEEP`.
 
-### 2.4. Operator Workflow
+### 2.3. Operator Notes
 
-1. Run `--dry-run`
-2. Review every `CANDIDATE`
-3. Confirm the path is absent from the active worktree inventories
-4. Run `--delete` only when the review is complete
+- This delete surface is explicit and never scheduled.
+- It re-runs the classification and active-worktree checks at execution time.
+- It has no preview mode and no flag-based delete switch.
 
 ## 3. Swap Consolidation
 

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -70,9 +70,8 @@ Use the single delete-focused command surface to remove stale auto GC roots.
 nix run '.#gc-roots-delete'
 ```
 
-The interface has no flags. It re-executes the delete script under `sudo`, so
-the destructive step does not depend on running `nix run` as root. Every
-invocation re-classifies roots as:
+The interface has no flags. It attempts current-user unlink directly and never
+asks for escalation. Every invocation re-classifies roots as:
 
 - `KEEP`
 - `CANDIDATE`
@@ -80,7 +79,8 @@ invocation re-classifies roots as:
 
 Each line includes a reason, the auto-root path, the original linked path, and
 the resolved target. The command unlinks only current `CANDIDATE` auto-root
-symlinks and then runs `nix-collect-garbage`.
+symlinks that the current user can delete, prints a `WARNING` for roots that
+cannot be removed, and then runs `nix-collect-garbage`.
 
 ### 2.2. Protected Root Classes
 
@@ -100,8 +100,8 @@ links such as `profile-*` stay `KEEP`.
 - This delete surface is explicit and never scheduled.
 - It re-runs the classification and active-worktree checks at execution time.
 - It has no preview mode and no flag-based delete switch.
-- The destructive step re-executes the script directly under `sudo`, not under
-  a root `nix run`.
+- It attempts deletion as the current user and keeps going when a specific root
+  cannot be removed.
 
 ## 3. Swap Consolidation
 

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -31,7 +31,6 @@ The report prints these sections:
 
 - `SUMMARY`
 - `USERS`
-- `CATEGORIES`
 - `TOP ACTIONS`
 - `NOTES`
 
@@ -56,7 +55,8 @@ silently.
   Meaning: do not remove by default
 
 The report is Linux-only by design. It targets `/home` usage and the current
-Ubuntu or WSL2 host.
+Ubuntu or WSL2 host. The `SUMMARY` line reports filesystem pressure for the
+filesystem backing the scanned homes.
 
 ## 2. Guarded GC-Root Review
 

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -91,11 +91,14 @@ checks at execution time, deletes only current `CANDIDATE` roots, and then runs
 
 These roots stay `BLOCKED` in issue `#123`:
 
+- Home Manager `current-home` gcroots under
+  `~/.local/state/home-manager/gcroots/current-home`
 - `.direnv`
 - `result`
 - `/tmp`
 
-Home Manager and profile generation links stay `KEEP`.
+Home Manager generation links such as `home-manager-*` and profile generation
+links such as `profile-*` stay `KEEP`.
 
 ### 2.4. Operator Workflow
 

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -60,14 +60,15 @@ The report is Linux-only by design. It targets `/home` usage and the current
 Ubuntu or WSL2 host. The `SUMMARY` line reports filesystem pressure for the
 filesystem backing the scanned homes.
 
-## 2. Guarded GC-Root Review
+## 2. Guarded GC-Root Delete
 
-Use this review before deleting stale auto GC roots.
+Use the single delete-focused command surface to review stale auto GC roots
+before deleting them.
 
 ### 2.1. Dry Run
 
 ```sh
-nix run '.#gc-roots-review' -- --dry-run
+nix run '.#gc-roots-delete' -- --dry-run
 ```
 
 This mode classifies roots as:
@@ -82,7 +83,7 @@ the resolved target.
 ### 2.2. Delete Mode
 
 ```sh
-sudo nix run '.#gc-roots-review' -- --delete
+sudo nix run '.#gc-roots-delete' -- --delete
 ```
 
 Delete mode is explicit and never scheduled. It re-runs the same classification

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -67,18 +67,20 @@ Use the single delete-focused command surface to remove stale auto GC roots.
 ### 2.1. Command
 
 ```sh
-sudo /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
+nix run '.#gc-roots-delete'
 ```
 
-The interface has no flags. Every invocation re-classifies roots as:
+The interface has no flags. It re-executes the delete script under `sudo`, so
+the destructive step does not depend on running `nix run` as root. Every
+invocation re-classifies roots as:
 
 - `KEEP`
 - `CANDIDATE`
 - `BLOCKED`
 
 Each line includes a reason, the auto-root path, the original linked path, and
-the resolved target. The command deletes only current `CANDIDATE` roots and
-then runs `nix-collect-garbage`.
+the resolved target. The command unlinks only current `CANDIDATE` auto-root
+symlinks and then runs `nix-collect-garbage`.
 
 ### 2.2. Protected Root Classes
 
@@ -98,6 +100,8 @@ links such as `profile-*` stay `KEEP`.
 - This delete surface is explicit and never scheduled.
 - It re-runs the classification and active-worktree checks at execution time.
 - It has no preview mode and no flag-based delete switch.
+- The destructive step re-executes the script directly under `sudo`, not under
+  a root `nix run`.
 
 ## 3. Swap Consolidation
 

--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
     "databricks-agent-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1775744177,
-        "narHash": "sha256-arir1vEEbXOyaKAfwFXz9gS6reWhXfYSrJYfXXGFN2Q=",
+        "lastModified": 1775837506,
+        "narHash": "sha256-9+cOjmUxAy4vdosAzQOv6p2Q4N+VrY+J4LO5p8gy5QQ=",
         "owner": "databricks-solutions",
         "repo": "ai-dev-kit",
-        "rev": "642b65e20aa6a9f974a2e113aa79484cdcece440",
+        "rev": "2feb7e05b8af7be50f1ae26bfe3e5d4dff779ffe",
         "type": "github"
       },
       "original": {
@@ -520,11 +520,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775762219,
-        "narHash": "sha256-e7BhggoWhg3Ok7dDI5kY1XZzORBQc0Rclcs3IWzux3w=",
+        "lastModified": 1775781825,
+        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c975a66a56306b38eaa3108f54bbc11e213f42f6",
+        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1775746837,
-        "narHash": "sha256-WrZCxhx82aBBQb6CMJwXimgOIcv9Eytl1zFsjfxiWSc=",
+        "lastModified": 1775877514,
+        "narHash": "sha256-yu/U7T3W4tGwV/VX4xdBi0NhFbMD5ez4xvQSAkPRZDs=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "b91b0e1583091847cf4f8a8fcaad92d66227abfb",
+        "rev": "476cf6f3f13e24bca38c26154d28fda23a9e23bb",
         "type": "github"
       },
       "original": {
@@ -578,11 +578,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775739963,
-        "narHash": "sha256-N6bOV8i74WFCplw4B9jTeit6Pm/Gn7LsnmjgkgqZBmg=",
+        "lastModified": 1775846687,
+        "narHash": "sha256-ziQGa9BpNrnP9btMZjuEQ2b5WLrhNtMKZ+oD/4UYS9c=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "253f02d9d483423580af3572e4078f0012a12422",
+        "rev": "9e8981ecf103732e52b4f12d8f08ee35cbb29865",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775732571,
-        "narHash": "sha256-cd6wKenSQ6G6jikqxFLvyel47TkY30uOSvOBV9gYDX0=",
+        "lastModified": 1775793324,
+        "narHash": "sha256-omax7atcZbol+6HJ2RLpP+ZCFcPa5bZ65Hn71RufeWQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02f3fa0374fa13707d42d55d58ecc76b091f223c",
+        "rev": "9d29d5f667d7467f98efc31881e824fa586c927e",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775701739,
-        "narHash": "sha256-2FWWY1rr/+pGUJK1npcVcsWNEblzmKs6VxD3VEvwJSs=",
+        "lastModified": 1775763530,
+        "narHash": "sha256-BuTK9z1QEwWPOIakQ1gCN4pa4VwVJpfptYCviy2uOGc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f7663154ff2fec150f9dbf5f81ec2785dc1e0db",
+        "rev": "b0188973b4b2a5b6bdba8b65381d6cd09a533da0",
         "type": "github"
       },
       "original": {
@@ -904,11 +904,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1775696448,
-        "narHash": "sha256-JGhqVH4Q0lCkBBL4+C8AsZjbRW9PEUyOULWtFq9kIUY=",
+        "lastModified": 1775801475,
+        "narHash": "sha256-J7h/A8No5BvVSitZqmlMaTztqjsz9U1dxivpkpwtSp4=",
         "owner": "i9wa4",
         "repo": "tmux-a2a-postman",
-        "rev": "ae0323fbc93ec8ff302a58d377fabd81af70535f",
+        "rev": "548305f9579aa992c465d167647235b785308771",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
     "databricks-agent-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1775837506,
-        "narHash": "sha256-9+cOjmUxAy4vdosAzQOv6p2Q4N+VrY+J4LO5p8gy5QQ=",
+        "lastModified": 1775744177,
+        "narHash": "sha256-arir1vEEbXOyaKAfwFXz9gS6reWhXfYSrJYfXXGFN2Q=",
         "owner": "databricks-solutions",
         "repo": "ai-dev-kit",
-        "rev": "2feb7e05b8af7be50f1ae26bfe3e5d4dff779ffe",
+        "rev": "642b65e20aa6a9f974a2e113aa79484cdcece440",
         "type": "github"
       },
       "original": {
@@ -520,11 +520,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775781825,
-        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
+        "lastModified": 1775762219,
+        "narHash": "sha256-e7BhggoWhg3Ok7dDI5kY1XZzORBQc0Rclcs3IWzux3w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
+        "rev": "c975a66a56306b38eaa3108f54bbc11e213f42f6",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1775877514,
-        "narHash": "sha256-yu/U7T3W4tGwV/VX4xdBi0NhFbMD5ez4xvQSAkPRZDs=",
+        "lastModified": 1775746837,
+        "narHash": "sha256-WrZCxhx82aBBQb6CMJwXimgOIcv9Eytl1zFsjfxiWSc=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "476cf6f3f13e24bca38c26154d28fda23a9e23bb",
+        "rev": "b91b0e1583091847cf4f8a8fcaad92d66227abfb",
         "type": "github"
       },
       "original": {
@@ -578,11 +578,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775846687,
-        "narHash": "sha256-ziQGa9BpNrnP9btMZjuEQ2b5WLrhNtMKZ+oD/4UYS9c=",
+        "lastModified": 1775739963,
+        "narHash": "sha256-N6bOV8i74WFCplw4B9jTeit6Pm/Gn7LsnmjgkgqZBmg=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "9e8981ecf103732e52b4f12d8f08ee35cbb29865",
+        "rev": "253f02d9d483423580af3572e4078f0012a12422",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775793324,
-        "narHash": "sha256-omax7atcZbol+6HJ2RLpP+ZCFcPa5bZ65Hn71RufeWQ=",
+        "lastModified": 1775732571,
+        "narHash": "sha256-cd6wKenSQ6G6jikqxFLvyel47TkY30uOSvOBV9gYDX0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d29d5f667d7467f98efc31881e824fa586c927e",
+        "rev": "02f3fa0374fa13707d42d55d58ecc76b091f223c",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775763530,
-        "narHash": "sha256-BuTK9z1QEwWPOIakQ1gCN4pa4VwVJpfptYCviy2uOGc=",
+        "lastModified": 1775701739,
+        "narHash": "sha256-2FWWY1rr/+pGUJK1npcVcsWNEblzmKs6VxD3VEvwJSs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0188973b4b2a5b6bdba8b65381d6cd09a533da0",
+        "rev": "0f7663154ff2fec150f9dbf5f81ec2785dc1e0db",
         "type": "github"
       },
       "original": {
@@ -904,11 +904,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1775801475,
-        "narHash": "sha256-J7h/A8No5BvVSitZqmlMaTztqjsz9U1dxivpkpwtSp4=",
+        "lastModified": 1775696448,
+        "narHash": "sha256-JGhqVH4Q0lCkBBL4+C8AsZjbRW9PEUyOULWtFq9kIUY=",
         "owner": "i9wa4",
         "repo": "tmux-a2a-postman",
-        "rev": "548305f9579aa992c465d167647235b785308771",
+        "rev": "ae0323fbc93ec8ff302a58d377fabd81af70535f",
         "type": "github"
       },
       "original": {

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -9,8 +9,8 @@
 #                             -- update flake inputs with a minimum-age gate
 #   nix run '.#check'        -- check flake configuration
 #   nix run '.#cleanup'      -- prune low-risk local caches
-#   nix run '.#gc-roots-delete' -- --dry-run
-#                             -- classify Linux auto GC roots before deletion
+#   sudo /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
+#                             -- delete Linux auto GC roots after guarded reclassification
 #   nix run '.#storage-report' -- summarize Linux home-directory storage
 #   nix run '.#apt-upgrade'  -- apt-get update && upgrade (Linux only)
 { lib, ... }:
@@ -108,9 +108,9 @@
         };
       }
       // lib.optionalAttrs isLinux {
-        # What: Review and delete stale auto-generated Nix GC roots through one delete-focused entrypoint.
-        # When: Run --dry-run first, then run --delete as root after the candidate list is reviewed.
-        # Example: nix run '.#gc-roots-delete' -- --dry-run
+        # What: Delete stale auto-generated Nix GC roots through one delete-focused entrypoint.
+        # When: Run as root to re-classify auto roots and delete only current CANDIDATE roots.
+        # Example: /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
         gc-roots-delete = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "gc-roots-delete" ''

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -96,6 +96,8 @@
 
             remove_dir "$cache_root/pre-commit"
             remove_dir "$cache_root/ruff"
+            remove_dir "$cache_root/go-build"
+            remove_dir "$cache_root/nix"
             remove_dir "$HOME/.npm"
 
             if [ -d "$HOME/Library/Caches" ]; then

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -10,7 +10,7 @@
 #   nix run '.#check'        -- check flake configuration
 #   nix run '.#cleanup'      -- prune low-risk local caches
 #   nix run '.#gc-roots-delete'
-#                             -- explicitly delete Linux auto GC roots through the dedicated cleanup command
+#                             -- attempt Linux auto GC-root cleanup through the dedicated command
 #   nix run '.#storage-report' -- summarize Linux home-directory storage
 #   nix run '.#apt-upgrade'  -- apt-get update && upgrade (Linux only)
 { lib, ... }:
@@ -109,7 +109,7 @@
       }
       // lib.optionalAttrs isLinux {
         # What: Keep Linux stale GC-root cleanup on one explicit command separate from switch.
-        # When: Run it directly when you want guarded stale-root deletion.
+        # When: Run it directly to attempt guarded stale-root deletion as the current user.
         # Example: nix run '.#gc-roots-delete'
         gc-roots-delete = {
           type = "app";

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -3,7 +3,7 @@
 #
 # Usage (quote .#name for zsh):
 #   nix run '.#switch'       -- rebuild and activate configuration
-#                               (Linux also prunes generations older than 1 day)
+#                               (Linux and macOS also prune generations older than 1 day)
 #   nix run '.#update'       -- update flake inputs
 #   nix run '.#update' -- --min-age-days 7
 #                             -- update flake inputs with a minimum-age gate
@@ -40,6 +40,7 @@
                 ''
                   profile=$(echo -e "macos-p\nmacos-w" | ${lib.getExe pkgs.fzf} --prompt="Select profile: ")
                   sudo darwin-rebuild switch --impure --flake ".#$profile"
+                  sudo ${pkgs.nix}/bin/nix-collect-garbage --delete-older-than 1d
                 ''
               else
                 ''
@@ -96,8 +97,15 @@
 
             remove_dir "$cache_root/pre-commit"
             remove_dir "$cache_root/ruff"
-            remove_dir "$cache_root/go-build"
-            remove_dir "$cache_root/nix"
+            ${
+              if isLinux then
+                ''
+                  remove_dir "$cache_root/go-build"
+                  remove_dir "$cache_root/nix"
+                ''
+              else
+                ""
+            }
             remove_dir "$HOME/.npm"
 
             if [ -d "$HOME/Library/Caches" ]; then

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -39,6 +39,7 @@
                 ''
                   nix run --access-tokens github.com=$(${lib.getExe pkgs.gh} auth token) \
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
+                  ${pkgs.nix}/bin/nix-collect-garbage -d
                 ''
             }
           ''}/bin/switch";

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -8,6 +8,7 @@
 #                             -- update flake inputs with a minimum-age gate
 #   nix run '.#check'        -- check flake configuration
 #   nix run '.#cleanup'      -- prune low-risk local caches
+#   nix run '.#storage-report' -- summarize Linux home-directory storage
 #   nix run '.#apt-upgrade'  -- apt-get update && upgrade (Linux only)
 { lib, ... }:
 {
@@ -98,6 +99,14 @@
         };
       }
       // lib.optionalAttrs isLinux {
+        storage-report = {
+          type = "app";
+          program = "${pkgs.writeShellScriptBin "storage-report" ''
+            set -euo pipefail
+            exec "$PWD/bin/ubuntu/storage-pressure-report.sh" "$@"
+          ''}/bin/storage-report";
+        };
+
         apt-upgrade = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "apt-upgrade" ''

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -99,6 +99,14 @@
         };
       }
       // lib.optionalAttrs isLinux {
+        gc-roots-review = {
+          type = "app";
+          program = "${pkgs.writeShellScriptBin "gc-roots-review" ''
+            set -euo pipefail
+            exec "$PWD/bin/ubuntu/list-stale-nix-gcroots.sh" "$@"
+          ''}/bin/gc-roots-review";
+        };
+
         storage-report = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "storage-report" ''

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -20,6 +20,8 @@
       gh = lib.getExe pkgs.gh;
       nix = lib.getExe pkgs.nix;
       python = lib.getExe pkgs.python3;
+      gcRootsReviewScript = ./../../../bin/ubuntu/list-stale-nix-gcroots.sh;
+      storagePressureReportScript = ./../../../bin/ubuntu/storage-pressure-report.sh;
     in
     {
       apps = {
@@ -103,7 +105,7 @@
           type = "app";
           program = "${pkgs.writeShellScriptBin "gc-roots-review" ''
             set -euo pipefail
-            exec "$PWD/bin/ubuntu/list-stale-nix-gcroots.sh" "$@"
+            exec ${pkgs.bash}/bin/bash ${gcRootsReviewScript} "$@"
           ''}/bin/gc-roots-review";
         };
 
@@ -111,7 +113,7 @@
           type = "app";
           program = "${pkgs.writeShellScriptBin "storage-report" ''
             set -euo pipefail
-            exec "$PWD/bin/ubuntu/storage-pressure-report.sh" "$@"
+            exec ${pkgs.bash}/bin/bash ${storagePressureReportScript} "$@"
           ''}/bin/storage-report";
         };
 

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -9,6 +9,8 @@
 #                             -- update flake inputs with a minimum-age gate
 #   nix run '.#check'        -- check flake configuration
 #   nix run '.#cleanup'      -- prune low-risk local caches
+#   nix run '.#gc-roots-delete' -- --dry-run
+#                             -- classify Linux auto GC roots before deletion
 #   nix run '.#storage-report' -- summarize Linux home-directory storage
 #   nix run '.#apt-upgrade'  -- apt-get update && upgrade (Linux only)
 { lib, ... }:
@@ -106,15 +108,15 @@
         };
       }
       // lib.optionalAttrs isLinux {
-        # What: Review auto-generated Nix GC roots and classify them before deletion.
-        # When: Run before manual Nix store cleanup when /nix/var/nix/gcroots/auto keeps growing.
-        # Example: nix run '.#gc-roots-review' -- --dry-run
-        gc-roots-review = {
+        # What: Review and delete stale auto-generated Nix GC roots through one delete-focused entrypoint.
+        # When: Run --dry-run first, then run --delete as root after the candidate list is reviewed.
+        # Example: nix run '.#gc-roots-delete' -- --dry-run
+        gc-roots-delete = {
           type = "app";
-          program = "${pkgs.writeShellScriptBin "gc-roots-review" ''
+          program = "${pkgs.writeShellScriptBin "gc-roots-delete" ''
             set -euo pipefail
             exec ${pkgs.bash}/bin/bash ${gcRootsReviewScript} "$@"
-          ''}/bin/gc-roots-review";
+          ''}/bin/gc-roots-delete";
         };
 
         # What: Summarize Linux home-directory storage pressure for the current user or all users.

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -46,9 +46,9 @@
               else
                 ''
                   access_token=$(${lib.getExe pkgs.gh} auth token)
-                  nix run --access-tokens github.com=$access_token \
+                  nix run --access-tokens "github.com=$access_token" \
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
-                  nix run --access-tokens github.com=$access_token \
+                  nix run --access-tokens "github.com=$access_token" \
                     home-manager -- expire-generations '-1 days'
                 ''
             }

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -3,7 +3,8 @@
 #
 # Usage (quote .#name for zsh):
 #   nix run '.#switch'       -- rebuild and activate configuration
-#                               (Linux and macOS also prune generations older than 1 day)
+#                               (Linux expires Home Manager generations older than 1 day;
+#                                macOS expires system generations older than 1 day)
 #   nix run '.#update'       -- update flake inputs
 #   nix run '.#update' -- --min-age-days 7
 #                             -- update flake inputs with a minimum-age gate
@@ -28,7 +29,7 @@
     in
     {
       apps = {
-        # What: Rebuild and activate the current machine configuration.
+        # What: Rebuild and activate the current machine configuration, then expire old generations without post-switch store GC.
         # When: Run after changing dotfiles, Home Manager modules, or nix-darwin modules.
         # Example: nix run '.#switch'
         switch = {
@@ -40,13 +41,15 @@
                 ''
                   profile=$(echo -e "macos-p\nmacos-w" | ${lib.getExe pkgs.fzf} --prompt="Select profile: ")
                   sudo darwin-rebuild switch --impure --flake ".#$profile"
-                  sudo ${pkgs.nix}/bin/nix-collect-garbage --delete-older-than 1d
+                  sudo ${pkgs.nix}/bin/nix-env --profile /nix/var/nix/profiles/system --delete-generations 1d
                 ''
               else
                 ''
-                  nix run --access-tokens github.com=$(${lib.getExe pkgs.gh} auth token) \
+                  access_token=$(${lib.getExe pkgs.gh} auth token)
+                  nix run --access-tokens github.com=$access_token \
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
-                  ${pkgs.nix}/bin/nix-collect-garbage --delete-older-than 1d
+                  nix run --access-tokens github.com=$access_token \
+                    home-manager -- expire-generations '-1 days'
                 ''
             }
           ''}/bin/switch";

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -3,6 +3,7 @@
 #
 # Usage (quote .#name for zsh):
 #   nix run '.#switch'       -- rebuild and activate configuration
+#                               (Linux also prunes generations older than 14 days)
 #   nix run '.#update'       -- update flake inputs
 #   nix run '.#update' -- --min-age-days 7
 #                             -- update flake inputs with a minimum-age gate
@@ -39,7 +40,7 @@
                 ''
                   nix run --access-tokens github.com=$(${lib.getExe pkgs.gh} auth token) \
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
-                  ${pkgs.nix}/bin/nix-collect-garbage -d
+                  ${pkgs.nix}/bin/nix-collect-garbage --delete-older-than 14d
                 ''
             }
           ''}/bin/switch";

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -26,6 +26,9 @@
     in
     {
       apps = {
+        # What: Rebuild and activate the current machine configuration.
+        # When: Run after changing dotfiles, Home Manager modules, or nix-darwin modules.
+        # Example: nix run '.#switch'
         switch = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "switch" ''
@@ -103,6 +106,9 @@
         };
       }
       // lib.optionalAttrs isLinux {
+        # What: Review auto-generated Nix GC roots and classify them before deletion.
+        # When: Run before manual Nix store cleanup when /nix/var/nix/gcroots/auto keeps growing.
+        # Example: nix run '.#gc-roots-review' -- --dry-run
         gc-roots-review = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "gc-roots-review" ''
@@ -111,6 +117,9 @@
           ''}/bin/gc-roots-review";
         };
 
+        # What: Summarize Linux home-directory storage pressure for the current user or all users.
+        # When: Run before cleanup so you know which homes and paths are using the most space.
+        # Example: nix run '.#storage-report' -- --self --summary
         storage-report = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "storage-report" ''

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -9,8 +9,8 @@
 #                             -- update flake inputs with a minimum-age gate
 #   nix run '.#check'        -- check flake configuration
 #   nix run '.#cleanup'      -- prune low-risk local caches
-#   sudo /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
-#                             -- delete Linux auto GC roots after guarded reclassification
+#   nix run '.#gc-roots-delete'
+#                             -- explicitly delete Linux auto GC roots through the dedicated cleanup command
 #   nix run '.#storage-report' -- summarize Linux home-directory storage
 #   nix run '.#apt-upgrade'  -- apt-get update && upgrade (Linux only)
 { lib, ... }:
@@ -108,9 +108,9 @@
         };
       }
       // lib.optionalAttrs isLinux {
-        # What: Delete stale auto-generated Nix GC roots through one delete-focused entrypoint.
-        # When: Run as root to re-classify auto roots and delete only current CANDIDATE roots.
-        # Example: /nix/var/nix/profiles/default/bin/nix run '.#gc-roots-delete'
+        # What: Keep Linux stale GC-root cleanup on one explicit command separate from switch.
+        # When: Run it directly when you want guarded stale-root deletion.
+        # Example: nix run '.#gc-roots-delete'
         gc-roots-delete = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "gc-roots-delete" ''

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -3,7 +3,7 @@
 #
 # Usage (quote .#name for zsh):
 #   nix run '.#switch'       -- rebuild and activate configuration
-#                               (Linux also prunes generations older than 14 days)
+#                               (Linux also prunes generations older than 1 day)
 #   nix run '.#update'       -- update flake inputs
 #   nix run '.#update' -- --min-age-days 7
 #                             -- update flake inputs with a minimum-age gate
@@ -43,7 +43,7 @@
                 ''
                   nix run --access-tokens github.com=$(${lib.getExe pkgs.gh} auth token) \
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
-                  ${pkgs.nix}/bin/nix-collect-garbage --delete-older-than 14d
+                  ${pkgs.nix}/bin/nix-collect-garbage --delete-older-than 1d
                 ''
             }
           ''}/bin/switch";

--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -53,7 +53,10 @@ in
           }:
           let
             storageReportScript = pkgs.writeShellScriptBin "storage-report-daily" ''
-              exec ${pkgs.bash}/bin/bash ${./../../../bin/ubuntu/storage-pressure-report.sh} --self --summary
+              report_dir="''${XDG_STATE_HOME:-$HOME/.local/state}/storage-report"
+              umask 077
+              mkdir -p "$report_dir"
+              exec ${pkgs.bash}/bin/bash ${./../../../bin/ubuntu/storage-pressure-report.sh} --self --summary >"$report_dir/latest.log"
             '';
           in
           {
@@ -95,7 +98,6 @@ in
               Service = {
                 Type = "oneshot";
                 ExecStart = "${storageReportScript}/bin/storage-report-daily";
-                StandardOutput = "null";
                 StandardError = "journal";
               };
             };

--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -51,6 +51,11 @@ in
             lib,
             ...
           }:
+          let
+            storageReportScript = pkgs.writeShellScriptBin "storage-report-daily" ''
+              exec ${pkgs.bash}/bin/bash ${./../../../bin/ubuntu/storage-pressure-report.sh} --self --summary
+            '';
+          in
           {
             nix = {
               # Garbage collection via systemd timer (daily at noon, delete older than 1 day)
@@ -82,6 +87,23 @@ in
                   eval $(${pkgs.openssh}/bin/ssh-agent)
                 fi
               '';
+            };
+            # Daily storage-pressure-report for the current user
+            # cf. nix.gc above (auto GC also runs daily via home-manager)
+            systemd.user.services."storage-report" = {
+              Unit.Description = "Linux home-directory storage pressure report";
+              Service = {
+                Type = "oneshot";
+                ExecStart = "${storageReportScript}/bin/storage-report-daily";
+              };
+            };
+            systemd.user.timers."storage-report" = {
+              Unit.Description = "Daily Linux home storage pressure report";
+              Timer = {
+                OnCalendar = "daily";
+                Persistent = true;
+              };
+              Install.WantedBy = [ "timers.target" ];
             };
           }
         )

--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -95,6 +95,8 @@ in
               Service = {
                 Type = "oneshot";
                 ExecStart = "${storageReportScript}/bin/storage-report-daily";
+                StandardOutput = "null";
+                StandardError = "journal";
               };
             };
             systemd.user.timers."storage-report" = {

--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -51,11 +51,6 @@ in
             lib,
             ...
           }:
-          let
-            storageReportScript = pkgs.writeShellScriptBin "storage-report-daily" ''
-              exec ${pkgs.bash}/bin/bash ${./../../../bin/ubuntu/storage-pressure-report.sh} --self --summary
-            '';
-          in
           {
             nix = {
               # Garbage collection via systemd timer (daily at noon, delete older than 1 day)
@@ -87,23 +82,6 @@ in
                   eval $(${pkgs.openssh}/bin/ssh-agent)
                 fi
               '';
-            };
-            # Daily storage-pressure-report for the current user
-            # cf. nix.gc above (auto GC also runs daily via home-manager)
-            systemd.user.services."storage-report" = {
-              Unit.Description = "Linux home-directory storage pressure report";
-              Service = {
-                Type = "oneshot";
-                ExecStart = "${storageReportScript}/bin/storage-report-daily";
-              };
-            };
-            systemd.user.timers."storage-report" = {
-              Unit.Description = "Daily Linux home storage pressure report";
-              Timer = {
-                OnCalendar = "daily";
-                Persistent = true;
-              };
-              Install.WantedBy = [ "timers.target" ];
             };
           }
         )

--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -58,7 +58,7 @@ in
               gc = {
                 automatic = true;
                 dates = "12:00";
-                options = "--delete-older-than 14d";
+                options = "--delete-older-than 1d";
               };
               settings = commonNixSettings // {
                 # Nix store optimisation via hard links (writes to ~/.config/nix/nix.conf)

--- a/nix/nix-darwin/default.nix
+++ b/nix/nix-darwin/default.nix
@@ -40,7 +40,7 @@
     #       and scheduled optimise can cause syspolicyd high CPU
     # cf. `https://github.com/nix-darwin/nix-darwin/issues/1252`
     optimise.automatic = false;
-    # Garbage collection (daily at noon, delete older than 3 days)
+    # Garbage collection (daily at noon, delete older than 1 day)
     # cf. https://mynixos.com/nix-darwin/option/nix.gc.interval
     gc = {
       automatic = true;
@@ -48,7 +48,7 @@
         Hour = 12;
         Minute = 0;
       };
-      options = "--delete-older-than 3d";
+      options = "--delete-older-than 1d";
     };
   };
 

--- a/nix/nix-darwin/default.nix
+++ b/nix/nix-darwin/default.nix
@@ -40,7 +40,7 @@
     #       and scheduled optimise can cause syspolicyd high CPU
     # cf. `https://github.com/nix-darwin/nix-darwin/issues/1252`
     optimise.automatic = false;
-    # Garbage collection (daily at noon, delete older than 1 day)
+    # Garbage collection (daily at noon, delete older than 3 days)
     # cf. https://mynixos.com/nix-darwin/option/nix.gc.interval
     gc = {
       automatic = true;
@@ -48,7 +48,7 @@
         Hour = 12;
         Minute = 0;
       };
-      options = "--delete-older-than 1d";
+      options = "--delete-older-than 3d";
     };
   };
 


### PR DESCRIPTION
## Summary

- add a Linux-only `storage-report` surface for self and all-user home-storage visibility
- add a low-risk `cleanup` surface for rebuildable user caches
- keep `gc-roots-delete` as a separate Linux-only fallback for stale auto gcroots
- add a daily Ubuntu `storage-report` user timer and keep the Linux app wrappers store-backed
- add duplicate-swap guardrails plus a manual swap-consolidation runbook
- keep `switch` on generation expiry only and align scheduled daemon GC retention to 1 day

## Usage

### Storage Report

- Self summary: `nix run '.#storage-report' -- --self --summary`
- All Linux home users: `sudo nix run '.#storage-report' -- --all-users --summary`

### Low-Risk Cleanup

- User caches: `nix run '.#cleanup'`

### GC-Root Fallback

- Current-user stale gcroot pass: `nix run '.#gc-roots-delete'`

## Notes

- `switch` is not a post-switch store GC command in the current branch. It performs profile generation expiry, while scheduled daemon GC remains separate.
- `gc-roots-delete` is an explicit fallback surface for suspected stale auto gcroots, not the default maintenance path.
- Swap consolidation remains manual by design. Follow `docs/storage-hygiene.md`.

## Reference

- Ref: #123
