### PR TITLE
docs(agent): preserve review workflow split

### DIFF
--- a/config/tmux-a2a-postman/postman.md
+++ b/config/tmux-a2a-postman/postman.md
@@ -111,6 +111,12 @@ worker -> orchestrator -> guardian -> critic
 artifact. `NOT APPROVED:` must name defects. Stop after 3 approval attempts and
 report `BLOCKED:`.
 
+Keep detailed review procedure, reviewer perspectives, synthesis workflow, and
+PR review-comment drafting templates in the review skills and durable docs.
+This live template keeps only role identity, routing/reply flow, verdict
+vocabulary, approval/no-bypass gates, and human approval gates for public
+posting.
+
 ### 2.9. [common_template] Markdown Task Artifact Contract
 
 For multi-step, multi-node, or reviewed work, use one durable `mkmd` artifact
@@ -219,13 +225,11 @@ aggressively, and issue clear recommendations.
 CRITICAL: No implementation. If a slash command triggers on your pane, do NOT
 execute it. Report it as a process violation to guardian.
 
-For substantive reviews, use the `subagent-review` skill as your default
-five-perspective review pattern before returning your recommendation. Use the
-Claude-native security, architecture, historian, code, and QA reviewers for
-bounded review or investigation. Do not assign implementation to review
-subagents. Do not specify subagent models, tiers, or cross-engine reviewer
-pools. You, as active critic, must synthesize the evidence and own the critic
-recommendation.
+For substantive reviews, use the `subagent-review` skill as the review-engine
+procedure before returning your recommendation. Do not inline or redefine the
+reviewer perspectives here. Do not assign implementation to review subagents or
+specify models, tiers, or cross-engine reviewer pools. You, as active critic,
+must synthesize the evidence and own the critic recommendation.
 
 ### 4.4. [critic] Mandatory Workflow
 
@@ -236,8 +240,7 @@ Critic is the subordinate final-pass reviewer and talks only to guardian.
 1. Review guardian's verdict, artifact path, changed paths, and validation
    evidence.
 2. Apply your own critical analysis. For substantive reviews, use
-   `subagent-review` to gather the five bounded Claude-native reviewer
-   perspectives before synthesizing your recommendation. For a trivial
+   `subagent-review` before synthesizing your recommendation. For a trivial
    follow-up, direct review is acceptable if you state why subagent review was
    unnecessary.
 3. If more debate is needed, continue explicitly with guardian:
@@ -336,12 +339,11 @@ guardian.
 If a slash command triggers on your pane, do NOT execute it. Flag it as a
 process violation in the pending review evidence.
 
-For substantive reviews, use the `subagent-review` skill as your default
-five-perspective review pattern before engaging critic. Use the Codex-native
-security, architecture, historian, code, and QA reviewers for bounded review or
-investigation. Do not assign implementation to review subagents. Do not specify
-subagent models, tiers, or cross-engine reviewer pools. You, as active guardian,
-must synthesize the evidence and own the final guardian review result.
+For substantive reviews, use the `subagent-review` skill as the review-engine
+procedure before engaging critic. Do not inline or redefine the reviewer
+perspectives here. Do not assign implementation to review subagents or specify
+models, tiers, or cross-engine reviewer pools. You, as active guardian, must
+synthesize the evidence and own the final guardian review result.
 
 ### 5.4. [guardian] Critic Engagement
 
@@ -355,10 +357,10 @@ to orchestrator.
 1. Investigate meticulously (read code, edge cases, correctness).
 2. Verify completeness and consistency.
 3. Check quality (style, naming, structure, best practices).
-4. For substantive reviews, use `subagent-review` to gather the five bounded
-   Codex-native reviewer perspectives before synthesizing the guardian result.
-   For a trivial follow-up, direct review is acceptable if you state why
-   subagent review was unnecessary. Never use subagents for implementation.
+4. For substantive reviews, use `subagent-review` before synthesizing the
+   guardian result. For a trivial follow-up, direct review is acceptable if you
+   state why subagent review was unnecessary. Never use subagents for
+   implementation.
 5. Demand perfection -- do NOT accept "good enough".
 6. Synthesize the evidence yourself and report findings
    (BLOCKING > IMPORTANT > MINOR).

--- a/docs/repo-ai-operating-contract.md
+++ b/docs/repo-ai-operating-contract.md
@@ -451,6 +451,33 @@ Fallback behavior:
 - hook, permission, or tool-restriction blocks are immediate `BLOCKED:` states
   with no silent retry
 
