### PR TITLE
docs(skills): add data-platform target

### DIFF
--- a/skills/aws-auth/SKILL.md
+++ b/skills/aws-auth/SKILL.md
@@ -2,28 +2,36 @@
 name: aws-auth
 license: MIT
 description: |
-  USE FOR: AWS authentication via tmux send-keys to user-authenticated pane. Use when AWS SSO login must happen in user pane, not agent pane. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: Cloud auth compatibility trigger for user-authenticated pane workflows. Detailed owner: data-platform. DO NOT USE FOR: agent harness runtime or generated outputs.
 ---
 
 # Aws Auth
 
-**UTILITY SKILL:** Apply this skill to AWS authentication via tmux send-keys to
-user-authenticated pane. Use when AWS SSO login must happen in user pane, not
-agent pane. Keep the task scoped to the requested domain and preserve existing
-repo conventions.
+Compatibility trigger for cloud authentication workflows that must run through
+a user-authenticated pane. Classification is confirmed under `data-platform`
+because the guidance protects cloud/data operations from credential misuse; use
+`agent-harness-engineering` only for generic tmux or pane mechanics.
 
-**USE FOR:** AWS authentication via tmux send-keys to user-authenticated pane.
-Use when AWS SSO login must happen in user pane, not agent pane; related file
-edits; verification and handoff in this skill domain.
+The durable implementation guidance now lives in
+`skills/data-platform/references/cloud-auth.md`.
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+## Use For
+
+- Cloud authentication workflows where the user has already authenticated in a
+  shell pane.
+- Sending read-only credential confirmation commands to that pane.
+- Preserving the boundary that agents do not run interactive login flows.
+
+## Do Not Use For
+
+- Generic tmux pane operation guidance; use `agent-harness-engineering`.
+- Broad data-platform work; use `data-platform`.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/data-platform/references/cloud-auth.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,7 +43,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
-- [Preserved Guidance](references/preserved-guidance.md)
+- `skills/data-platform/references/cloud-auth.md`
 
 ## Troubleshooting
 

--- a/skills/bigquery-local/SKILL.md
+++ b/skills/bigquery-local/SKILL.md
@@ -2,28 +2,30 @@
 name: bigquery-local
 license: MIT
 description: |
-  USE FOR: BigQuery local: cost-aware query patterns, GoogleSQL guardrails, project conventions, partitioned/clustered table design, slot usage. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: BigQuery compatibility trigger for cost guardrails, GoogleSQL, table design, and slot checks. Detailed owner: data-platform. DO NOT USE FOR: generated outputs.
 ---
 
 # Bigquery Local
 
-**UTILITY SKILL:** Apply this skill to BigQuery local: cost-aware query
-patterns, GoogleSQL guardrails, project conventions, partitioned/clustered table
-design, slot usage. Keep the task scoped to the requested domain and preserve
-existing repo conventions.
+Compatibility trigger for BigQuery-specific tasks. The durable implementation
+guidance now lives in `skills/data-platform/references/bigquery.md`.
 
-**USE FOR:** BigQuery local: cost-aware query patterns, GoogleSQL guardrails,
-project conventions, partitioned/clustered table design, slot usage; related
-file edits; verification and handoff in this skill domain.
+## Use For
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+- BigQuery cost-aware query patterns in this repo.
+- GoogleSQL guardrails and partition/filter conventions.
+- Partitioned and clustered table design.
+- Slot usage checks.
+
+## Do Not Use For
+
+- Broad data-platform work; use `data-platform`.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/data-platform/references/bigquery.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,7 +37,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
-- [Preserved Guidance](references/preserved-guidance.md)
+- `skills/data-platform/references/bigquery.md`
 
 ## Troubleshooting
 

--- a/skills/classification.yaml
+++ b/skills/classification.yaml
@@ -343,73 +343,91 @@ skills:
     personal_content_action: scan_before_publish
     validation_expectations: *common_validation
 
