### PR TITLE
fix(pnpm): repair global CLI migration

### DIFF
--- a/nix/home-manager/modules/pnpm.nix
+++ b/nix/home-manager/modules/pnpm.nix
@@ -52,6 +52,58 @@ in
           ' >/dev/null
       }
 
+      pnpmPackageReady() {
+        pnpmPackageInstalled "$1" || return 1
+        case "$1" in
+          "ctx7")
+            [ -x "${pnpmBin}/ctx7" ]
+            ;;
+          "vde-layout")
+            [ -x "${pnpmBin}/vde-layout" ]
+            ;;
+          "vde-monitor")
+            [ -x "${pnpmBin}/vde-monitor" ] &&
+              [ -x "${pnpmBin}/vde-monitor-hook" ]
+            ;;
+          *)
+            return 0
+            ;;
+        esac
+      }
+
+      removeLegacyNpmPackageDir() {
+        pkg="$1"
+        pkgDir="${legacyNpmPrefix}/lib/node_modules/$pkg"
+        if [ -e "$pkgDir" ] || [ -L "$pkgDir" ]; then
+          echo "Removing legacy npm package residue $pkg..."
+          rm -rf "$pkgDir"
+        fi
+        case "$pkg" in
+          @*/*)
+            scope="''${pkg%%/*}"
+            rmdir "${legacyNpmPrefix}/lib/node_modules/$scope" 2>/dev/null || true
+            ;;
+        esac
+      }
+
+      removeLegacyNpmShim() {
+        shim="${pnpmBin}/$1"
+        if [ -L "$shim" ]; then
+          target=$(readlink "$shim" || true)
+          case "$target" in
+            "${legacyNpmPrefix}/lib/node_modules/"* | ../lib/node_modules/*)
+              echo "Removing legacy npm shim $1..."
+              rm -f "$shim"
+              ;;
+          esac
+        elif [ -f "$shim" ] &&
+          { grep -Fq "${legacyNpmPrefix}/lib/node_modules" "$shim" ||
+            grep -Fq "../lib/node_modules" "$shim"; }; then
+          echo "Removing legacy npm shim $1..."
+          rm -f "$shim"
+        fi
+      }
+
       SAFE_CHAIN_PACKAGE="@aikidosec/safe-chain"
       PNPM_PACKAGES=(
         "ctx7"
@@ -67,12 +119,40 @@ in
         "$SAFE_CHAIN_PACKAGE"
         "''${PNPM_PACKAGES[@]}"
       )
+      LEGACY_NPM_SHIMS=(
+        "aikido-bun"
+        "aikido-bunx"
+        "aikido-npm"
+        "aikido-npx"
+        "aikido-pip"
+        "aikido-pip3"
+        "aikido-pipx"
+        "aikido-pnpm"
+        "aikido-pnpx"
+        "aikido-poetry"
+        "aikido-python"
+        "aikido-python3"
+        "aikido-uv"
+        "aikido-uvx"
+        "aikido-yarn"
+        "ctx7"
+        "safe-chain"
+        "vde-layout"
+        "vde-monitor"
+        "vde-monitor-hook"
+      )
       for pkg in "''${LEGACY_NPM_PACKAGES[@]}"; do
         if ${npm} --prefix ${legacyNpmPrefix} list -g --depth=0 "$pkg" >/dev/null 2>&1; then
           echo "Removing legacy npm-managed package $pkg..."
           ${npm} --prefix ${legacyNpmPrefix} uninstall -g "$pkg" >/dev/null 2>&1 || true
         fi
+        removeLegacyNpmPackageDir "$pkg"
       done
+      for shim in "''${LEGACY_NPM_SHIMS[@]}"; do
+        removeLegacyNpmShim "$shim"
+      done
+      rmdir "${legacyNpmPrefix}/lib/node_modules" 2>/dev/null || true
+      rmdir "${legacyNpmPrefix}/lib" 2>/dev/null || true
 
       # Install/update Safe Chain first, then use its explicit pnpm wrapper for
       # package-changing operations in this non-interactive activation script.
@@ -127,7 +207,7 @@ in
 
       missingPackages=()
       for pkg in "''${PNPM_PACKAGES[@]}"; do
-        if ! pnpmPackageInstalled "$pkg"; then
+        if ! pnpmPackageReady "$pkg"; then
           echo "Installing $pkg..."
           missingPackages+=("$pkg")
         fi

--- a/nix/home-manager/modules/pnpm.nix
+++ b/nix/home-manager/modules/pnpm.nix
@@ -34,12 +34,23 @@ in
     installPnpmPackages = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       mkdir -p ${pnpmBin} ${pnpmGlobalDir} ${pnpmStoreDir}
       export PNPM_HOME="${pnpmHome}"
-      export PATH="${pnpmBin}:${nodejs}/bin:$PATH"
+      export PATH="${pnpmBin}:${pkgs.pnpm}/bin:${nodejs}/bin:$PATH"
 
       ${pnpm} config set --location=global globalBinDir "${pnpmBin}" >/dev/null
       ${pnpm} config set --location=global globalDir "${pnpmGlobalDir}" >/dev/null
       ${pnpm} config set --location=global storeDir "${pnpmStoreDir}" >/dev/null
       ${pnpm} config set --location=global minimumReleaseAge ${toString pnpmMinimumReleaseAgeMinutes} >/dev/null
+
+      pnpmPackageInstalled() {
+        ${pnpm} list -g --depth=0 --json 2>/dev/null |
+          ${pkgs.jq}/bin/jq -e --arg pkg "$1" '
+            if type == "array" then
+              (.[0].dependencies // {})
+            else
+              (.dependencies // {})
+            end | has($pkg)
+          ' >/dev/null
+      }
 
       SAFE_CHAIN_PACKAGE="@aikidosec/safe-chain"
       PNPM_PACKAGES=(
@@ -65,7 +76,7 @@ in
 
       # Install/update Safe Chain first, then use its explicit pnpm wrapper for
       # package-changing operations in this non-interactive activation script.
-      if ${pnpm} list -g --depth=0 "$SAFE_CHAIN_PACKAGE" >/dev/null 2>&1; then
+      if pnpmPackageInstalled "$SAFE_CHAIN_PACKAGE"; then
         safeChainWasInstalled=1
       else
         safeChainWasInstalled=0
@@ -116,7 +127,7 @@ in
 
       missingPackages=()
       for pkg in "''${PNPM_PACKAGES[@]}"; do
-        if ! ${pnpm} list -g --depth=0 "$pkg" >/dev/null 2>&1; then
+        if ! pnpmPackageInstalled "$pkg"; then
           echo "Installing $pkg..."
           missingPackages+=("$pkg")
         fi


### PR DESCRIPTION
## Summary

- Repair pnpm global package detection so managed CLIs are installed and relinked on switch.
- Put pnpm on the activation PATH so `aikido-pnpm` can invoke it.
- Clean old `npm.nix` package-directory residue and npm-origin shims for repo-managed globals while preserving unrelated npm state.

## Verification

- `git diff --check`
- `nix-instantiate --parse nix/home-manager/modules/pnpm.nix`
- `LOGNAME=$(id -un) USER=$(id -un) nix eval --impure .#homeConfigurations.ubuntu.activationPackage.drvPath`
- `nix flake check --no-build`
- `nix build .#checks.x86_64-linux.treefmt --no-link`
- `nix run '.#switch'`
- `which -a ctx7 vde-layout vde-monitor vde-monitor-hook safe-chain aikido-pnpm`
- `ctx7 --version`
- `vde-layout --version`

Related: #162
Follow-up to #166