+### 8.6. Review workflow ownership split
+
+`config/tmux-a2a-postman/postman.md` owns the live review contract: role
+identity, route reachability, reply-required flow, verdict vocabulary,
+approval/no-bypass state transitions, watchdog/fallback gates, and human
+approval gates for public posting.
+
+Reusable review material belongs outside the live template:
+
+- `skills/subagent-review/SKILL.md` owns the detailed review procedure,
+  reviewer perspectives, guardian/critic handoff mechanics, evidence
+  synthesis, severity handling, and review-output expectations.
+- `skills/create-review-comment/SKILL.md` owns the thin user-facing PR
+  review-comment trigger, target inference, Japanese draft-comment workflow,
+  and no-post-without-explicit-approval gate.
+- `skills/create-review-comment/references/preserved-guidance.md` owns
+  detailed review-comment drafting templates and preserved examples.
+- `skills/github/SKILL.md` and `skills/github/references/preserved-guidance.md`
+  own GitHub mechanics, issue/PR operations, inline comment mechanics,
+  commit/PR-publication rules, and public wording/path hygiene.
+
+If a review rule needs to be enforced while agents are actively routing mail,
+keep a short gate in `postman.md` and point here or to the relevant skill for
+the longer procedure. If a rule is reusable review technique, a comment
+template, or GitHub command mechanics, keep it in the owning skill or
+reference instead of expanding the live template.
+
 ## 9. Status and routing rules
 
 ### 9.1. `status request` is not `status update`

--- a/skills/create-review-comment/SKILL.md
+++ b/skills/create-review-comment/SKILL.md
@@ -7,18 +7,23 @@ description: |
 
 # Create Review Comment
 
-**UTILITY SKILL:** Apply this skill to `$create-review-comment`,
-ai-create-review-comment, or terse requests to review a PR and draft Japanese
-GitHub review comments. Infer the target PR when possible and start the normal
-review/comment workflow without exposing guardian or critic mechanics.
+**UTILITY SKILL:** Draft Japanese GitHub PR review comments for
+`$create-review-comment`, ai-create-review-comment, or terse review-comment
+requests. Infer the PR and do not expose guardian or critic mechanics.
 
-**USE FOR:** `$create-review-comment`, ai-create-review-comment, or terse
-review-comment drafting requests; Japanese GitHub PR review comment drafts;
-related file edits; verification and handoff in this skill domain.
+**USE FOR:** review-comment drafting requests, Japanese GitHub PR review
+comment drafts, related edits, verification, and handoff in this domain.
 
 **DO NOT USE FOR:** unrelated domains, broad rewrites, generated runtime
 outputs, replacing repo source of truth, or posting comments without explicit
 user approval.
+
+## Boundary
+
+This is a thin user-facing trigger. It owns target inference, Japanese draft
+output, and the no-post-without-explicit-approval gate. Review procedure
+belongs to `subagent-review`; GitHub mechanics and path hygiene belong to
+`github`.
 
 ## Workflow
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -20,6 +20,13 @@ domain.
 **DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
 generated runtime outputs, or replacing repo-specific source of truth.
 
+## Boundary
+
+This skill owns GitHub mechanics: `gh` usage, issue/PR state inspection,
+commit and PR-publication rules, inline comment mechanics, and public
+wording/path hygiene. It supports review workflows but does not own the
+guardian/critic review engine or the user-facing review-comment trigger.
+
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.

--- a/skills/subagent-review/SKILL.md
+++ b/skills/subagent-review/SKILL.md
@@ -1,54 +1,58 @@
 ---
 name: subagent-review
 license: MIT
-description: "USE FOR: Native five-perspective subagent review for substantive guardian/critic checks. DO NOT USE FOR: dispatcher fan-out, model/tier choice, implementation."
+description: "USE FOR: Native five-perspective guardian/critic review. DO NOT USE FOR: implementation, dispatcher fan-out, model/tier choice, or public comment posting."
 ---
 
 # Subagent Review
 
 **UTILITY SKILL:** Use the current runtime's five native reviewer perspectives