+  - name: data-platform
+    path: skills/data-platform
+    publish: true
+    scope: data-platform-target
+    action: keep
+    target_group: data-platform
+    target_name: data-platform
+    release_state: needs_private_content_scan
+    owner_surface: skill
+    standalone_decision: keep_standalone_target
+    personal_content_action: scan_before_publish
+    validation_expectations: *common_validation
+    notes: >
+      Owns repo-local BigQuery, Databricks, dbt, restricted BigQuery/dbt safety,
+      and cloud-auth workflow references.
+
   - name: bigquery-local
     path: skills/bigquery-local
     publish: true
     scope: bigquery-local-workflow
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: data-platform
     target_name: data-platform
-    release_state: migrate_before_release
-    owner_surface: references
-    standalone_decision: merge_into_target
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_data_platform_target
+    owner_surface: skills/data-platform/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation
 
   - name: databricks-local
     path: skills/databricks-local
     publish: true
     scope: databricks-local-workflow
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: data-platform
     target_name: data-platform
-    release_state: migrate_before_release
-    owner_surface: references
-    standalone_decision: merge_into_target
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_data_platform_target
+    owner_surface: skills/data-platform/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation
 
   - name: dbt-local
     path: skills/dbt-local
     publish: true
     scope: dbt-local-workflow
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: data-platform
     target_name: data-platform
-    release_state: migrate_before_release
-    owner_surface: references
-    standalone_decision: merge_into_target
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_data_platform_target
+    owner_surface: skills/data-platform/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation
 
   - name: restricted-bigquery-dbt-environment
     path: skills/restricted-bigquery-dbt-environment
     publish: true
     scope: bigquery-dbt-safety
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: data-platform
     target_name: data-platform
-    release_state: migrate_before_release
-    owner_surface: references
-    standalone_decision: merge_into_target
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_data_platform_target
+    owner_surface: skills/data-platform/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation
 
   - name: aws-auth
     path: skills/aws-auth
     publish: true
     scope: cloud-auth-workflow
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: data-platform
     target_name: data-platform
-    release_state: needs_classification_confirmation
-    owner_surface: references
-    standalone_decision: merge_into_target_unless_reclassified
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_data_platform_target
+    owner_surface: skills/data-platform/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation
     notes: >
-      Reclassify under agent-harness-engineering if later review finds this is
-      primarily a harness-operation skill.
+      Classification confirmed under data-platform: the pane mechanics are
+      incidental; the safety boundary protects cloud/data authentication and
+      write operations. Use agent-harness-engineering only for generic tmux pane
+      operation guidance.
 
   - name: drawio-local
     path: skills/drawio-local

--- a/skills/data-platform/SKILL.md
+++ b/skills/data-platform/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: data-platform
+license: MIT
+description: |
+  USE FOR: Repo-local BigQuery, Databricks, dbt, restricted BigQuery/dbt safety, and cloud auth workflows. DO NOT USE FOR: harness, diagrams, or generic code.
+---
+
+# Data Platform
+
+Owns repo-local data-platform guidance for BigQuery, Databricks, dbt,
+restricted BigQuery/dbt safety, and cloud authentication workflows. Use official
+provider skills for general cloud or product documentation, then apply these
+repo-specific guardrails.
+
+## Use For
+
+- BigQuery cost-aware query patterns, GoogleSQL guardrails, table design, and
+  slot usage checks.
+- Databricks Queries API, VARIANT/JSON patterns, dashboard API notes, dbt
+  integration, and Jupyter kernel execution.
+- Local dbt target setup and Databricks SQL dialect caveats.
+- Restricted BigQuery/dbt safety workflows that keep local runs out of
+  production schemas.
+- Cloud authentication workflows that must run through a user-authenticated
+  pane instead of the agent pane.
+
+## Do Not Use For
+
+- Agent harness runtime, Home Manager agent config, hooks, postman routing, or
+  installed agent outputs; use `agent-harness-engineering`.
+- GitHub issue, PR, review, or public-surface mechanics; use `github`.
+- Diagram authoring or export workflows; use `diagramming`.
+- Generic Bash, Python, Nix, Markdown, or implementation-loop work; use
+  `programming`.
+
+## Workflow
+
+1. Inspect the relevant files, current repo conventions, and `git status`.
+2. Select the focused reference below before changing files or running data
+   commands.
+3. For any command that can write cloud or warehouse state, verify the target,
+   schema, and approval requirements before execution.
+4. Keep repo-local safety constraints in references and keep compatibility
+   trigger skills short.
+5. Run the fastest focused check during iteration, then the nearest repo
+   validation surface before reporting success.
+
+## References
+
+- [BigQuery](references/bigquery.md)
+- [Databricks](references/databricks.md)
+- [dbt](references/dbt.md)
+- [Restricted BigQuery dbt Safety](references/restricted-bigquery-dbt.md)
+- [Cloud Auth](references/cloud-auth.md)

