### PR TITLE
fix(worktree): make repo setup resilient

### DIFF
--- a/bin/issue-worktree-create
+++ b/bin/issue-worktree-create
@@ -9,13 +9,14 @@ set -o posix
 # Falls back to title-based naming if Claude is not available.
 #
 # Usage:
-#   issue-worktree-create <issue_number> [issue_number2 ...]
+#   issue-worktree-create [--allow-direnv] <issue_number> [issue_number2 ...]
 #
 # Dependencies:
 #   - gh (GitHub CLI)
 #   - jq
 #   - claude (Anthropic CLI, optional)
 #   - repo-setup (optional)
+#   - direnv (optional; only for --allow-direnv)
 
 # Check required dependencies
 for cmd in gh jq git; do
@@ -25,10 +26,34 @@ for cmd in gh jq git; do
   fi
 done
 
+allow_direnv="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-direnv)
+      allow_direnv="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      echo "Usage: $0 [--allow-direnv] <issue_number> [issue_number2 ...]" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 # Check arguments
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $0 <issue_number> [issue_number2 ...]" >&2
+  echo "Usage: $0 [--allow-direnv] <issue_number> [issue_number2 ...]" >&2
   echo "Example: $0 123" >&2
+  echo "Example: $0 --allow-direnv 123" >&2
   echo "Example: $0 123 456 789" >&2
   exit 1
 fi
@@ -250,7 +275,11 @@ ${issue_comments}
     if command -v repo-setup &>/dev/null; then
       echo "-> Running repo-setup..."
       cd "$worktree_path"
-      repo-setup
+      if [[ ${allow_direnv} == "true" ]]; then
+        repo-setup --allow-direnv
+      else
+        repo-setup
+      fi
       cd - >/dev/null
     fi
   fi

--- a/bin/pr-worktree-create
+++ b/bin/pr-worktree-create
@@ -8,11 +8,12 @@ set -o posix
 # Checks out the PR branch for code review.
 #
 # Usage:
-#   pr-worktree-create <pr_number> [pr_number2 ...]
+#   pr-worktree-create [--allow-direnv] <pr_number> [pr_number2 ...]
 #
 # Dependencies:
 #   - gh (GitHub CLI)
 #   - repo-setup (optional)
+#   - direnv (optional; only for --allow-direnv)
 
 # Check required dependencies
 for cmd in gh git; do
@@ -22,10 +23,34 @@ for cmd in gh git; do
   fi
 done
 
+allow_direnv="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-direnv)
+      allow_direnv="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      echo "Usage: $0 [--allow-direnv] <pr_number> [pr_number2 ...]" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 # Check arguments
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $0 <pr_number> [pr_number2 ...]" >&2
+  echo "Usage: $0 [--allow-direnv] <pr_number> [pr_number2 ...]" >&2
   echo "Example: $0 123" >&2
+  echo "Example: $0 --allow-direnv 123" >&2
   echo "Example: $0 123 456 789" >&2
   exit 1
 fi
@@ -294,7 +319,11 @@ for pr_number in "$@"; do
     if command -v repo-setup &>/dev/null; then
       echo "-> Running repo-setup..."
       cd "$worktree_path"
-      repo-setup
+      if [[ ${allow_direnv} == "true" ]]; then
+        repo-setup --allow-direnv
+      else
+        repo-setup
+      fi
       cd - >/dev/null
     fi
   fi

--- a/bin/repo-setup
+++ b/bin/repo-setup
@@ -5,16 +5,74 @@ set -o pipefail
 set -o posix
 
 # Set up repository environment for development.
-# Prints explicit manual trust steps when needed and runs repository-specific
-# setup based on repo name.
+# Trust changes are opt-in. Pass --allow-direnv only after reviewing the
+# repository/worktree .envrc and the code it will load.
 #
 # Usage:
-#   repo-setup
+#   repo-setup [--allow-direnv] [--skip-devshell-hooks]
 #
+allow_direnv="false"
+install_devshell_hooks="true"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-direnv)
+      allow_direnv="true"
+      shift
+      ;;
+    --skip-devshell-hooks)
+      install_devshell_hooks="false"
+      shift
+      ;;
+    -h | --help)
+      echo "Usage: repo-setup [--allow-direnv] [--skip-devshell-hooks]"
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown option: $1" >&2
+      echo "Usage: repo-setup [--allow-direnv] [--skip-devshell-hooks]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # Get current worktree root
 worktree_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
 project_dir="$(basename "${worktree_root}")"