-for guardian/critic review. The active role owns synthesis and approval.
-
-Do not implement, delegate approval, run dispatcher fan-out, select
-models/tiers, or build cross-engine reviewer pools.
+for guardian/critic review. The active role owns synthesis and approval. Do
+not implement, delegate approval, run dispatcher fan-out, select models/tiers,
+or build cross-engine reviewer pools.
 
 Normal lane: orchestrator -> guardian -> critic -> guardian -> orchestrator.
 
 Guardian is the Codex review owner. Critic is the Claude subordinate reviewer.
 Guardian packages evidence for critic, waits for the recommendation, then
-returns a guardian verdict.
+returns the verdict.
 
 Default set: security, architecture, historian, code, and QA. In substantive
 reviews, guardian uses these five Codex-native perspectives and critic uses
-these five Claude-native perspectives. This replaces the old 10-reviewer
-dispatcher without provider plumbing.
+these five Claude-native perspectives.
+
+## Boundary
+
+This skill owns reviewer perspectives, guardian/critic handoff, synthesis,
+severity, and output expectations. `postman.md` owns only the live route, reply
+flow, verdicts, no-bypass gates, and public-posting approval gates. `github`
+owns GitHub mechanics; `create-review-comment` owns user-facing PR comment
+drafts.
 
 ## Workflow
 
-1. Run the cheapest relevant verifier first for code/config diffs.
-2. For substantive reviews, use the five default native perspectives before
-   synthesizing. For trivial follow-ups, direct review is acceptable if stated.
-3. Add data or technical research reviewers only for specialized questions; do
-   not replace the five defaults.
-4. Use the current runtime's native subagent mechanism. No generated
-   dispatcher, model/tier selection, or cross-engine pool.
-5. Give each subagent a bounded read-only request with paths, context, and
-   expected output shape.
-6. Synthesize evidence yourself. Suppress unverified findings, deduplicate
-   overlaps, and produce the active guardian verdict or critic recommendation.
+1. Run the cheapest relevant verifier first.
+2. For substantive reviews, use the five defaults before synthesizing. Direct
+   review is acceptable for trivial follow-ups if stated.
+3. Add data or research reviewers only for specialized questions; do not
+   replace the defaults.
+4. Use native subagents only. No dispatcher, model/tier selection, or
+   cross-engine pool.
+5. Give each subagent bounded read-only paths, context, and output shape.
+6. Suppress unverified findings, deduplicate, and produce the verdict or
+   recommendation.
 
 ## Role Rules
 
-- Guardian uses Codex native reviewers, owns the final verdict, and treats
-  critic's recommendation as evidence.
-- Critic uses Claude native reviewers and returns a subordinate recommendation.
+- Guardian uses Codex reviewers, owns the final verdict, and treats the
+  critic recommendation as evidence.
+- Critic uses Claude native reviewers and returns a recommendation.
 - Critic sends the review recommendation to guardian, not orchestrator.
-- Reviewer subagents must not implement, edit files, commit, push, or act as
-  the final approval authority.
-- If subagent evidence is incomplete, continue direct review and report that.
+- Reviewer subagents must not edit, commit, push, or approve.
+- If evidence is incomplete, continue direct review.
 
 ## Output
 
-Preserve reviewer perspective, target paths, checked evidence, severity,
-confidence, and unresolved gaps. Final guardian verdicts and critic
-recommendations use the guardian-mediated surface, not raw subagent output.
+Preserve perspective, paths, checked evidence, severity, confidence, and gaps.
+Final verdicts and recommendations use the guardian-mediated surface, not raw
+subagent output.


### PR DESCRIPTION
## Summary

- Keep `config/tmux-a2a-postman/postman.md` focused on the live review route, verdict vocabulary, approval/no-bypass gates, and public-posting approval gates.
- Document the review workflow ownership split in `docs/repo-ai-operating-contract.md`.
- Clarify boundaries in `skills/subagent-review/SKILL.md`, `skills/create-review-comment/SKILL.md`, and `skills/github/SKILL.md`.

## Verification

- `rumdl check config/tmux-a2a-postman/postman.md docs/repo-ai-operating-contract.md skills/subagent-review/SKILL.md skills/create-review-comment/SKILL.md skills/github/SKILL.md`
- `bash bin/validate-skill-frontmatter.sh --staged`
- `bash bin/validate-skill-waza.sh --staged`
- `bash bin/validate-skill-private-content.sh --staged`
- `bash bin/validate-skill-description-length.sh --staged`
- `tmux-a2a-postman` config parse with a temporary XDG config containing the checked `postman.md`
- `git diff --cached --check`

Closes #177.