--- a/skills/data-platform/references/bigquery.md
+++ b/skills/data-platform/references/bigquery.md
@@ -1,0 +1,59 @@
+# BigQuery
+
+Repo-specific BigQuery conventions. Standard GoogleSQL syntax, `bq` CLI usage,
+joins, window functions, BQML, and external tables are assumed knowledge.
+
+## Cost Guardrails
+
+- Use `--dry_run` before large queries.
+- Avoid `SELECT *`; specify columns explicitly.
+- Always filter on partition columns when querying partitioned tables.
+- Do not wrap partition columns in functions when pruning matters.
+- Prefer `APPROX_COUNT_DISTINCT` over `COUNT(DISTINCT)` when exact counts are
+  not required.
+
+Partition pruning example:
+
+```sql
+WHERE created_at >= '2024-01-01'
+  AND created_at < '2024-01-02'
+```
+
+Avoid this shape for partition pruning:
+
+```sql
+WHERE DATE(created_at) = '2024-01-01'
+```
+
+## Table Design
+
+- Combine date partitioning with clustering on up to four high-cardinality
+  columns.
+- Set `require_partition_filter = TRUE` on large tables.
+- Put the smaller table on the right side of joins when broadcast optimization
+  is useful.
+
+## Pricing Reference
+
+- On-demand analysis: `$5/TB` scanned.
+- Active storage: `$0.02/GB`.
+- Long-term storage: `$0.01/GB`.
+
+## Slot Usage Check
+
+```sql
+SELECT
+  job_id,
+  total_bytes_processed,
+  total_slot_ms,
+  TIMESTAMP_DIFF(end_time, start_time, SECOND) AS duration_sec
+FROM `region-us`.INFORMATION_SCHEMA.JOBS
+WHERE creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+ORDER BY total_slot_ms DESC
+LIMIT 10;
+```
+
+## References
+
+- BigQuery docs: <https://cloud.google.com/bigquery/docs>
+- BigQuery pricing: <https://cloud.google.com/bigquery/pricing>

--- a/skills/data-platform/references/cloud-auth.md
+++ b/skills/data-platform/references/cloud-auth.md
@@ -1,0 +1,34 @@
+# Cloud Auth
+
+Use this reference when a cloud task requires credentials that are already
+available in a user-authenticated shell pane.
+
+## Core Pattern
+
+Do not run interactive cloud login commands in the agent pane. Ask for or use
+the user-provided authenticated pane, then send commands to that pane with
+`tmux send-keys` and capture output with `tmux capture-pane`.
+
+```sh
+tmux send-keys -t <pane_id> 'aws sts get-caller-identity' Enter
+sleep 2
+tmux capture-pane -t <pane_id> -p
+```
+
+## Workflow
+
+1. The user authenticates in their own pane.
+2. The user provides the pane ID, or the task context already names it.
+3. Confirm credentials with a read-only identity command.
+4. Send subsequent cloud commands to that pane.
+5. Capture output from that pane for evidence.
+
+## Rules
+
+- Do not run interactive SSO login, credential discovery, or profile selection
+  from the agent pane.
+- Confirm credentials before real operations.
+- Stop for explicit approval before any command that writes cloud resources or
+  production data.
+- If credentials are expired, report that the user-authenticated pane must be
+  refreshed.