+envrc_path="${worktree_root}/.envrc"
 echo "* Repository: ${project_dir}"
+
+install_dotfiles_devshell_hooks() {
+  local previous_dir
+
+  if [[ ${install_devshell_hooks} != "true" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "${worktree_root}/flake.nix" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "${worktree_root}/nix/flake-parts/modules/pre-commit.nix" ]]; then
+    return 0
+  fi
+
+  if ! command -v nix &>/dev/null; then
+    echo "* Skipped installing devshell hooks: nix command not found"
+    return 0
+  fi
+
+  echo "-> Installing devshell hooks..."
+  previous_dir=$(pwd -P)
+  cd "${worktree_root}"
+  if ! nix develop "${worktree_root}#default" --command true; then
+    cd "${previous_dir}"
+    echo "Warning: could not install devshell hooks with nix develop; continuing without generated .pre-commit-config.yaml." >&2
+    echo "Warning: before pushing, re-run repo-setup after fixing Nix or enter the devshell to generate .pre-commit-config.yaml." >&2
+    return 0
+  fi
+  cd "${previous_dir}"
+}
 
 # Keep repository trust changes opt-in only.
 if [[ -f "mise.toml" ]]; then
@@ -23,10 +81,21 @@ if [[ -f "mise.toml" ]]; then
 fi
 
 # Keep .envrc allow changes opt-in only.
-if [[ -f ".envrc" ]]; then
-  echo "* Skipped allowing .envrc by default"
-  printf "* Optional: run '%s %s' to allow .envrc\n" "direnv" "allow"
+if [[ -f "${envrc_path}" ]]; then
+  if [[ ${allow_direnv} == "true" ]]; then
+    if ! command -v direnv &>/dev/null; then
+      echo "Error: direnv command not found, cannot allow .envrc." >&2
+      exit 1
+    fi
+    direnv allow "${envrc_path}"
+    echo "* Allowed .envrc with direnv"
+  else
+    echo "* Skipped allowing .envrc by default"
+    printf "* Optional: run '%s %s' to allow .envrc\n" "repo-setup" "--allow-direnv"
+  fi
 fi
+
+install_dotfiles_devshell_hooks
 
 # Repository-specific setup
 case "${project_dir}" in

--- a/docs/worktree-development-overview.md
+++ b/docs/worktree-development-overview.md
@@ -28,7 +28,12 @@ The workflow has five recurring phases:
    directory names derived from the issue or PR.
 3. Bootstrap the task environment.
    New worktrees copy `.envrc`, run `repo-setup` when available, and register
-   the final path with `zoxide`.
+   the final path with `zoxide`. `repo-setup` attempts to install the repo
+   devshell hooks and generated per-worktree pre-commit config. If Nix or
+   devshell setup fails, it warns and continues; re-run `repo-setup` or enter
+   the devshell before pushing so `.pre-commit-config.yaml` is generated.
+   `direnv allow` stays opt-in; pass `--allow-direnv` to the creation command
+   when the worktree contents are trusted and you want setup to allow `.envrc`.
 4. Re-enter quickly.
    Use `z <keyword>`, `zi [keywords...]`, or Ctrl-G to jump back to a repo or
    worktree from normal shell use. Inside tmux, re-entry also keeps session
@@ -46,7 +51,8 @@ policy:
 - issue and PR lookup through `gh`
 - branch reuse and upstream tracking
 - cross-repository PR review support
-- `.envrc` and `repo-setup` bootstrap
+- `.envrc`, devshell hook, and `repo-setup` bootstrap with explicit direnv
+  trust
 - zoxide registration for fast re-entry
 - tmux-aware session naming
 - explicit cleanup checks before removal

--- a/docs/worktree-development.md
+++ b/docs/worktree-development.md
@@ -12,9 +12,10 @@ For the adoption decision behind the current tool stack, see
 
 ## 1. Stable entrypoints
 