--- a/skills/data-platform/references/databricks.md
+++ b/skills/data-platform/references/databricks.md
@@ -1,0 +1,113 @@
+# Databricks
+
+Repo-specific Databricks additions. Use official Databricks skills for CLI
+basics, auth, Unity Catalog, Delta Lake, Lakeflow Jobs, ML, security, and schema
+discovery.
+
+## Profile Verification
+
+When a Databricks CLI profile name is provided but not confirmed, verify it
+before incorporating it into a plan or using it in commands:
+
+```sh
+databricks --profile <name> clusters list
+```
+
+If verification fails, report the failure before proceeding.
+
+## Queries API
+
+For saved query objects, use `warehouse_id`, `query_text`, and `display_name`.
+Do not use the older `data_source_id`, `query`, or `name` fields for this API.
+
+```sh
+databricks api post /api/2.0/sql/queries --profile "DEFAULT" --json '{
+  "warehouse_id": "xxxxxxxxxx",
+  "display_name": "My Query",
+  "query_text": "SELECT * FROM table_name LIMIT 10",
+  "description": "Optional description"
+}'
+```
+
+Useful read operations:
+
+```sh
+databricks api get /api/2.0/sql/queries --profile "DEFAULT"
+databricks api get /api/2.0/sql/queries/{query_id} --profile "DEFAULT"
+```
+
+## VARIANT And JSON
+
+Prefer the VARIANT type for semi-structured data on runtimes that support it.
+It avoids fixed schemas and is faster than repeatedly parsing JSON strings.
+
+```sql
+CREATE TABLE events (
+  id BIGINT,
+  data VARIANT
+);
+
+SELECT
+  data:name::STRING AS name,
+  data:age::INT AS age
+FROM events;
+```
+
+Use colon notation for object fields, array elements, wildcards, and type
+casts:
+
+```sql
+json_data:name
+json_data:metadata.status
+json_data:tags[0]
+json_data:tags[*]
+json_data:age::INT
+```
+
+`get_json_object()` remains useful for simple JSON strings, but its path
+argument must be a string literal and does not support colon-notation
+wildcards.
+
+## Dashboard API
+
+Use Lakeview APIs for AI/BI dashboards. Legacy dashboard APIs are deprecated.
+Lakeview dashboards do not support custom HTML, client-side JavaScript, or
+client-side JSON parsing. Parse JSON in SQL before visualization.
+
+## dbt Integration
+
+Store raw semi-structured data in bronze tables as VARIANT, expand fields in
+silver dbt models, then apply business logic in gold models.
+
+```text
+Source -> Bronze (VARIANT) -> Silver (dbt expand) -> Gold (business logic)
+```
+
+Dynamic JSON expansion belongs in macros and must still be reviewed for schema
+drift before production use.
+
+## Jupyter Kernel
+
+For Databricks-backed notebooks, install and run the Databricks Jupyter kernel
+when the environment provides the required host, token, and cluster ID.
+
+```sh
+uv pip install jupyter-databricks-kernel
+uv run python -m jupyter_databricks_kernel.install
+uv run jupyter execute <notebook_path> --inplace --kernel_name=databricks --timeout=300
+```
+
+Cluster startup can take several minutes if the target cluster is stopped.
+
+## References
+
+- VARIANT: <https://docs.databricks.com/aws/en/semi-structured/variant.html>
+- JSON operations:
+  <https://docs.databricks.com/aws/en/semi-structured/json.html>
+- Colon notation:
+  <https://docs.databricks.com/aws/en/sql/language-manual/functions/colonsign.html>
+- Lakeview dashboards:
+  <https://docs.databricks.com/aws/en/dashboards/>
+- dbt: <https://docs.getdbt.com/>
+- Jupyter Databricks kernel:
+  <https://github.com/i9wa4/jupyter-databricks-kernel>

--- a/skills/data-platform/references/dbt.md
+++ b/skills/data-platform/references/dbt.md
@@ -1,0 +1,55 @@
+# dbt
+
+Repo-local dbt additions. Use official dbt skills for command basics such as
+`debug`, `compile`, `run`, `test`, `show`, selectors, verification procedures,
+and ad-hoc queries.
+
+## Issue Work Target Setup
+
+Set up an issue-specific target before local `dbt run` work.
+
+1. Read the local dbt profile and check existing settings.
+2. Add an issue-specific target based on the existing development target.
+3. Use a target and schema name that includes the issue number.
+4. Run dbt commands with `--target <issue_target>` and the appropriate
+   profiles directory option for the project.
+
+Example target shape:
+
+```yaml
+my_databricks_dbt:
+  outputs:
+    dev:
+      # Existing development settings.
+    issue_123:
+      catalog: dbt_dev_{username}
+      host: dbc-xxxxx.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/xxxxx
+      schema: dwh_issue_123
+      threads: 1
+      token: dapixxxxx
+      type: databricks
+  target: dev
+```
+
+Example commands:
+
+```sh
+dbt debug --target issue_123 --profiles-dir <profiles_dir> --no-use-colors
+dbt run --select +model_name --target issue_123 --profiles-dir <profiles_dir> --no-use-colors
+```
+
+Manually delete unused issue schemas after the work is complete.
+
+## Databricks SQL Dialect
+
+Use backticks for full-width column names and names containing hyphens.
+
+```sql
+SELECT * FROM `catalog-name`.schema_name.table_name;
+SELECT `full-width column` FROM table_name;
+```
+
+## Examples
+
+- Staging model example: `skills/dbt-local/examples/staging-model.sql`

--- a/skills/data-platform/references/restricted-bigquery-dbt.md
+++ b/skills/data-platform/references/restricted-bigquery-dbt.md
@@ -1,0 +1,55 @@
+# Restricted BigQuery dbt Safety
+
+Use this workflow when local dbt runs must stay out of production BigQuery
+schemas.
+
+## Environment Selection
+
+Follow the repository's actual Python environment. Do not treat `pyproject.toml`
+as a requirements file.
+
+- If `uv.lock` exists, use `uv run dbt`.
+- If `poetry.lock` exists, create the virtual environment with `uv`, activate
+  it, then use `dbt`.
+- If neither exists, activate `.venv` when available, then use `dbt`.
+
+This repo has no root `pyproject.toml`, `uv.lock`, or `poetry.lock`, so do not
+prescribe `uv pip install --requirement pyproject.toml`.
+
+## Redirect Local Writes
+
+Temporarily add `schema='test'` at the beginning of the target model config
+before a local run.
+
+```sql
+{{
+  config(
+    schema='test',
+    materialized='incremental',
+  )
+}}
+```
+
+Compile first and confirm the rendered relation uses the `test` schema:
+
+```sh
+<dbt-command> compile --select <model_name> --profiles-dir <profiles_dir> --no-use-colors
+```
+
+## Running dbt
+
+- Get explicit user approval before `dbt run`.
+- Confirm the output schema is redirected away from production before running.
+- Prefer focused selectors.
+
+```sh
+<dbt-command> run --select <model_name> --profiles-dir <profiles_dir> --no-use-colors
+<dbt-command> test --select <model_name> --profiles-dir <profiles_dir> --no-use-colors
+```
+
+## Before Commit
+
+Remove the temporary `schema='test'` override before committing and verify the
+diff.
+
+Never commit a temporary schema override.

--- a/skills/databricks-local/SKILL.md
+++ b/skills/databricks-local/SKILL.md
@@ -2,28 +2,31 @@
 name: databricks-local
 license: MIT
 description: |
-  USE FOR: Databricks local: Queries API, VARIANT/JSON, Dashboard API, dbt integration (target setup, SQL dialect), Jupyter kernel. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: Databricks compatibility trigger for Queries API, VARIANT/JSON, dashboards, dbt, and Jupyter. Detailed owner: data-platform. DO NOT USE FOR: generated outputs.
 ---
 
 # Databricks Local
 
-**UTILITY SKILL:** Apply this skill to Databricks local: Queries API,
-VARIANT/JSON, Dashboard API, dbt integration (target setup, SQL dialect),
-Jupyter kernel. Keep the task scoped to the requested domain and preserve
-existing repo conventions.
+Compatibility trigger for Databricks-specific tasks. The durable
+implementation guidance now lives in
+`skills/data-platform/references/databricks.md`.
 
-**USE FOR:** Databricks local: Queries API, VARIANT/JSON, Dashboard API, dbt
-integration (target setup, SQL dialect), Jupyter kernel; related file edits;
-verification and handoff in this skill domain.
+## Use For
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+- Databricks Queries API object management.
+- VARIANT/JSON usage patterns.
+- AI/BI dashboard API notes.
+- Databricks/dbt integration and Jupyter kernel execution.
+
+## Do Not Use For
+
+- Broad data-platform work; use `data-platform`.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/data-platform/references/databricks.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,7 +38,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
-- [Preserved Guidance](references/preserved-guidance.md)
+- `skills/data-platform/references/databricks.md`
 
 ## Troubleshooting
 