-- Use `issue-worktree-create <issue_number> [issue_number2 ...]` to start
-  issue work.
-- Use `pr-worktree-create <pr_number> [pr_number2 ...]` to start PR review.
+- Use `issue-worktree-create [--allow-direnv] <issue_number>
+  [issue_number2 ...]` to start issue work.
+- Use `pr-worktree-create [--allow-direnv] <pr_number> [pr_number2 ...]` to
+  start PR review.
 - Use `worktree-remove` from a repository to list that repo's managed
   worktrees under `.worktrees/`, choose one with `fzf`, type `yes`, and delete
   it through `git worktree remove`.
@@ -56,7 +57,12 @@ For the adoption decision behind the current tool stack, see
    --porcelain`. If no worktree exists, it creates one under `.worktrees/`
    with `git worktree add`.
 9. On a newly created worktree, it copies `.envrc` when present and runs
-   `repo-setup` when available.
+   `repo-setup` when available. `repo-setup` attempts to install the repo
+   devshell hooks and generated `.pre-commit-config.yaml` by default, but does
+   not allow `.envrc`; pass `--allow-direnv` when creating the worktree to run
+   `repo-setup --allow-direnv` in the new worktree. If Nix or devshell setup
+   fails, `repo-setup` warns and continues; re-run `repo-setup` or enter the
+   devshell before pushing so `.pre-commit-config.yaml` is generated.
 10. It adds the final worktree path to the `zoxide` database when `zoxide`
    exists.
 
@@ -83,7 +89,12 @@ For the adoption decision behind the current tool stack, see
    the branch automatically.
 9. It creates the review worktree at the derived PR directory path when needed.
 10. On a newly created worktree, it copies `.envrc` when present and runs
-    `repo-setup` when available.
+    `repo-setup` when available. `repo-setup` attempts to install the repo
+    devshell hooks and generated `.pre-commit-config.yaml` by default, but does
+    not allow `.envrc`; pass `--allow-direnv` when creating the worktree to run
+    `repo-setup --allow-direnv` in the new worktree. If Nix or devshell setup
+    fails, `repo-setup` warns and continues; re-run `repo-setup` or enter the
+    devshell before pushing so `.pre-commit-config.yaml` is generated.
 11. It adds the final worktree path to the `zoxide` database when `zoxide`
     exists.
 12. If any requested PR is invalid, skipped, refused, or otherwise fails, the
@@ -153,7 +164,14 @@ For the adoption decision behind the current tool stack, see
 - If a path was added to zoxide manually and still appears after deletion,
   remove it with `zoxide remove <path>`.
 - Preserve `.envrc` copy behavior and `repo-setup` bootstrap when changing the
-  backend or jump layer.
+  backend or jump layer. Keep `direnv allow` explicit because allowing a
+  worktree `.envrc` can evaluate code from that worktree; use
+  `--allow-direnv` only when the worktree contents are trusted.
+- If a linked worktree reports `No .pre-commit-config.yaml file was found`,
+  run `repo-setup` from that worktree. This attempts to install the devshell
+  hooks and the generated per-worktree pre-commit config without allowing
+  `.envrc`; if Nix or devshell setup fails, fix that failure and re-run
+  `repo-setup` or enter the devshell before pushing.
 - Notification or daemon behavior is outside this document. That belongs to
   `tmux-a2a-postman`.
 

--- a/skills/agent-workspace/references/preserved-guidance.md
+++ b/skills/agent-workspace/references/preserved-guidance.md
@@ -7,7 +7,9 @@ concise skill needs domain-specific details.
 ---
 name: agent-workspace
 license: MIT
-description: Boot and manage agent tmux workspaces using the vde-layout va preset, worktree creation and re-entry, session naming, and pane operations.
+description: |
+  Boot and manage agent tmux workspaces using the vde-layout va preset,
+  worktree creation and re-entry, session naming, and pane operations.
 ---
 
 # Agent Workspace
@@ -140,16 +142,20 @@ session by name in tmux commands.
 
 ## 4. Worktree Lifecycle
 
-Primary creation entrypoints: `bin/issue-worktree-create <issue_number>` and
-`bin/pr-worktree-create <pr_number>`. For interactive cleanup in the current
-repository, use `bin/worktree-remove` to choose one managed worktree under the
-repo's `.worktrees/` directory with `fzf`, confirm with `yes`, and delete
-through native `git worktree` cleanup.
+Primary creation entrypoints: `bin/issue-worktree-create [--allow-direnv]
+<issue_number>` and `bin/pr-worktree-create [--allow-direnv] <pr_number>`. For
+interactive cleanup in the current repository, use `bin/worktree-remove` to
+choose one managed worktree under the repo's `.worktrees/` directory with
+`fzf`, confirm with `yes`, and delete through native `git worktree` cleanup.
 
 Both scripts:
 
 - Copy `.envrc` from repo root
-- Run `repo-setup` if available
+- Run `repo-setup` if available to attempt devshell hook installation and
+  generate per-worktree `.pre-commit-config.yaml`, or
+  `repo-setup --allow-direnv` when the explicit `--allow-direnv` flag is
+  passed. If Nix or devshell setup fails, `repo-setup` warns and continues;
+  re-run `repo-setup` or enter the devshell before pushing.
 - Register path with `zoxide add "$worktree_path"` as the last step
 
 Issue worktrees use the issue branch name as the worktree directory name.

--- a/skills/agent-workspace/references/worktree-workflow.md
+++ b/skills/agent-workspace/references/worktree-workflow.md
@@ -16,7 +16,8 @@ Migrated from `skills/using-git-worktrees/SKILL.md`.
 
 ### Issue Execution
 
-Run `issue-worktree-create <issue_number>` from the repo. Expect it to:
+Run `issue-worktree-create [--allow-direnv] <issue_number>` from the repo.
+Expect it to:
 
 - fetch `origin`
 - refresh `main`
@@ -27,11 +28,16 @@ Run `issue-worktree-create <issue_number>` from the repo. Expect it to:
   plain `git push` creates and records `origin/<branch>`
 - create a new linked worktree when needed
 - copy `.envrc` when available
-- run `repo-setup` when available
+- run `repo-setup` when available to attempt devshell hook installation and
+  generate per-worktree `.pre-commit-config.yaml`, or
+  `repo-setup --allow-direnv` when the explicit `--allow-direnv` flag is
+  passed. If Nix or devshell setup fails, `repo-setup` warns and continues;
+  re-run `repo-setup` or enter the devshell before pushing.
 
 ### PR Review
 
-Run `pr-worktree-create <pr_number>` from the repo. Expect it to:
+Run `pr-worktree-create [--allow-direnv] <pr_number>` from the repo. Expect it
+to:
 
 - fetch `origin`
 - refresh `main`
@@ -45,7 +51,11 @@ Run `pr-worktree-create <pr_number>` from the repo. Expect it to:
   from the PR source branch
 - create or reuse a linked review worktree
 - copy `.envrc` when available
-- run `repo-setup` when available
+- run `repo-setup` when available to attempt devshell hook installation and
+  generate per-worktree `.pre-commit-config.yaml`, or
+  `repo-setup --allow-direnv` when the explicit `--allow-direnv` flag is
+  passed. If Nix or devshell setup fails, `repo-setup` warns and continues;
+  re-run `repo-setup` or enter the devshell before pushing.
 - exit nonzero and avoid the all-ready success message when any requested PR is
   invalid, skipped, refused, or otherwise fails
 
@@ -118,6 +128,8 @@ git worktree list --porcelain
   worktree is a simple branch-only case.
 - If the task is about changing worktree scripts or config, read those files in
   full and treat that as a code-change task, not a normal use of this reference.
+- If a worktree has shared Git hooks but lacks `.pre-commit-config.yaml`, run
+  `repo-setup` in that worktree before pushing.
 
 ## 7. Do Not Do These By Default
 


### PR DESCRIPTION
## Summary

- keep direnv trust opt-in through `repo-setup --allow-direnv`
- let issue and PR worktree creation pass `--allow-direnv` explicitly when requested
- make devshell hook setup best-effort so worktree creation can continue to zoxide registration when `nix develop` cannot generate hooks
- document the recovery path for regenerating `.pre-commit-config.yaml`

## Verification

- branch `direnv-worktree-setup-fix` is synced with `origin/direnv-worktree-setup-fix`
- duplicate PR check returned no existing PR for this head branch
- changed files verified with `git diff --name-only origin/main...HEAD`