--- a/skills/dbt-local/SKILL.md
+++ b/skills/dbt-local/SKILL.md
@@ -2,28 +2,30 @@
 name: dbt-local
 license: MIT
 description: |
-  USE FOR: Local dbt additions - Issue-specific target setup and Databricks SQL dialect notes. Supplements the official dbt and running-dbt-commands skills. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: dbt compatibility trigger for issue targets, Databricks SQL dialect notes, and local examples. Detailed owner: data-platform. DO NOT USE FOR: generated outputs.
 ---
 
 # Dbt Local
 
-**UTILITY SKILL:** Apply this skill to Local dbt additions - Issue-specific
-target setup and Databricks SQL dialect notes. Supplements the official dbt and
-running-dbt-commands skills. Keep the task scoped to the requested domain and
-preserve existing repo conventions.
+Compatibility trigger for dbt-specific repo additions. The durable
+implementation guidance now lives in `skills/data-platform/references/dbt.md`.
 
-**USE FOR:** Local dbt additions - Issue-specific target setup and Databricks
-SQL dialect notes. Supplements the official dbt and running-dbt-commands skills;
-related file edits; verification and handoff in this skill domain.
+## Use For
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+- Issue-specific local dbt target setup.
+- Databricks SQL dialect caveats for dbt work.
+- Repo-local dbt examples.
+
+## Do Not Use For
+
+- Broad data-platform work; use `data-platform`.
+- General dbt command basics; use official dbt skills when available.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/data-platform/references/dbt.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,7 +37,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
-- [Preserved Guidance](references/preserved-guidance.md)
+- `skills/data-platform/references/dbt.md`
 
 ## Troubleshooting
 

--- a/skills/restricted-bigquery-dbt-environment/SKILL.md
+++ b/skills/restricted-bigquery-dbt-environment/SKILL.md
@@ -2,28 +2,29 @@
 name: restricted-bigquery-dbt-environment
 license: MIT
 description: |
-  USE FOR: BigQuery dbt safety workflow: temporarily add schema='test' to avoid production writes, run dbt, remove override before commit. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: Restricted BigQuery/dbt safety compatibility trigger for local schema redirection. Detailed owner: data-platform. DO NOT USE FOR: broad data-platform work or generated outputs.
 ---
 
 # Restricted Bigquery Dbt Environment
 
-**UTILITY SKILL:** Apply this skill to BigQuery dbt safety workflow: temporarily
-add schema='test' to avoid production writes, run dbt, remove override before
-commit. Keep the task scoped to the requested domain and preserve existing repo
-conventions.
+Compatibility trigger for restricted BigQuery/dbt safety work. The durable
+implementation guidance now lives in
+`skills/data-platform/references/restricted-bigquery-dbt.md`.
 
-**USE FOR:** BigQuery dbt safety workflow: temporarily add schema='test' to
-avoid production writes, run dbt, remove override before commit; related file
-edits; verification and handoff in this skill domain.
+## Use For
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+- Local dbt work that must avoid production BigQuery schemas.
+- Temporary schema override workflow and pre-commit removal checks.
+
+## Do Not Use For
+
+- Broad data-platform work; use `data-platform`.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/data-platform/references/restricted-bigquery-dbt.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,7 +36,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
-- [Preserved Guidance](references/preserved-guidance.md)
+- `skills/data-platform/references/restricted-bigquery-dbt.md`
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add `skills/data-platform/` as the target owner for repo data-platform guidance.
- Move BigQuery, Databricks, dbt, restricted BigQuery/dbt safety, and cloud auth details into target references.
- Demote the source skills to trigger-focused compatibility entries and update `skills/classification.yaml`.

## Verification

- `bash bin/validate-skill-frontmatter.sh skills`
- `bash bin/validate-skill-private-content.sh --staged`
- `bash bin/validate-skill-description-length.sh --staged`
- `bash bin/validate-skill-waza.sh --staged`
- `git diff --cached --check`
- `nix run nixpkgs#rumdl -- check ...`
- `nix run nixpkgs#gh -- skill publish --dry-run`
- `nix run nixpkgs#pre-commit -- run --files $(git diff --cached --name-only)`

Closes https://github.com/i9wa4/dotfiles/issues/174
