### PR TITLE
docs(skills): add diagramming target

### DIFF
--- a/skills/classification.yaml
+++ b/skills/classification.yaml
@@ -411,28 +411,44 @@ skills:
       Reclassify under agent-harness-engineering if later review finds this is
       primarily a harness-operation skill.
 
+  - name: diagramming
+    path: skills/diagramming
+    publish: true
+    scope: diagramming-target
+    action: keep
+    target_group: diagramming
+    target_name: diagramming
+    release_state: needs_private_content_scan
+    owner_surface: skill
+    standalone_decision: keep_standalone_target
+    personal_content_action: scan_before_publish
+    validation_expectations: *common_validation
+    notes: >
+      Owns repo-local draw.io and Mermaid authoring, preview, export, layout,
+      color, and asset workflow references.
+
   - name: drawio-local
     path: skills/drawio-local
     publish: true
     scope: drawio-diagramming
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: diagramming
     target_name: diagramming
-    release_state: migrate_before_release
-    owner_surface: references
-    standalone_decision: merge_into_target
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_diagramming_target
+    owner_surface: skills/diagramming/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation
 
   - name: mermaid-local
     path: skills/mermaid-local
     publish: true
     scope: mermaid-diagramming
-    action: merge_into_references
+    action: compatibility_trigger
     target_group: diagramming
     target_name: diagramming
-    release_state: migrate_before_release
-    owner_surface: references
-    standalone_decision: merge_into_target
-    personal_content_action: scan_before_migration
+    release_state: migrated_to_diagramming_target
+    owner_surface: skills/diagramming/references
+    standalone_decision: compatibility_trigger_until_release
+    personal_content_action: scan_before_publish
     validation_expectations: *common_validation

--- a/skills/diagramming/SKILL.md
+++ b/skills/diagramming/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: diagramming
+license: MIT
+description: |
+  USE FOR: draw.io and Mermaid diagram authoring, preview, export, layout, color, and asset workflows in this repo. DO NOT USE FOR: data-platform or generic coding tasks.
+---
+
+# Diagramming
+
+Owns repo-local diagramming guidance for draw.io and Mermaid workflows. Use this
+skill for diagram source edits, preview/export decisions, layout checks,
+color/asset conventions, and diagram-focused validation.
+
+## Use For
+
+- draw.io `.drawio` source creation, editing, review, and export.
+- draw.io layout, color palette, shape vocabulary, and AWS icon usage.
+- Mermaid diagrams in Quarto revealjs `.qmd` files.
+- Mermaid CLI preview, `%%{init}%%` configuration, CSS overrides, and layout
+  validation.
+- Diagram-focused scripts and reference assets.
+
+## Do Not Use For
+
+- Data-platform workflows; use `data-platform`.
+- GitHub issue, PR, review, or public-surface mechanics; use `github`.
+- Generic Bash, Python, Nix, Markdown, or implementation-loop work; use
+  `programming`.
+- Agent harness runtime, hooks, postman routing, or installed agent outputs;
+  use `agent-harness-engineering`.
+
+## Workflow
+
+1. Inspect the diagram source, nearby conventions, and `git status`.
+2. Choose the focused reference below before editing or validating diagrams.
+3. Preserve editable source files; treat generated exports as reproducible
+   outputs unless the surrounding workflow requires them.
+4. Verify rendered dimensions, text contrast, and overlap when diagram layout
+   changes are user-visible.
+5. Run the nearest diagram or Markdown checks before reporting success.
+
+## References
+
+- [draw.io](references/drawio.md)
+- [Mermaid](references/mermaid.md)

--- a/skills/diagramming/references/aws-icons.md
+++ b/skills/diagramming/references/aws-icons.md
@@ -1,0 +1,678 @@
+# AWS アイコンとサービス名
+
+## 1. 正しいサービス名の規則
+
+| 接頭辞  | 例                                                               |
+| ------- | ---------------------------------------------------------------- |
+| Amazon  | Amazon ECS, Amazon ECR, Amazon S3, Amazon RDS, Amazon CloudWatch |
+| AWS     | AWS Lambda, AWS IAM, AWS CloudFormation, AWS Step Functions      |
+| Elastic | Elastic Load Balancing                                           |
+
+- 略称のみの使用は避ける (ECS → Amazon ECS)
+- 正式名称を使用する
+
+## 2. アイコンスタイル
+
+### 2.1. リソースアイコン (基本形式)
+
+```xml
+shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.{service_name};
+```
+
+### 2.2. プロダクトアイコン
+
+```xml
+shape=mxgraph.aws4.productIcon;prIcon=mxgraph.aws4.{service_name};
+```
+
+### 2.3. 注意事項
+
+- `mxgraph.aws4.*` を使用 (aws3 は古いため非推奨)
+- サービス名は snake_case で指定
+
+## 3. カテゴリ別アイコン
+
+### 3.1. Compute (コンピューティング)
+
+| サービス                      | resIcon                                |
+| ----------------------------- | -------------------------------------- |
+| Amazon EC2                    | mxgraph.aws4.ec2                       |
+| EC2 Instance                  | mxgraph.aws4.instance2                 |
+| EC2 Instances                 | mxgraph.aws4.instances                 |
+| Instance with CloudWatch      | mxgraph.aws4.instance_with_cloudwatch2 |
+| Spot Instance                 | mxgraph.aws4.spot_instance             |
+| Optimized Instance            | mxgraph.aws4.optimized_instance        |
+| DB on Instance                | mxgraph.aws4.db_on_instance            |
+| Elastic IP Address            | mxgraph.aws4.elastic_ip_address        |
+| Rescue                        | mxgraph.aws4.rescue                    |
+| Auto Scaling                  | mxgraph.aws4.auto_scaling2             |
+| AWS Lambda                    | mxgraph.aws4.lambda                    |
+| Lambda Function               | mxgraph.aws4.lambda_function           |
+| Amazon Lightsail              | mxgraph.aws4.lightsail                 |
+| AWS Batch                     | mxgraph.aws4.batch                     |
+| AWS Elastic Beanstalk         | mxgraph.aws4.elastic_beanstalk         |
+| Elastic Beanstalk Application | mxgraph.aws4.application               |
+| Elastic Beanstalk Deployment  | mxgraph.aws4.deployment                |
+| AWS Outposts                  | mxgraph.aws4.outposts                  |
+| AWS App Runner                | mxgraph.aws4.app_runner                |
+| AWS ParallelCluster           | mxgraph.aws4.parallel_cluster          |
+| AWS Wavelength                | mxgraph.aws4.wavelength                |
+| AWS Local Zones               | mxgraph.aws4.local_zones               |
+| VMware Cloud on AWS           | mxgraph.aws4.vmware_cloud_on_aws       |
+| Bottlerocket                  | mxgraph.aws4.bottlerocket              |
+| EC2 Image Builder             | mxgraph.aws4.ec2_image_builder         |
+| Elastic Fabric Adapter        | mxgraph.aws4.elastic_fabric_adapter    |
+| NICE DCV                      | mxgraph.aws4.nice_dcv                  |
+
+### 3.2. Containers (コンテナ)
+
+| サービス                 | resIcon                        |
+| ------------------------ | ------------------------------ |
+| Amazon ECS               | mxgraph.aws4.ecs               |
+| ECS Task                 | mxgraph.aws4.ecs_task          |
+| Amazon EKS               | mxgraph.aws4.eks               |
+| EKS Cloud                | mxgraph.aws4.eks_cloud         |
+| EKS Anywhere             | mxgraph.aws4.eks_anywhere      |
+| Amazon ECR               | mxgraph.aws4.ecr               |
+| AWS Fargate              | mxgraph.aws4.fargate           |
+| Container 1              | mxgraph.aws4.container_1       |
+| Container 2              | mxgraph.aws4.container_2       |
+| Container 3              | mxgraph.aws4.container_3       |
+| AWS App2Container        | mxgraph.aws4.app2container     |
+| Red Hat OpenShift on AWS | mxgraph.aws4.red_hat_openshift |
+
+### 3.3. Storage (ストレージ)
+
+| サービス                      | resIcon                                  |
+| ----------------------------- | ---------------------------------------- |
+| Amazon S3                     | mxgraph.aws4.s3                          |
+| S3 Bucket                     | mxgraph.aws4.bucket                      |
+| S3 Bucket with Objects        | mxgraph.aws4.bucket_with_objects         |
+| S3 Object                     | mxgraph.aws4.object                      |
+| S3 Glacier                    | mxgraph.aws4.glacier                     |
+| S3 Glacier Archive            | mxgraph.aws4.archive                     |
+| S3 Glacier Vault              | mxgraph.aws4.vault                       |
+| Amazon EBS                    | mxgraph.aws4.ebs                         |
+| EBS Volume                    | mxgraph.aws4.volume                      |
+| EBS Snapshot                  | mxgraph.aws4.snapshot                    |
+| Amazon EFS                    | mxgraph.aws4.efs                         |
+| EFS File System               | mxgraph.aws4.file_system                 |
+| Amazon FSx                    | mxgraph.aws4.fsx                         |
+| FSx for Lustre                | mxgraph.aws4.fsx_for_lustre              |
+| FSx for Windows File Server   | mxgraph.aws4.fsx_for_windows_file_server |
+| FSx for NetApp ONTAP          | mxgraph.aws4.fsx_for_netapp_ontap        |
+| FSx for OpenZFS               | mxgraph.aws4.fsx_for_openzfs             |
+| AWS Storage Gateway           | mxgraph.aws4.storage_gateway             |
+| File Gateway                  | mxgraph.aws4.file_gateway                |
+| Volume Gateway                | mxgraph.aws4.volume_gateway              |
+| Tape Gateway                  | mxgraph.aws4.tape_gateway                |
+| AWS Backup                    | mxgraph.aws4.backup                      |
+| AWS Elastic Disaster Recovery | mxgraph.aws4.elastic_disaster_recovery   |
+| AWS Snow Family               | mxgraph.aws4.snow_family                 |
+
+### 3.4. Database (データベース)
+
+| サービス                        | resIcon                                   |
+| ------------------------------- | ----------------------------------------- |
+| Amazon RDS                      | mxgraph.aws4.rds                          |
+| RDS DB Instance                 | mxgraph.aws4.db_instance                  |
+| RDS Read Replica                | mxgraph.aws4.db_instance_read_replica     |
+| RDS Standby                     | mxgraph.aws4.db_instance_standby          |
+| RDS MySQL                       | mxgraph.aws4.mysql_db_instance            |
+| RDS MySQL (Alt)                 | mxgraph.aws4.mysql_db_instance_alternate  |
+| RDS PostgreSQL                  | mxgraph.aws4.postgresql_instance          |
+| RDS Oracle                      | mxgraph.aws4.oracle_db_instance           |
+| RDS Oracle (Alt)                | mxgraph.aws4.oracle_db_instance_alternate |
+| RDS SQL Server                  | mxgraph.aws4.ms_sql_instance              |
+| RDS SQL Server (Alt)            | mxgraph.aws4.ms_sql_instance_alternate    |
+| RDS MariaDB                     | mxgraph.aws4.mariadb_instance             |
+| RDS SQL Primary                 | mxgraph.aws4.sql_primary                  |
+| RDS SQL Replica                 | mxgraph.aws4.sql_replica                  |
+| RDS PIOP                        | mxgraph.aws4.piop                         |
+| Amazon Aurora                   | mxgraph.aws4.aurora                       |
+| Aurora MySQL                    | mxgraph.aws4.aurora_mysql_instance        |
+| Aurora PostgreSQL               | mxgraph.aws4.aurora_postgresql_instance   |
+| Amazon DynamoDB                 | mxgraph.aws4.dynamodb                     |
+| DynamoDB Table                  | mxgraph.aws4.table                        |
+| DynamoDB Item                   | mxgraph.aws4.item                         |
+| DynamoDB Items                  | mxgraph.aws4.items                        |
+| DynamoDB Attribute              | mxgraph.aws4.attribute                    |
+| DynamoDB Attributes             | mxgraph.aws4.attributes                   |
+| DynamoDB Global Secondary Index | mxgraph.aws4.global_secondary_index       |
+| Amazon ElastiCache              | mxgraph.aws4.elasticache                  |
+| ElastiCache for Redis           | mxgraph.aws4.elasticache_for_redis        |
+| ElastiCache for Memcached       | mxgraph.aws4.elasticache_for_memcached    |
+| ElastiCache Cache Node          | mxgraph.aws4.cache_node                   |
+| Amazon Redshift                 | mxgraph.aws4.redshift                     |
+| Redshift Dense Compute Node     | mxgraph.aws4.dense_compute_node           |
+| Redshift Dense Storage Node     | mxgraph.aws4.dense_storage_node           |
+| Amazon Neptune                  | mxgraph.aws4.neptune                      |
+| Amazon DocumentDB               | mxgraph.aws4.documentdb                   |
+| Amazon Timestream               | mxgraph.aws4.timestream                   |
+| Amazon MemoryDB                 | mxgraph.aws4.memorydb                     |
+| Amazon Keyspaces                | mxgraph.aws4.keyspaces                    |
+| Amazon QLDB                     | mxgraph.aws4.qldb                         |
+| Generic Database                | mxgraph.aws4.database                     |
+
+### 3.5. Networking (ネットワーク)
+
+| サービス                          | resIcon                                  |
+| --------------------------------- | ---------------------------------------- |
+| Amazon VPC                        | mxgraph.aws4.vpc                         |
+| Internet Gateway                  | mxgraph.aws4.internet_gateway            |
+| NAT Gateway                       | mxgraph.aws4.nat_gateway                 |
+| VPN Gateway                       | mxgraph.aws4.vpn_gateway                 |
+| Customer Gateway                  | mxgraph.aws4.customer_gateway            |
+| VPN Connection                    | mxgraph.aws4.vpn_connection              |
+| VPC Peering                       | mxgraph.aws4.peering                     |
+| VPC Endpoints                     | mxgraph.aws4.endpoints                   |
+| VPC Flow Logs                     | mxgraph.aws4.flow_logs                   |
+| Network ACL                       | mxgraph.aws4.network_access_control_list |
+| Router                            | mxgraph.aws4.router                      |
+| Elastic Network Interface         | mxgraph.aws4.elastic_network_interface   |
+| Elastic Network Adapter           | mxgraph.aws4.elastic_network_adapter     |
+| Amazon CloudFront                 | mxgraph.aws4.cloudfront                  |
+| CloudFront Edge Location          | mxgraph.aws4.edge_location               |
+| CloudFront Download Distribution  | mxgraph.aws4.download_distribution       |
+| CloudFront Streaming Distribution | mxgraph.aws4.streaming_distribution      |
+| Amazon Route 53                   | mxgraph.aws4.route_53                    |
+| Route 53 Hosted Zone              | mxgraph.aws4.hosted_zone                 |
+| Route 53 Route Table              | mxgraph.aws4.route_table                 |
+| Elastic Load Balancing            | mxgraph.aws4.elastic_load_balancing      |
+| Application Load Balancer         | mxgraph.aws4.application_load_balancer   |
+| Network Load Balancer             | mxgraph.aws4.network_load_balancer       |
+| Gateway Load Balancer             | mxgraph.aws4.gateway_load_balancer       |
+| Classic Load Balancer             | mxgraph.aws4.classic_load_balancer       |
+| ELB (旧)                          | mxgraph.aws4.elb                         |
+| Amazon API Gateway                | mxgraph.aws4.api_gateway                 |
+| API Gateway Endpoint              | mxgraph.aws4.endpoint                    |
+| AWS Direct Connect                | mxgraph.aws4.direct_connect              |
+| AWS Transit Gateway               | mxgraph.aws4.transit_gateway             |
+| Transit Gateway Attachment        | mxgraph.aws4.transit_gateway_attachment  |
+| AWS PrivateLink                   | mxgraph.aws4.privatelink                 |
+| AWS Global Accelerator            | mxgraph.aws4.global_accelerator          |
+| AWS App Mesh                      | mxgraph.aws4.app_mesh                    |
+| AWS Cloud Map                     | mxgraph.aws4.cloud_map                   |
+| AWS Client VPN                    | mxgraph.aws4.client_vpn                  |
+| AWS Site-to-Site VPN              | mxgraph.aws4.site_to_site_vpn            |
+| AWS Network Firewall              | mxgraph.aws4.network_firewall            |
+| Amazon VPC Lattice                | mxgraph.aws4.vpc_lattice                 |
+| Verified Access                   | mxgraph.aws4.verified_access             |
+
+### 3.6. Security, Identity & Compliance (セキュリティ)
+
+| サービス                    | resIcon                                     |
+| --------------------------- | ------------------------------------------- |
+| AWS IAM                     | mxgraph.aws4.identity_and_access_management |
+| IAM (短縮)                  | mxgraph.aws4.iam                            |
+| IAM Role                    | mxgraph.aws4.role                           |
+| IAM Permissions             | mxgraph.aws4.permissions                    |
+| IAM Identity Center         | mxgraph.aws4.iam_identity_center            |
+| Amazon Cognito              | mxgraph.aws4.cognito                        |
+| AWS WAF                     | mxgraph.aws4.waf                            |
+| AWS Shield                  | mxgraph.aws4.shield                         |
+| AWS KMS                     | mxgraph.aws4.key_management_service         |
+| AWS Secrets Manager         | mxgraph.aws4.secrets_manager                |
+| AWS Certificate Manager     | mxgraph.aws4.certificate_manager            |
+| Amazon GuardDuty            | mxgraph.aws4.guardduty                      |
+| Amazon Inspector            | mxgraph.aws4.inspector                      |
+| Amazon Macie                | mxgraph.aws4.macie                          |
+| AWS Security Hub            | mxgraph.aws4.security_hub                   |
+| AWS Directory Service       | mxgraph.aws4.directory_service              |
+| AWS Firewall Manager        | mxgraph.aws4.firewall_manager               |
+| AWS Organizations           | mxgraph.aws4.organizations                  |
+| AWS Resource Access Manager | mxgraph.aws4.resource_access_manager        |
+| AWS Artifact                | mxgraph.aws4.artifact                       |
+| AWS Audit Manager           | mxgraph.aws4.audit_manager                  |
+| AWS CloudHSM                | mxgraph.aws4.cloudhsm                       |
+| Amazon Detective            | mxgraph.aws4.detective                      |
+| AWS Network Firewall        | mxgraph.aws4.network_firewall               |
+| AWS Private CA              | mxgraph.aws4.private_ca                     |
+| AWS Security Lake           | mxgraph.aws4.security_lake                  |
+| AWS Signer                  | mxgraph.aws4.signer                         |
+| Amazon Verified Permissions | mxgraph.aws4.verified_permissions           |
+| SAML Token                  | mxgraph.aws4.saml_token                     |
+
+### 3.7. Analytics (分析)
+
+| サービス                     | resIcon                             |
+| ---------------------------- | ----------------------------------- |
+| Amazon Athena                | mxgraph.aws4.athena                 |
+| Amazon CloudSearch           | mxgraph.aws4.cloudsearch            |
+| CloudSearch Search Documents | mxgraph.aws4.search_documents       |
+| AWS Glue                     | mxgraph.aws4.glue                   |
+| AWS Glue DataBrew            | mxgraph.aws4.glue_databrew          |
+| AWS Glue Elastic Views       | mxgraph.aws4.glue_elastic_views     |
+| AWS Glue Data Catalog        | mxgraph.aws4.data_catalog           |
+| AWS Glue Crawler             | mxgraph.aws4.crawler                |
+| Amazon Kinesis               | mxgraph.aws4.kinesis                |
+| Kinesis Data Streams         | mxgraph.aws4.kinesis_data_streams   |
+| Kinesis Data Firehose        | mxgraph.aws4.kinesis_data_firehose  |
+| Kinesis Data Analytics       | mxgraph.aws4.kinesis_data_analytics |
+| Kinesis Video Streams        | mxgraph.aws4.kinesis_video_streams  |
+| Amazon EMR                   | mxgraph.aws4.emr                    |
+| EMR Engine                   | mxgraph.aws4.emr_engine             |
+| EMR Engine MapR M3           | mxgraph.aws4.emr_engine_mapr_m3     |
+| EMR Engine MapR M5           | mxgraph.aws4.emr_engine_mapr_m5     |
+| EMR Engine MapR M7           | mxgraph.aws4.emr_engine_mapr_m7     |
+| EMR HDFS Cluster             | mxgraph.aws4.hdfs_cluster           |
+| EMR Cluster                  | mxgraph.aws4.cluster                |
+| Amazon OpenSearch            | mxgraph.aws4.opensearch             |
+| Elasticsearch (旧)           | mxgraph.aws4.elasticsearch_service  |
+| Amazon QuickSight            | mxgraph.aws4.quicksight             |
+| AWS Data Pipeline            | mxgraph.aws4.data_pipeline          |
+| Amazon MSK                   | mxgraph.aws4.msk                    |
+| AWS Lake Formation           | mxgraph.aws4.lake_formation         |
+| AWS Data Exchange            | mxgraph.aws4.data_exchange          |
+| Amazon DataZone              | mxgraph.aws4.datazone               |
+| AWS Clean Rooms              | mxgraph.aws4.clean_rooms            |
+| AWS Entity Resolution        | mxgraph.aws4.entity_resolution      |
+| Amazon FinSpace              | mxgraph.aws4.finspace               |
+| Amazon Managed Grafana       | mxgraph.aws4.managed_grafana        |
+| Amazon Managed Prometheus    | mxgraph.aws4.managed_prometheus     |
+
+### 3.8. Machine Learning & AI (機械学習・AI)
+
+| サービス                 | resIcon                               |
+| ------------------------ | ------------------------------------- |
+| Amazon SageMaker         | mxgraph.aws4.sagemaker                |
+| SageMaker Notebook       | mxgraph.aws4.sagemaker_notebook       |
+| SageMaker Model          | mxgraph.aws4.sagemaker_model          |
+| SageMaker Ground Truth   | mxgraph.aws4.sagemaker_ground_truth   |
+| Amazon Bedrock           | mxgraph.aws4.bedrock                  |
+| Amazon Q                 | mxgraph.aws4.amazon_q                 |
+| Amazon Q Business        | mxgraph.aws4.q_business               |
+| Amazon Q Developer       | mxgraph.aws4.q_developer              |
+| Amazon Lex               | mxgraph.aws4.lex                      |
+| Amazon Polly             | mxgraph.aws4.polly                    |
+| Amazon Rekognition       | mxgraph.aws4.rekognition              |
+| Amazon Transcribe        | mxgraph.aws4.transcribe               |
+| Amazon Comprehend        | mxgraph.aws4.comprehend               |
+| Amazon Textract          | mxgraph.aws4.textract                 |
+| Amazon Translate         | mxgraph.aws4.translate                |
+| Amazon Personalize       | mxgraph.aws4.personalize              |
+| Amazon Forecast          | mxgraph.aws4.forecast                 |
+| Amazon Kendra            | mxgraph.aws4.kendra                   |
+| Amazon CodeWhisperer     | mxgraph.aws4.codewhisperer            |
+| Amazon CodeGuru          | mxgraph.aws4.codeguru                 |
+| CodeGuru Reviewer        | mxgraph.aws4.codeguru_reviewer        |
+| CodeGuru Profiler        | mxgraph.aws4.codeguru_profiler        |
+| Amazon Lookout           | mxgraph.aws4.lookout                  |
+| Lookout for Vision       | mxgraph.aws4.lookout_for_vision       |
+| Lookout for Equipment    | mxgraph.aws4.lookout_for_equipment    |
+| Lookout for Metrics      | mxgraph.aws4.lookout_for_metrics      |
+| Amazon Fraud Detector    | mxgraph.aws4.fraud_detector           |
+| AWS DeepRacer            | mxgraph.aws4.deepracer                |
+| AWS DeepLens             | mxgraph.aws4.deeplens                 |
+| AWS DeepComposer         | mxgraph.aws4.deepcomposer             |
+| AWS Panorama             | mxgraph.aws4.panorama                 |
+| Amazon Augmented AI      | mxgraph.aws4.augmented_ai             |
+| Amazon HealthLake        | mxgraph.aws4.healthlake               |
+| Amazon Monitron          | mxgraph.aws4.monitron                 |
+| Amazon Omics             | mxgraph.aws4.omics                    |
+| Apache MXNet on AWS      | mxgraph.aws4.apache_mxnet             |
+| TensorFlow on AWS        | mxgraph.aws4.tensorflow               |
+| PyTorch on AWS           | mxgraph.aws4.pytorch                  |
+| Deep Learning AMIs       | mxgraph.aws4.deep_learning_amis       |
+| Deep Learning Containers | mxgraph.aws4.deep_learning_containers |
+| Machine Learning (汎用)  | mxgraph.aws4.machine_learning         |
+
+### 3.9. Application Integration (アプリケーション統合)
+
+| サービス                                    | resIcon                                       |
+| ------------------------------------------- | --------------------------------------------- |
+| Amazon SNS                                  | mxgraph.aws4.sns                              |
+| SNS Topic                                   | mxgraph.aws4.topic                            |
+| SNS Email Notification                      | mxgraph.aws4.email_notification               |
+| SNS HTTP Notification                       | mxgraph.aws4.http_notification                |
+| Amazon SQS                                  | mxgraph.aws4.sqs                              |
+| SQS Queue                                   | mxgraph.aws4.queue                            |
+| SQS Message                                 | mxgraph.aws4.message                          |
+| Amazon EventBridge                          | mxgraph.aws4.eventbridge                      |
+| EventBridge Event Bus                       | mxgraph.aws4.event_bus                        |
+| EventBridge Rule                            | mxgraph.aws4.rule                             |
+| EventBridge Schema Registry                 | mxgraph.aws4.schema_registry                  |
+| EventBridge Pipes                           | mxgraph.aws4.eventbridge_pipes                |
+| EventBridge Scheduler                       | mxgraph.aws4.eventbridge_scheduler            |
+| AWS Step Functions                          | mxgraph.aws4.step_functions                   |
+| Step Functions Workflow                     | mxgraph.aws4.workflow                         |
+| Amazon AppFlow                              | mxgraph.aws4.appflow                          |
+| Amazon MQ                                   | mxgraph.aws4.mq                               |
+| AWS AppSync                                 | mxgraph.aws4.appsync                          |
+| AWS Express Workflows                       | mxgraph.aws4.express_workflows                |
+| Amazon Managed Workflows for Apache Airflow | mxgraph.aws4.managed_workflows_apache_airflow |
+
+### 3.10. Management & Governance (管理・ガバナンス)
+
+| サービス                         | resIcon                                   |
+| -------------------------------- | ----------------------------------------- |
+| Amazon CloudWatch                | mxgraph.aws4.cloudwatch                   |
+| CloudWatch (v2)                  | mxgraph.aws4.cloudwatch_2                 |
+| CloudWatch Alarm                 | mxgraph.aws4.alarm                        |
+| CloudWatch Rule                  | mxgraph.aws4.event                        |
+| CloudWatch Logs                  | mxgraph.aws4.logs                         |
+| CloudWatch Metrics               | mxgraph.aws4.metrics                      |
+| AWS CloudFormation               | mxgraph.aws4.cloudformation               |
+| CloudFormation Template          | mxgraph.aws4.template                     |
+| CloudFormation Stack             | mxgraph.aws4.stack                        |
+| CloudFormation Change Set        | mxgraph.aws4.change_set                   |
+| AWS CloudTrail                   | mxgraph.aws4.cloudtrail                   |
+| AWS Systems Manager              | mxgraph.aws4.systems_manager              |
+| Systems Manager Automation       | mxgraph.aws4.automation                   |
+| Systems Manager Inventory        | mxgraph.aws4.inventory                    |
+| Systems Manager Patch Manager    | mxgraph.aws4.patch_manager                |
+| Systems Manager Run Command      | mxgraph.aws4.run_command                  |
+| Systems Manager State Manager    | mxgraph.aws4.state_manager                |
+| Systems Manager Parameter Store  | mxgraph.aws4.parameter_store              |
+| Systems Manager OpsCenter        | mxgraph.aws4.opscenter                    |
+| AWS Config                       | mxgraph.aws4.config                       |
+| AWS Service Catalog              | mxgraph.aws4.service_catalog              |
+| AWS Trusted Advisor              | mxgraph.aws4.trusted_advisor              |
+| AWS Control Tower                | mxgraph.aws4.control_tower                |
+| AWS License Manager              | mxgraph.aws4.license_manager              |
+| AWS Resource Explorer            | mxgraph.aws4.resource_explorer            |
+| AWS Well-Architected             | mxgraph.aws4.well_architected             |
+| AWS OpsWorks                     | mxgraph.aws4.opsworks                     |
+| AWS Launch Wizard                | mxgraph.aws4.launch_wizard                |
+| AWS Management Console           | mxgraph.aws4.management_console           |
+| AWS Personal Health Dashboard    | mxgraph.aws4.personal_health_dashboard    |
+| AWS Proton                       | mxgraph.aws4.proton                       |
+| AWS Resilience Hub               | mxgraph.aws4.resilience_hub               |
+| AWS Service Management Connector | mxgraph.aws4.service_management_connector |
+| AWS Chatbot                      | mxgraph.aws4.chatbot                      |
+| AWS Application Auto Scaling     | mxgraph.aws4.application_auto_scaling     |
+
+### 3.11. Developer Tools (開発者ツール)
+
+| サービス                    | resIcon                                   |
+| --------------------------- | ----------------------------------------- |
+| AWS CodeBuild               | mxgraph.aws4.codebuild                    |
+| AWS CodePipeline            | mxgraph.aws4.codepipeline                 |
+| AWS CodeCommit              | mxgraph.aws4.codecommit                   |
+| AWS CodeDeploy              | mxgraph.aws4.codedeploy                   |
+| AWS CodeArtifact            | mxgraph.aws4.codeartifact                 |
+| AWS CodeStar                | mxgraph.aws4.codestar                     |
+| AWS CodeCatalyst            | mxgraph.aws4.codecatalyst                 |
+| AWS Cloud9                  | mxgraph.aws4.cloud9                       |
+| AWS X-Ray                   | mxgraph.aws4.xray                         |
+| AWS CLI                     | mxgraph.aws4.command_line_interface       |
+| AWS SDK                     | mxgraph.aws4.sdk                          |
+| AWS CloudShell              | mxgraph.aws4.cloudshell                   |
+| AWS CDK                     | mxgraph.aws4.cloud_development_kit        |
+| AWS Application Composer    | mxgraph.aws4.application_composer         |
+| AWS Fault Injection Service | mxgraph.aws4.fault_injection_service      |
+| AWS Tools and SDKs          | mxgraph.aws4.tools_and_sdks               |
+| AWS SAM                     | mxgraph.aws4.serverless_application_model |
+
+### 3.12. Front-end Web & Mobile (フロントエンド)
+
+| サービス                | resIcon                       |
+| ----------------------- | ----------------------------- |
+| AWS Amplify             | mxgraph.aws4.amplify          |
+| AWS AppSync             | mxgraph.aws4.appsync          |
+| Amazon API Gateway      | mxgraph.aws4.api_gateway      |
+| Amazon Location Service | mxgraph.aws4.location_service |
+| AWS Device Farm         | mxgraph.aws4.device_farm      |
+| Amazon Pinpoint         | mxgraph.aws4.pinpoint         |
+
+### 3.13. Customer Engagement (カスタマーエンゲージメント)
+
+| サービス                         | resIcon                                |
+| -------------------------------- | -------------------------------------- |
+| Amazon Pinpoint                  | mxgraph.aws4.pinpoint                  |
+| Amazon SES                       | mxgraph.aws4.simple_email_service      |
+| Amazon Connect                   | mxgraph.aws4.connect                   |
+| Amazon Connect Customer Profiles | mxgraph.aws4.connect_customer_profiles |
+| Amazon Connect Wisdom            | mxgraph.aws4.connect_wisdom            |
+| Amazon Connect Voice ID          | mxgraph.aws4.connect_voice_id          |
+
+### 3.14. Business Applications (ビジネスアプリケーション)
+
+| サービス         | resIcon                   |
+| ---------------- | ------------------------- |
+| Amazon Chime     | mxgraph.aws4.chime        |
+| Amazon Chime SDK | mxgraph.aws4.chime_sdk    |
+| Amazon WorkMail  | mxgraph.aws4.workmail     |
+| Amazon Honeycode | mxgraph.aws4.honeycode    |
+| AWS Supply Chain | mxgraph.aws4.supply_chain |
+| AWS Wickr        | mxgraph.aws4.wickr        |
+
+### 3.15. End User Computing (エンドユーザーコンピューティング)
+
+| サービス              | resIcon                     |
+| --------------------- | --------------------------- |
+| Amazon WorkSpaces     | mxgraph.aws4.workspaces     |
+| Amazon WorkSpaces Web | mxgraph.aws4.workspaces_web |
+| Amazon AppStream 2.0  | mxgraph.aws4.appstream      |
+| AppStream 2.0 (v2)    | mxgraph.aws4.appstream_20   |
+| Amazon WorkDocs       | mxgraph.aws4.workdocs       |
+| Amazon WorkLink       | mxgraph.aws4.worklink       |
+| NICE DCV              | mxgraph.aws4.nice_dcv       |
+
+### 3.16. Internet of Things (IoT)
+
+| サービス                  | resIcon                               |
+| ------------------------- | ------------------------------------- |
+| AWS IoT Core              | mxgraph.aws4.iot_core                 |
+| IoT MQTT Protocol         | mxgraph.aws4.mqtt_protocol            |
+| IoT HTTP Protocol         | mxgraph.aws4.http_protocol            |
+| IoT HTTP2 Protocol        | mxgraph.aws4.http2_protocol           |
+| IoT Rule                  | mxgraph.aws4.iot_rule                 |
+| IoT Action                | mxgraph.aws4.iot_action               |
+| IoT Topic                 | mxgraph.aws4.iot_topic                |
+| IoT Shadow                | mxgraph.aws4.iot_shadow               |
+| IoT Certificate           | mxgraph.aws4.iot_certificate          |
+| IoT Policy                | mxgraph.aws4.iot_policy               |
+| IoT Hardware Board        | mxgraph.aws4.iot_hardware_board       |
+| IoT Sensor                | mxgraph.aws4.sensor                   |
+| IoT Servo                 | mxgraph.aws4.servo                    |
+| IoT Actuator              | mxgraph.aws4.actuator                 |
+| IoT Reported State        | mxgraph.aws4.reported_state           |
+| IoT Desired State         | mxgraph.aws4.desired_state            |
+| AWS IoT Greengrass        | mxgraph.aws4.iot_greengrass           |
+| IoT Greengrass Connector  | mxgraph.aws4.greengrass_connector     |
+| AWS IoT Analytics         | mxgraph.aws4.iot_analytics            |
+| IoT Analytics Channel     | mxgraph.aws4.iot_analytics_channel    |
+| IoT Analytics Pipeline    | mxgraph.aws4.iot_analytics_pipeline   |
+| IoT Analytics Data Store  | mxgraph.aws4.iot_analytics_data_store |
+| IoT Analytics Data Set    | mxgraph.aws4.iot_analytics_data_set   |
+| IoT Analytics Notebook    | mxgraph.aws4.iot_analytics_notebook   |
+| AWS IoT Device Defender   | mxgraph.aws4.iot_device_defender      |
+| AWS IoT Device Management | mxgraph.aws4.iot_device_management    |
+| AWS IoT Events            | mxgraph.aws4.iot_events               |
+| AWS IoT SiteWise          | mxgraph.aws4.iot_sitewise             |
+| AWS IoT Things Graph      | mxgraph.aws4.iot_things_graph         |
+| AWS IoT 1-Click           | mxgraph.aws4.iot_1click               |
+| AWS IoT Button            | mxgraph.aws4.iot_button               |
+| AWS IoT FleetWise         | mxgraph.aws4.iot_fleetwise            |
+| AWS IoT RoboRunner        | mxgraph.aws4.iot_roborunner           |
+| AWS IoT TwinMaker         | mxgraph.aws4.iot_twinmaker            |
+| FreeRTOS                  | mxgraph.aws4.freertos                 |
+
+### 3.17. Migration & Transfer (移行・転送)
+
+| サービス                          | resIcon                                      |
+| --------------------------------- | -------------------------------------------- |
+| AWS DMS                           | mxgraph.aws4.database_migration_service      |
+| DMS Database Migration Workflow   | mxgraph.aws4.database_migration_workflow_job |
+| AWS Snowball                      | mxgraph.aws4.snowball                        |
+| Snowball Import Export            | mxgraph.aws4.snowball_import_export          |
+| AWS Snowcone                      | mxgraph.aws4.snowcone                        |
+| AWS Snowmobile                    | mxgraph.aws4.snowmobile                      |
+| AWS Transfer Family               | mxgraph.aws4.transfer_family                 |
+| AWS Migration Hub                 | mxgraph.aws4.migration_hub                   |
+| Migration Hub Orchestrator        | mxgraph.aws4.migration_hub_orchestrator      |
+| Migration Hub Refactor Spaces     | mxgraph.aws4.migration_hub_refactor_spaces   |
+| AWS Application Migration         | mxgraph.aws4.application_migration_service   |
+| AWS Application Discovery Service | mxgraph.aws4.application_discovery_service   |
+| AWS DataSync                      | mxgraph.aws4.datasync                        |
+| DataSync Agent                    | mxgraph.aws4.datasync_agent                  |
+| AWS Mainframe Modernization       | mxgraph.aws4.mainframe_modernization         |
+
+### 3.18. Media Services (メディアサービス)
+
+| サービス                         | resIcon                           |
+| -------------------------------- | --------------------------------- |
+| AWS Elemental MediaConvert       | mxgraph.aws4.mediaconvert         |
+| AWS Elemental MediaLive          | mxgraph.aws4.medialive            |
+| AWS Elemental MediaPackage       | mxgraph.aws4.mediapackage         |
+| AWS Elemental MediaStore         | mxgraph.aws4.mediastore           |
+| AWS Elemental MediaTailor        | mxgraph.aws4.mediatailor          |
+| AWS Elemental MediaConnect       | mxgraph.aws4.mediaconnect         |
+| AWS Elemental Appliances         | mxgraph.aws4.elemental_appliances |
+| AWS Elemental Link               | mxgraph.aws4.elemental_link       |
+| AWS Elemental Server             | mxgraph.aws4.elemental_server     |
+| AWS Elemental Conductor          | mxgraph.aws4.elemental_conductor  |
+| AWS Elemental Delta              | mxgraph.aws4.elemental_delta      |
+| AWS Elemental Live               | mxgraph.aws4.elemental_live       |
+| Amazon Elastic Transcoder        | mxgraph.aws4.elastic_transcoder   |
+| Amazon Interactive Video Service | mxgraph.aws4.ivs                  |
+| Amazon Nimble Studio             | mxgraph.aws4.nimble_studio        |
+| AWS Deadline Cloud               | mxgraph.aws4.deadline_cloud       |
+
+### 3.19. Game Tech (ゲーム開発)
+
+| サービス          | resIcon                     |
+| ----------------- | --------------------------- |
+| Amazon GameLift   | mxgraph.aws4.gamelift       |
+| Amazon GameSparks | mxgraph.aws4.gamesparks     |
+| Open 3D Engine    | mxgraph.aws4.open_3d_engine |
+| Amazon Lumberyard | mxgraph.aws4.lumberyard     |
+
+### 3.20. Cost Management (コスト管理)
+
+| サービス                      | resIcon                                  |
+| ----------------------------- | ---------------------------------------- |
+| AWS Cost Explorer             | mxgraph.aws4.cost_explorer               |
+| AWS Budgets                   | mxgraph.aws4.budgets                     |
+| AWS Cost and Usage Report     | mxgraph.aws4.cost_and_usage_report       |
+| Reserved Instance Reporting   | mxgraph.aws4.reserved_instance_reporting |
+| Savings Plans                 | mxgraph.aws4.savings_plans               |
+| AWS Billing Conductor         | mxgraph.aws4.billing_conductor           |
+| AWS Application Cost Profiler | mxgraph.aws4.application_cost_profiler   |
+
+### 3.21. Blockchain (ブロックチェーン)
+
+| サービス                  | resIcon                         |
+| ------------------------- | ------------------------------- |
+| Amazon Managed Blockchain | mxgraph.aws4.managed_blockchain |
+| Amazon QLDB               | mxgraph.aws4.qldb               |
+
+### 3.22. Quantum Technologies (量子技術)
+
+| サービス      | resIcon             |
+| ------------- | ------------------- |
+| Amazon Braket | mxgraph.aws4.braket |
+
+### 3.23. Satellite (衛星)
+
+| サービス           | resIcon                     |
+| ------------------ | --------------------------- |
+| AWS Ground Station | mxgraph.aws4.ground_station |
+
+### 3.24. Robotics (ロボティクス)
+
+| サービス                          | resIcon                                        |
+| --------------------------------- | ---------------------------------------------- |
+| AWS RoboMaker                     | mxgraph.aws4.robomaker                         |
+| RoboMaker Simulation              | mxgraph.aws4.robomaker_simulation              |
+| RoboMaker Development Environment | mxgraph.aws4.robomaker_development_environment |
+| RoboMaker Fleet Management        | mxgraph.aws4.robomaker_fleet_management        |
+| RoboMaker Cloud Extension         | mxgraph.aws4.robomaker_cloud_extension         |
+
+### 3.25. General/Generic Icons (汎用アイコン)
+
+| 説明                  | resIcon                            |
+| --------------------- | ---------------------------------- |
+| Users                 | mxgraph.aws4.users                 |
+| User                  | mxgraph.aws4.user                  |
+| Client                | mxgraph.aws4.client                |
+| Internet              | mxgraph.aws4.internet              |
+| Internet (v2)         | mxgraph.aws4.internet_2            |
+| Mobile Client         | mxgraph.aws4.mobile_client         |
+| Mobile                | mxgraph.aws4.mobile                |
+| Desktop               | mxgraph.aws4.illustration_desktop  |
+| Laptop                | mxgraph.aws4.laptop                |
+| Tablet                | mxgraph.aws4.tablet                |
+| Browser               | mxgraph.aws4.browser               |
+| Traditional Server    | mxgraph.aws4.traditional_server    |
+| Generic Database      | mxgraph.aws4.generic_database      |
+| Generic Firewall      | mxgraph.aws4.generic_firewall      |
+| General               | mxgraph.aws4.general               |
+| AWS Cloud             | mxgraph.aws4.aws_cloud             |
+| Data Center           | mxgraph.aws4.data_center           |
+| Corporate Data Center | mxgraph.aws4.corporate_data_center |
+| On-Premises           | mxgraph.aws4.on_premises           |
+| Folder                | mxgraph.aws4.folder                |
+| Forums                | mxgraph.aws4.forums                |
+| Office Building       | mxgraph.aws4.office_building       |
+| SAML Token            | mxgraph.aws4.saml_token            |
+| SSL Padlock           | mxgraph.aws4.ssl_padlock           |
+| Tape Storage          | mxgraph.aws4.tape_storage          |
+| Toolkit               | mxgraph.aws4.toolkit               |
+| Generic SDK           | mxgraph.aws4.generic_sdk           |
+| Disk                  | mxgraph.aws4.disk                  |
+| External SDK          | mxgraph.aws4.external_sdk          |
+
+## 4. グループアイコン
+
+### 4.1. 基本構文
+
+```xml
+shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.{group_name};
+```
+
+### 4.2. グループアイコン一覧
+
+| 説明                          | grIcon                                         |
+| ----------------------------- | ---------------------------------------------- |
+| AWS Cloud                     | mxgraph.aws4.group_aws_cloud                   |
+| AWS Cloud (Alt)               | mxgraph.aws4.group_aws_cloud_alt               |
+| Region                        | mxgraph.aws4.group_region                      |
+| VPC                           | mxgraph.aws4.group_vpc                         |
+| Availability Zone             | mxgraph.aws4.group_availability_zone           |
+| Security Group                | mxgraph.aws4.group_security_group              |
+| Public Subnet                 | mxgraph.aws4.group_public_subnet               |
+| Private Subnet                | mxgraph.aws4.group_private_subnet              |
+| AWS Account                   | mxgraph.aws4.group_aws_account                 |
+| Corporate Data Center         | mxgraph.aws4.group_corporate_data_center       |
+| EC2 Instance Contents         | mxgraph.aws4.group_ec2_instance_contents       |
+| Elastic Beanstalk Container   | mxgraph.aws4.group_elastic_beanstalk_container |
+| Auto Scaling                  | mxgraph.aws4.group_auto_scaling                |
+| Spot Fleet                    | mxgraph.aws4.group_spot_fleet                  |
+| AWS Step Functions Workflow   | mxgraph.aws4.group_step_functions_workflow     |
+| Generic Group                 | mxgraph.aws4.group_generic                     |
+| AWS IoT Greengrass Deployment | mxgraph.aws4.group_iot_greengrass_deployment   |
+| Server Contents               | mxgraph.aws4.group_server_contents             |
+
+### 4.3. 使用例
+
+```xml
+<!-- AWS Cloud -->
+<mxCell style="shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud;..." />
+
+<!-- VPC -->
+<mxCell style="shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_vpc;..." />
+
+<!-- Availability Zone -->
+<mxCell style="shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_availability_zone;..." />
+
+<!-- Public Subnet -->
+<mxCell style="shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_public_subnet;fillColor=#E9F3E6;..." />
+
+<!-- Private Subnet -->
+<mxCell style="shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_private_subnet;fillColor=#E6F2F8;..." />
+```
+
+## 5. アイコン検索スクリプト
+
+[scripts/find_aws_icon.py](../scripts/find_aws_icon.py)
+を使用して効率的に検索可能。
+
+## 6. 参考リンク
+
+- [draw.io AWS Diagrams Blog](https://www.drawio.com/blog/aws-diagrams)
+- [AWS Architecture Icons](https://aws.amazon.com/architecture/icons/)
+- [jgraph/drawio GitHub](https://github.com/jgraph/drawio)
+- [awsicons.dev](https://awsicons.dev/)
+- [diagrams-aws-icons](https://github.com/m-radzikowski/diagrams-aws-icons)

--- a/skills/diagramming/references/color-palette.md
+++ b/skills/diagramming/references/color-palette.md
@@ -1,0 +1,54 @@
+# Color Palette
+
+Material Design color set extracted from existing slide diagrams.
+
+## 1. Color Table
+
+| Role    | Background | Stroke    | Text      |
+| ------- | ---------- | --------- | --------- |
+| Primary | `#E3F2FD`  | `#2196F3` | `#1565C0` |
+| Accent  | `#BBDEFB`  | `#1976D2` | `#0D47A1` |
+| Success | `#E8F5E9`  | `#4CAF50` | `#2E7D32` |
+| Warning | `#FFF3E0`  | `#FF9800` | `#E65100` |
+| Danger  | `#FFEBEE`  | `#F44336` | `#C62828` |
+| Info    | `#E8EAF6`  | `#3F51B5` | `#283593` |
+| Purple  | `#F3E5F5`  | `#9C27B0` | `#7B1FA2` |
+| Note    | `#FFF8E1`  | `#FFC107` | `#F57F17` |
+| Neutral | `#ECEFF1`  | `#607D8B` | `#455A64` |
+| Code bg | `#ECEFF1`  | -         | `#37474F` |
+
+## 2. Usage Rules
+
+- Use 1-3 accent colors per diagram to avoid visual noise
+- Background frame (dashed): use Neutral stroke, no fill
+- Box elements: use `rounded=1`, `strokeWidth=2` or `3`
+- Step numbers (circles): use filled stroke color, white text
+- Arrows: match the source element's stroke color
+- Code blocks: use `fontFamily=monospace`, Code bg fill
+
+## 3. Semantic Mapping
+
+Common semantic assignments observed in existing diagrams:
+
+| Concept           | Recommended Role |
+| ----------------- | ---------------- |
+| Developer/Eng     | Primary          |
+| Success/Positive  | Success          |
+| Alert/Budget      | Warning          |
+| Error/Negative    | Danger           |
+| Governance/Admin  | Info             |
+| LLM/AI/External   | Purple           |
+| Takeaway/Callout  | Note             |
+| Infrastructure    | Neutral          |
+| Data/Analytics    | Success          |
+| Business/Consumer | Warning          |
+
+---
+
+Last updated: 2026-02-02
+Source files analyzed:
+
+- i9wa4.github.io/assets/2026-01-27-jedai-ai-gateway/\*.drawio
+- i9wa4.github.io/assets/2025-12-22-aeon-tech-hub-databricks/\*.drawio
+- i9wa4.github.io/assets/2025-12-12-databricks-notebook-ai-ready/\*.drawio
+- i9wa4.github.io/assets/2025-11-07-tamesare-data-sapporo-uma-chan/\*.drawio

--- a/skills/diagramming/references/drawio.md
+++ b/skills/diagramming/references/drawio.md
@@ -1,0 +1,94 @@
+# draw.io
+
+Use this reference for native draw.io diagram creation, editing, review, and
+export in this repo.
+
+## Source And Output Rules
+
+- Edit `.drawio` source files, not generated exports.
+- Always commit editable `.drawio` sources.
+- Treat `.drawio.png`, `.drawio.svg`, and `.drawio.pdf` as generated exports
+  unless a nearby workflow explicitly expects them.
+- Prefer native `mxGraphModel` XML over Mermaid or CSV conversions for draw.io
+  work.
+- Use descriptive lowercase filenames with hyphens, such as
+  `login-flow.drawio`.
+
+## Output Formats
+
+| Format        | Embedded XML | Recommended use                |
+| ------------- | ------------ | ------------------------------ |
+| `.drawio`     | n/a          | Editable source diagram        |
+| `.drawio.png` | Yes          | Docs, slides, chat attachments |
+| `.drawio.svg` | Yes          | Docs, scalable output          |
+| `.drawio.pdf` | Yes          | Review and print               |
+| `.drawio.jpg` | No           | Last-resort lossy export       |
+
+## Font And Canvas Rules
+
+- For Quarto slides, set `defaultFontFamily="Noto Sans JP"` on
+  `mxGraphModel`.
+- Set `fontFamily=Noto Sans JP` explicitly on each text element.
+- For slide diagrams, use transparent background with `page="0"`.
+- Keep slide diagrams to one to three accent colors.
+- Include a bottom takeaway bar when the diagram is explanatory.
+
+## XML Rules
+
+Every diagram must use native `mxGraphModel` XML with root cells:
+
+```xml
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+  </root>
+</mxGraphModel>
+```
+
+Every edge must contain geometry:
+
+```xml
+<mxCell id="e1" edge="1" parent="1" source="a" target="b" style="edgeStyle=orthogonalEdgeStyle;">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+Do not use self-closing edge cells.
+
+## Layout Guidance
+
+- Choose diagram abstraction before drawing: context, system, component,
+  deployment, data flow, or sequence.
+- Use semantic shapes before product icons.
+- Use AWS icons only when cloud product identity matters.
+- Keep related diagram sets consistent in canvas size, colors, fonts, and
+  stroke widths.
+- Use container parent relationships instead of fake visual containment.
+- Space nodes generously and prefer orthogonal edges for technical diagrams.
+- Add explicit waypoints when auto-routing overlaps labels or nodes.
+
+## Scripts And Assets
+
+The target skill owns the workflow and carries the reusable draw.io helper
+assets:
+
+- Color palette:
+  [color-palette.md](color-palette.md)
+- Layout catalog:
+  [layout-guidelines.md](layout-guidelines.md)
+- AWS icon catalog:
+  [aws-icons.md](aws-icons.md)
+- PNG export:
+  [scripts/convert-drawio-to-png.sh](../scripts/convert-drawio-to-png.sh)
+- AWS icon search:
+  [scripts/find_aws_icon.py](../scripts/find_aws_icon.py)
+- SVG overlap check:
+  [scripts/check-drawio-svg-overlaps.mjs](../scripts/check-drawio-svg-overlaps.mjs)
+
+## Validation
+
+- Run the conversion hook or script when generated PNGs are part of the target
+  workflow.
+- Inspect generated output for overlap, text clipping, and unreadable contrast.
+- For slide diagrams, verify the rendered slide, not only the XML.

--- a/skills/diagramming/references/layout-guidelines.md
+++ b/skills/diagramming/references/layout-guidelines.md
@@ -1,0 +1,343 @@
+# Layout Guidelines
+
+## 1. AWS Architecture Diagrams
+
+### 1.1. Grouping Principles
+
+- Use AWS Cloud group as the outermost layer
+- Create subgroups by functional unit
+- Arrange groups horizontally, following data flow
+
+```text
+AWS Cloud (outermost)
+├── VPC
+│   ├── Public Subnet
+│   │   └── ALB, NAT Gateway, etc.
+│   └── Private Subnet
+│       └── ECS, RDS, etc.
+├── S3
+├── CloudWatch
+└── Other services
+```
+
+### 1.2. Connection Line Rules
+
+| Flow Type      | Line Style | Purpose          |
+| -------------- | ---------- | ---------------- |
+| Ingestion Flow | Dashed     | Data ingestion   |
+| Query Flow     | Solid      | Query / lookup   |
+| Control Flow   | Dotted     | Control / manage |
+
+- Arrows follow the direction of data flow
+- For bidirectional communication, use 2 unidirectional arrows
+
+### 1.3. Placement Principles
+
+Left-to-right flow (default):
+
+```text
+[Data Source] → [Processing] → [Storage] → [Analytics / Visualization]
+```
+
+Top-to-bottom flow (alternative):
+
+```text
+[User / Client]
+       ↓
+[Load Balancer]
+       ↓
+[Application]
+       ↓
+[Database]
+```
+
+## 2. Slide Diagram Pattern Catalog
+
+Reusable layout patterns extracted from existing slides.
+Select the best-matching pattern from this catalog when creating diagrams.
+
+### 2.1. Comparison Patterns
+
+#### A. Side-by-Side Comparison Panel
+
+Compare two concepts horizontally.
+
+```text
+┌─────── Suitable ────────┐  ┌──── Not Suitable ────┐
+│ ┌─────────────────────┐ │  │ ┌─────────────────────┐│
+│ │ Item 1              │ │  │ │ Item 1              ││
+│ ├─────────────────────┤ │  │ ├─────────────────────┤│
+│ │ Item 2              │ │  │ │ Item 2              ││
+│ └─────────────────────┘ │  │ └─────────────────────┘│
+└─────────────────────────┘  └────────────────────────┘
+```
+
+- Left: Success color (positive) / Right: Danger color (negative)
+- Optional Note-colored supplementary box at the bottom
+
+#### B. Before/After (Vertical Two-Row)
+
+Show improvement over time.
+
+```text
+┌────────── Before (red background) ──────────┐
+│ [Step1] → [Step2] → [Step3] → [Total]      │
+└─────────────────────────────────────────────┘
+┌────────── After (green background) ─────────┐
+│ [Step1] → [Step2] → [Total]                │
+└─────────────────────────────────────────────┘
+```
+
+- Before: Danger background + Warning steps
+- After: Success background + Success steps
+- Show total time/cost on the right edge
+
+#### C. 3-Column Comparison Table
+
+Show mappings and correspondences.
+
+```text
+┌──────────┬──────────┬──────────┐
+│ Header 1 │ Header 2 │ Header 3 │
+├──────────┼──────────┼──────────┤
+│ Item     │ Item     │ Item     │
+├──────────┼──────────┼──────────┤
+│ Item     │ Item     │ Item     │
+└──────────┴──────────┴──────────┘
+```
+
+- Assign different color roles to each column
+- Use arrows "→" to indicate directionality
+
+### 2.2. Flow / Process Patterns
+
+#### D. Horizontal Step Flow
+
+Show sequential steps or processes.
+
+```text
+  ①          ②          ③
+┌────┐    ┌────┐    ┌────┐
+│Step│ →  │Step│ →  │Step│
+│    │    │    │    │    │
+└────┘    └────┘    └────┘
+┌──────── Supplement / Code Block ───────┐
+│ export VAR=value                       │
+└────────────────────────────────────────┘
+┌──────── Takeaway (Note color) ─────────┐
+│ Key message                            │
+└────────────────────────────────────────┘
+```
+
+- Number badges on each step (circle, filled stroke, white text)
+- Different color role per step
+- Neutral-colored code example and Note-colored takeaway at bottom
+
+#### E. Multi-Column Layout
+
+Expand system structure from left to right.
+
+```text
+┌── Left Panel ──┐     ┌── Center Panel ──┐     ┌── Right Panel ──┐
+│ ┌───────────┐  │     │ ┌─────────────┐  │     │ ┌───────────┐   │
+│ │ Element   │  │ ──→ │ │ Feature 1   │  │ ──→ │ │ Element 1 │   │
+│ ├───────────┤  │     │ ├─────────────┤  │     │ ├───────────┤   │
+│ │ Element   │  │     │ │ Feature 2   │  │     │ │ Element 2 │   │
+│ └───────────┘  │     │ └─────────────┘  │     │ └───────────┘   │
+└────────────────┘     └─────────────────┘     └─────────────────┘
+┌──────────── Takeaway (Primary color) ────────────┐
+│ Key message                                      │
+└──────────────────────────────────────────────────┘
+```
+
+- Different color role per panel
+- Thick arrows between panels (strokeWidth=4)
+- Summary bar at bottom
+
+#### F. Vertical Flow + Branching
+
+Show Git-flow-style branching and merging.
+
+```text
+       [Config File]
+            ↓
+    ┌───────┴───────┐
+    ↓               ↓
+[Local]         [CI/CD]
+    ↓               ↓
+    └───────┬───────┘
+            ↓
+        [PR/Review]
+            ↓
+        [main]
+```
+
+- Main line thick (strokeWidth=3), branches thin
+- Highlight points with colored border (Danger stroke)
+
+### 2.3. Aggregation / Decomposition Patterns
+
+#### G. Multiple → Unified Result
+
+Multiple inputs converge into a single result.
+
+```text
+┌────┐ ┌────┐ ┌────┐ ┌────┐
+│Sol1│ │Sol2│ │Sol3│ │Sol4│
+└──┬─┘ └──┬─┘ └──┬─┘ └──┬─┘
+   └───┬───┴───┬──┘      │
+       ↓       ↓         ↓
+┌───────────── Unified Result ──────────────┐
+│ ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐         │
+│ │Feat1│ │Feat2│ │Feat3│ │Feat4│         │
+│ └─────┘ └─────┘ └─────┘ └─────┘         │
+└───────────────────────────────────────────┘
+```
+
+- Different color role per input
+- Result box with accent stroke
+- Internal feature cards on white background
+
+#### H. Center + Radial (Problem Statement)
+
+Arrange problems/features around a central icon.
+
+```text
+        ┌────────┐
+        │Problem1│
+        └───┬────┘
+            ↓
+┌────┐  ┌──────┐  ┌────┐
+│Prob2│→ │Center│ ←│Prob3│
+└────┘  └──────┘  └────┘
+            ↑
+        ┌───┴────┐
+        │Problem4│
+        └────────┘
+```
+
+- Central icon (emoji or person)
+- Surrounding boxes in uniform color (Warning or Danger)
+- Dashed arrows from problems to center
+
+### 2.4. Card / Metric Patterns
+
+#### I. Side-by-Side Cards (KPI / Metrics)
+
+Display independent metrics in parallel.
+
+```text
+┌──── Metric 1 ────┐ ┌──── Metric 2 ────┐ ┌──── Metric 3 ────┐
+│ Icon             │ │ Icon             │ │ Icon             │
+│ Title            │ │ Title            │ │ Title            │
+│ Before → After   │ │ Before → After   │ │ Before → After   │
+│ ┌─────────────┐  │ │ ┌─────────────┐  │ │ ┌─────────────┐  │
+│ │ XX% improved│  │ │ │ XX% improved│  │ │ │ XX% improved│  │
+│ └─────────────┘  │ │ └─────────────┘  │ │ └─────────────┘  │
+└──────────────────┘ └──────────────────┘ └──────────────────┘
+```
+
+- Different color role per card
+- Improvement values highlighted in Success color
+
+### 2.5. Hierarchy / Structure Patterns
+
+#### J. Multi-Layer Architecture Diagram
+
+Expand vertically from user layer to foundation layer.
+
+```text
+┌──── 5 User Types ──────────────────────────┐
+│ [Type1] [Type2] [Type3] [Type4] [Type5]    │
+└────────────────────────────────────────────┘
+┌──── Feature Layer ─────────────────────────┐
+│ ┌────┐ ┌────┐ ┌────┐ ┌──────────────┐     │
+│ │Dev │ │ML  │ │SQL │ │Consumer      │     │
+│ └────┘ └────┘ └────┘ └──────────────┘     │
+├──── Shared Layer ──────────────────────────┤
+│ [Compute] [Storage]                        │
+└────────────────────────────────────────────┘
+┌──── Foundation Layer ──────────────────────┐
+│ [Governance / Catalog]                     │
+└────────────────────────────────────────────┘
+```
+
+- Different color role per feature section
+- Shared layer in Neutral color
+- Foundation in Note color (indicates importance)
+
+#### K. 3-Column Mapping
+
+Visualize relationships between left and right elements via center.
+
+```text
+┌──Left──┐     ┌──Center──┐     ┌──Right──┐
+│ Role 1 │ ──→ │ Perm A   │ ──→ │ Feat X  │
+│ Role 2 │ ──→ │ Perm B   │ ──→ │ Feat Y  │
+│ Role 3 │ ──→ │ Perm C   │ ──→ │ Feat Z  │
+└────────┘     └──────────┘     └─────────┘
+```
+
+- Different color role for left, center, and right
+- Arrow color matches source element color
+
+### 2.6. Technical / AI System Patterns
+
+#### L. Agent + Tool + Memory Loop
+
+Show the user request, agent core, tools, and memory as separate
+responsibilities.
+
+```text
+[User / Trigger] ──→ [Agent / Planner] ──→ [Tool Call]
+                        │   ↑                │
+                        │   └── feedback ───┘
+                        ↓
+                 [Short-term Memory]
+                        ↓
+                 [Long-term Store]
+                        │
+                        └──── retrieval ───→ [Agent / Planner] ──→ [Response]
+```
+
+- Keep the agent core visually distinct from ordinary services
+- Show tool calls and memory reads as different arrow meanings
+- Use a curved feedback arrow only when the reasoning loop matters to the
+  story
+
+#### M. Memory Tier Read / Write Split
+
+Separate what the runtime reads from what it writes.
+
+```text
+                read path
+[Runtime] <──── [Working Set] <──── [Long-term Store]
+    │                  │                   ↑
+    │                  └──── write path ───┘
+    └──────────────→ [Event / History Log]
+```
+
+- Put runtime or agent logic on one side and stores on the other
+- Use dashed retrieval arrows and solid persistence arrows consistently
+- Label the stored asset type when it is not obvious (`chunks`, `embeddings`,
+  `memory`, `events`)
+
+## 3. Visibility
+
+- Place labels close to their elements
+- Adjust placement to avoid crossing arrows
+- Group related elements and place them nearby
+- Ensure adequate whitespace for readability
+- Always include a Takeaway bar at the bottom of slide diagrams
+
+---
+
+Last updated: 2026-04-14
+Source files analyzed:
+
+- i9wa4.github.io/assets/2026-01-27-jedai-ai-gateway/\*.drawio
+- i9wa4.github.io/assets/2025-12-22-aeon-tech-hub-databricks/\*.drawio
+- i9wa4.github.io/assets/2025-12-12-databricks-notebook-ai-ready/\*.drawio
+- i9wa4.github.io/assets/2025-11-07-tamesare-data-sapporo-uma-chan/\*.drawio
+- Selective adaptation study:
+  `yizhiyanhua-ai/fireworks-tech-graph@c8668407ebfa72e00719be8f4312b71ab90c3c3e`

--- a/skills/diagramming/references/mermaid.md
+++ b/skills/diagramming/references/mermaid.md
@@ -1,0 +1,82 @@
+# Mermaid
+
+Use this reference for Mermaid diagrams in Quarto revealjs `.qmd` files and for
+Mermaid CLI preview.
+
+## mmdc And revealjs Differences
+
+`%%{init}%%` `themeVariables` can work in `mmdc` output but be overridden by
+revealjs CSS at render time. Quarto revealjs injects Mermaid CSS variables
+after SVG generation.
+
+Important variables:
+
+| CSS variable               | Targets                | Default value |
+| -------------------------- | ---------------------- | ------------- |
+| `--mermaid-edge-color`     | signal text, loop text | `#999`        |
+| `--mermaid-label-fg-color` | actor names            | `#2a76dd`     |
+| `--mermaid-node-fg-color`  | alt/else labels        | `#000`        |
+
+## revealjs Text Color Fix
+
+Prefer overriding the CSS variables at `:root` in the Quarto
+`include-in-header` block:
+
+```css
+:root {
+  --mermaid-edge-color: #000000 !important;
+  --mermaid-label-fg-color: #000000 !important;
+  --mermaid-node-fg-color: #000000 !important;
+}
+```
+
+Do not rely only on `.mermaid text { fill: #000000 !important; }` for revealjs
+slides, because Mermaid is rendered client-side and CSS variables take
+precedence.
+
+## sequenceDiagram Tips
+
+Use `mirrorActors: false` to hide duplicate bottom actors when space matters:
+
+```mermaid
+%%{init: {'theme': 'base', 'sequence': {'mirrorActors': false}}}%%
+```
+
+About 20 content lines fit on a 1920x1080 revealjs slide with
+`scrollable: true` before readability suffers.
+
+## Mermaid CLI Preview
+
+Run Mermaid CLI through the local Nix/comma workflow:
+
+```sh
+, mmdc -i input.mmd -o output.png
+```
+
+When a system Chrome path is required, set `PUPPETEER_EXECUTABLE_PATH` for that
+command. Strip code fence markers before sending content to `mmdc`.
+
+## Layout Checks
+
+Text review of Mermaid source is not enough for layout-sensitive changes.
+Render and inspect dimensions before reporting a diagram fixed.
+
+For `graph TD`, disconnected subgraphs tile horizontally even when spacing
+directives are set. Split wide disconnected groups into separate Mermaid blocks
+so they stack vertically on slides.
+
+For rendered SVGs, inspect the `viewBox`: a width much larger than height is a
+strong signal that the diagram will overflow or be unreadable.
+
+## revealjs Shape Coloring
+
+Useful CSS selectors for sequence diagrams:
+
+| Element              | CSS class    |
+| -------------------- | ------------ |
+| Actor boxes          | `rect.actor` |
+| alt/loop section bg  | `.loopLine`  |
+| alt/loop label boxes | `.labelBox`  |
+
+`alt` and `loop` blocks share `.loopLine`, so styling them differently requires
+more invasive CSS.

--- a/skills/diagramming/scripts/check-drawio-svg-overlaps.mjs
+++ b/skills/diagramming/scripts/check-drawio-svg-overlaps.mjs
@@ -1,0 +1,1101 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const EPSILON = 0.5;
+const BOX_INTERIOR_THRESHOLD = 8;
+const BOX_BORDER_OVERLAP_THRESHOLD = 10;
+const MAX_OBSTACLE_AREA = 100_000;
+const MAX_OBSTACLE_WIDTH = 420;
+const MAX_OBSTACLE_HEIGHT = 240;
+const TEXT_OVERFLOW_TOLERANCE = 4;
+const DEFAULT_TEXT_PADDING = 4;
+
+function parseAttributes(source) {
+  const attributes = {};
+
+  for (const match of source.matchAll(/([:\w-]+)="([^"]*)"/g)) {
+    attributes[match[1]] = match[2];
+  }
+
+  return attributes;
+}
+
+function parseStyle(styleText = '') {
+  const style = {};
+
+  for (const declaration of styleText.split(';')) {
+    if (!declaration.includes(':')) {
+      continue;
+    }
+
+    const [rawKey, rawValue] = declaration.split(':');
+    const key = rawKey.trim();
+    const value = rawValue.trim();
+
+    if (key) {
+      style[key] = value;
+    }
+  }
+
+  return style;
+}
+
+function getPaint(attributes, name) {
+  if (attributes[name]) {
+    return attributes[name];
+  }
+
+  const style = parseStyle(attributes.style);
+  return style[name];
+}
+
+function getPresentationValue(attributes, name) {
+  if (attributes[name] !== undefined) {
+    return attributes[name];
+  }
+
+  const style = parseStyle(attributes.style);
+  return style[name];
+}
+
+function isNone(value) {
+  return value === undefined || value === null || value === '' || value === 'none';
+}
+
+function parseTranslate(transformText = '') {
+  const match = transformText.match(/translate\(\s*([-\d.]+)(?:[\s,]+([-\d.]+))?\s*\)/i);
+
+  if (!match) {
+    return { x: 0, y: 0 };
+  }
+
+  return {
+    x: Number(match[1]),
+    y: Number(match[2] ?? 0),
+  };
+}
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function decodeXmlEntities(text = '') {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, '\'')
+    .replace(/&amp;/g, '&');
+}
+
+function parsePathData(d, offset) {
+  const tokens = d.match(/[MLZmlz]|-?\d*\.?\d+(?:e[-+]?\d+)?/g) ?? [];
+  const segments = [];
+
+  let index = 0;
+  let command = null;
+  let current = null;
+  let start = null;
+
+  function readPoint(relative) {
+    const x = Number(tokens[index++]);
+    const y = Number(tokens[index++]);
+
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      return null;
+    }
+
+    if (!current) {
+      return {
+        x: x + offset.x,
+        y: y + offset.y,
+      };
+    }
+
+    if (!relative) {
+      return {
+        x: x + offset.x,
+        y: y + offset.y,
+      };
+    }
+
+    return {
+      x: current.x + x,
+      y: current.y + y,
+    };
+  }
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+
+    if (/^[MLZmlz]$/.test(token)) {
+      command = token;
+      index += 1;
+    }
+
+    if (!command) {
+      throw new Error(`Unsupported or malformed path: ${d}`);
+    }
+
+    if (command === 'M' || command === 'm') {
+      const firstPoint = readPoint(command === 'm');
+
+      if (!firstPoint) {
+        break;
+      }
+
+      current = firstPoint;
+      start = firstPoint;
+
+      while (index < tokens.length && !/^[MLZmlz]$/.test(tokens[index])) {
+        const point = readPoint(command === 'm');
+
+        if (!point) {
+          break;
+        }
+
+        segments.push({ start: current, end: point });
+        current = point;
+      }
+
+      command = command === 'm' ? 'l' : 'L';
+      continue;
+    }
+
+    if (command === 'L' || command === 'l') {
+      while (index < tokens.length && !/^[MLZmlz]$/.test(tokens[index])) {
+        const point = readPoint(command === 'l');
+
+        if (!point) {
+          break;
+        }
+
+        segments.push({ start: current, end: point });
+        current = point;
+      }
+
+      continue;
+    }
+
+    if (command === 'Z' || command === 'z') {
+      if (current && start) {
+        segments.push({ start: current, end: start });
+        current = start;
+      }
+
+      command = null;
+    }
+  }
+
+  return segments;
+}
+
+function approximatelyEqual(a, b, epsilon = EPSILON) {
+  return Math.abs(a - b) <= epsilon;
+}
+
+function samePoint(a, b, epsilon = EPSILON) {
+  return approximatelyEqual(a.x, b.x, epsilon) && approximatelyEqual(a.y, b.y, epsilon);
+}
+
+function subtract(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y };
+}
+
+function cross(a, b) {
+  return (a.x * b.y) - (a.y * b.x);
+}
+
+function distance(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function segmentBounds(segment) {
+  return {
+    minX: Math.min(segment.start.x, segment.end.x),
+    maxX: Math.max(segment.start.x, segment.end.x),
+    minY: Math.min(segment.start.y, segment.end.y),
+    maxY: Math.max(segment.start.y, segment.end.y),
+  };
+}
+
+function boundsOverlap(a, b, epsilon = EPSILON) {
+  return !(
+    a.maxX < (b.minX - epsilon)
+    || a.minX > (b.maxX + epsilon)
+    || a.maxY < (b.minY - epsilon)
+    || a.minY > (b.maxY + epsilon)
+  );
+}
+
+function rectBounds(rect) {
+  return {
+    minX: rect.x,
+    maxX: rect.x + rect.width,
+    minY: rect.y,
+    maxY: rect.y + rect.height,
+  };
+}
+
+function expandBounds(bounds, padding) {
+  return {
+    minX: bounds.minX - padding,
+    maxX: bounds.maxX + padding,
+    minY: bounds.minY - padding,
+    maxY: bounds.maxY + padding,
+  };
+}
+
+function rangeOverlapLength(firstStart, firstEnd, secondStart, secondEnd) {
+  const overlapStart = Math.max(Math.min(firstStart, firstEnd), Math.min(secondStart, secondEnd));
+  const overlapEnd = Math.min(Math.max(firstStart, firstEnd), Math.max(secondStart, secondEnd));
+  return Math.max(0, overlapEnd - overlapStart);
+}
+
+function classifySegmentIntersection(first, second) {
+  const firstVector = subtract(first.end, first.start);
+  const secondVector = subtract(second.end, second.start);
+  const delta = subtract(second.start, first.start);
+  const denominator = cross(firstVector, secondVector);
+  const deltaFirst = cross(delta, firstVector);
+
+  if (Math.abs(denominator) <= EPSILON) {
+    if (Math.abs(deltaFirst) > EPSILON) {
+      return null;
+    }
+
+    const useX = Math.abs(firstVector.x) >= Math.abs(firstVector.y);
+    const axis = useX ? 'x' : 'y';
+    const firstMin = Math.min(first.start[axis], first.end[axis]);
+    const firstMax = Math.max(first.start[axis], first.end[axis]);
+    const secondMin = Math.min(second.start[axis], second.end[axis]);
+    const secondMax = Math.max(second.start[axis], second.end[axis]);
+    const overlapStart = Math.max(firstMin, secondMin);
+    const overlapEnd = Math.min(firstMax, secondMax);
+
+    if ((overlapEnd - overlapStart) <= EPSILON) {
+      return null;
+    }
+
+    return {
+      type: 'overlap',
+      detail: `collinear overlap (${(overlapEnd - overlapStart).toFixed(1)}px)`,
+    };
+  }
+
+  const t = cross(delta, subtract(second.end, second.start)) / denominator;
+  const u = cross(delta, firstVector) / denominator;
+
+  if (
+    t < -EPSILON
+    || t > 1 + EPSILON
+    || u < -EPSILON
+    || u > 1 + EPSILON
+  ) {
+    return null;
+  }
+
+  const point = {
+    x: first.start.x + (t * firstVector.x),
+    y: first.start.y + (t * firstVector.y),
+  };
+
+  const atEndpointOfFirst = samePoint(point, first.start) || samePoint(point, first.end);
+  const atEndpointOfSecond = samePoint(point, second.start) || samePoint(point, second.end);
+
+  if (atEndpointOfFirst && atEndpointOfSecond) {
+    return null;
+  }
+
+  return {
+    type: 'crossing',
+    point,
+    detail: `crossing near (${point.x.toFixed(1)}, ${point.y.toFixed(1)})`,
+  };
+}
+
+function interiorLengthInsideRect(segment, rect) {
+  const dx = segment.end.x - segment.start.x;
+  const dy = segment.end.y - segment.start.y;
+  let t0 = 0;
+  let t1 = 1;
+
+  const checks = [
+    [-dx, segment.start.x - rect.x],
+    [dx, (rect.x + rect.width) - segment.start.x],
+    [-dy, segment.start.y - rect.y],
+    [dy, (rect.y + rect.height) - segment.start.y],
+  ];
+
+  for (const [p, q] of checks) {
+    if (Math.abs(p) <= EPSILON) {
+      if (q < 0) {
+        return 0;
+      }
+      continue;
+    }
+
+    const ratio = q / p;
+
+    if (p < 0) {
+      t0 = Math.max(t0, ratio);
+    } else {
+      t1 = Math.min(t1, ratio);
+    }
+
+    if (t0 > t1) {
+      return 0;
+    }
+  }
+
+  return Math.max(0, t1 - t0) * distance(segment.start, segment.end);
+}
+
+function borderContactTolerance(edge, rect) {
+  const edgeStroke = Math.max(1, edge.strokeWidth ?? 1);
+  const rectStroke = Math.max(1, rect.strokeWidth ?? 1);
+  return ((edgeStroke + rectStroke) / 2) + EPSILON;
+}
+
+function insetRect(rect, inset) {
+  const width = rect.width - (inset * 2);
+  const height = rect.height - (inset * 2);
+
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+
+  return {
+    x: rect.x + inset,
+    y: rect.y + inset,
+    width,
+    height,
+  };
+}
+
+function findSegmentRectBorderContacts(segment, edge, rect) {
+  if (isNone(rect.stroke)) {
+    return [];
+  }
+
+  const tolerance = borderContactTolerance(edge, rect);
+  const contacts = [];
+  const horizontal = approximatelyEqual(segment.start.y, segment.end.y, tolerance);
+  const vertical = approximatelyEqual(segment.start.x, segment.end.x, tolerance);
+  const rectRight = rect.x + rect.width;
+  const rectBottom = rect.y + rect.height;
+
+  if (horizontal) {
+    const y = (segment.start.y + segment.end.y) / 2;
+    const overlapLength = rangeOverlapLength(segment.start.x, segment.end.x, rect.x, rectRight);
+
+    if (overlapLength > BOX_BORDER_OVERLAP_THRESHOLD) {
+      const topDistance = Math.abs(y - rect.y);
+      if (topDistance <= tolerance) {
+        contacts.push({
+          side: 'top',
+          length: overlapLength,
+          offset: topDistance,
+        });
+      }
+
+      const bottomDistance = Math.abs(y - rectBottom);
+      if (bottomDistance <= tolerance) {
+        contacts.push({
+          side: 'bottom',
+          length: overlapLength,
+          offset: bottomDistance,
+        });
+      }
+    }
+  }
+
+  if (vertical) {
+    const x = (segment.start.x + segment.end.x) / 2;
+    const overlapLength = rangeOverlapLength(segment.start.y, segment.end.y, rect.y, rectBottom);
+
+    if (overlapLength > BOX_BORDER_OVERLAP_THRESHOLD) {
+      const leftDistance = Math.abs(x - rect.x);
+      if (leftDistance <= tolerance) {
+        contacts.push({
+          side: 'left',
+          length: overlapLength,
+          offset: leftDistance,
+        });
+      }
+
+      const rightDistance = Math.abs(x - rectRight);
+      if (rightDistance <= tolerance) {
+        contacts.push({
+          side: 'right',
+          length: overlapLength,
+          offset: rightDistance,
+        });
+      }
+    }
+  }
+
+  return contacts;
+}
+
+function isBackgroundRect(rect) {
+  const lowerId = rect.cellId.toLowerCase();
+  const area = rect.width * rect.height;
+
+  if (
+    lowerId.startsWith('label-')
+    || lowerId.includes('-label')
+    || lowerId === 'title'
+    || lowerId === 'title-bg'
+    || lowerId.endsWith('-bg')
+    || lowerId.endsWith('_bg')
+    || lowerId.includes('background')
+    || lowerId.includes('layer-bg')
+  ) {
+    return true;
+  }
+
+  if (area > MAX_OBSTACLE_AREA) {
+    return true;
+  }
+
+  return rect.width > MAX_OBSTACLE_WIDTH || rect.height > MAX_OBSTACLE_HEIGHT;
+}
+
+function parseStyleNumber(style, key, fallback = null) {
+  const rawValue = style[key];
+
+  if (rawValue === undefined) {
+    return fallback;
+  }
+
+  const match = String(rawValue).match(/-?\d*\.?\d+/);
+  if (!match) {
+    return fallback;
+  }
+
+  return Number(match[0]);
+}
+
+function estimateTextWidth(text, fontSize) {
+  let width = 0;
+
+  for (const char of text) {
+    if (/\s/.test(char)) {
+      width += fontSize * 0.35;
+      continue;
+    }
+
+    if (/[\u3000-\u30FF\u3400-\u9FFF\uF900-\uFAFF]/u.test(char)) {
+      width += fontSize * 0.92;
+      continue;
+    }
+
+    if (/[A-Z0-9]/.test(char)) {
+      width += fontSize * 0.62;
+      continue;
+    }
+
+    width += fontSize * 0.56;
+  }
+
+  return width;
+}
+
+function extractLineMetrics(value, defaultFontSize) {
+  const decoded = decodeXmlEntities(value);
+  const tokenRegex = /<br\s*\/?>|<font\b([^>]*)>|<\/font>|([^<]+)/gi;
+  const fontStack = [defaultFontSize];
+  const lines = [];
+  let currentLine = { width: 0, fontSize: defaultFontSize, text: '' };
+
+  function pushLine() {
+    lines.push(currentLine);
+    currentLine = { width: 0, fontSize: defaultFontSize, text: '' };
+  }
+
+  for (const match of decoded.matchAll(tokenRegex)) {
+    const [token, fontAttributes = '', textChunk = ''] = match;
+
+    if (/^<br/i.test(token)) {
+      pushLine();
+      continue;
+    }
+
+    if (/^<font/i.test(token)) {
+      const attributes = parseAttributes(fontAttributes);
+      const inlineStyle = parseStyle(attributes.style ?? '');
+      const fontSize = parseStyleNumber(inlineStyle, 'font-size', fontStack[fontStack.length - 1]);
+      fontStack.push(fontSize);
+      continue;
+    }
+
+    if (/^<\/font/i.test(token)) {
+      if (fontStack.length > 1) {
+        fontStack.pop();
+      }
+      continue;
+    }
+
+    if (!textChunk) {
+      continue;
+    }
+
+    const normalizedText = textChunk.replace(/\s+/g, ' ');
+    const fontSize = fontStack[fontStack.length - 1];
+    currentLine.width += estimateTextWidth(normalizedText, fontSize);
+    currentLine.fontSize = Math.max(currentLine.fontSize, fontSize);
+    currentLine.text += normalizedText;
+  }
+
+  if (currentLine.text || lines.length === 0) {
+    lines.push(currentLine);
+  }
+
+  return lines.filter((line) => line.text.trim().length > 0);
+}
+
+function estimateWrappedMetrics(lines, availableWidth) {
+  if (availableWidth <= 0) {
+    return {
+      estimatedWidth: lines.reduce((maxWidth, line) => Math.max(maxWidth, line.width), 0),
+      estimatedHeight: lines.reduce((total, line) => total + (line.fontSize * 1.25), 0),
+    };
+  }
+
+  let estimatedWidth = 0;
+  let estimatedHeight = 0;
+
+  for (const line of lines) {
+    const wrappedLineCount = Math.max(1, Math.ceil(line.width / availableWidth));
+    estimatedWidth = Math.max(estimatedWidth, Math.min(line.width, availableWidth));
+    estimatedHeight += wrappedLineCount * line.fontSize * 1.25;
+  }
+
+  return { estimatedWidth, estimatedHeight };
+}
+
+function parseDrawioTextBlocks(drawioText) {
+  const blocks = [];
+  const cellRegex = /<mxCell\b([^>]*?)(?:\/>|>([\s\S]*?)<\/mxCell>)/g;
+
+  for (const match of drawioText.matchAll(cellRegex)) {
+    const [, rawAttributes = '', body = ''] = match;
+    const attributes = parseAttributes(rawAttributes);
+    const rawStyle = attributes.style ?? '';
+
+    if (attributes.vertex !== '1') {
+      continue;
+    }
+
+    if (!attributes.value) {
+      continue;
+    }
+
+    if (/(^|;)text(;|$)/i.test(rawStyle)) {
+      continue;
+    }
+
+    const geometryMatch = body.match(/<mxGeometry\b([^>]*?)\/>/);
+    if (!geometryMatch) {
+      continue;
+    }
+
+    const geometryAttributes = parseAttributes(geometryMatch[1]);
+    const width = toNumber(geometryAttributes.width);
+    const height = toNumber(geometryAttributes.height);
+
+    if (width <= 0 || height <= 0) {
+      continue;
+    }
+
+    const style = parseStyle(rawStyle);
+    const fontSize = parseStyleNumber(style, 'fontSize', 17);
+    const spacing = parseStyleNumber(style, 'spacing', DEFAULT_TEXT_PADDING);
+    const spacingLeft = parseStyleNumber(style, 'spacingLeft', spacing);
+    const spacingRight = parseStyleNumber(style, 'spacingRight', spacing);
+    const spacingTop = parseStyleNumber(style, 'spacingTop', spacing);
+    const spacingBottom = parseStyleNumber(style, 'spacingBottom', spacing);
+    const lines = extractLineMetrics(attributes.value, fontSize);
+    const availableWidth = Math.max(0, width - spacingLeft - spacingRight);
+    const availableHeight = Math.max(0, height - spacingTop - spacingBottom);
+    const wrappedMetrics = estimateWrappedMetrics(lines, availableWidth);
+
+    blocks.push({
+      cellId: attributes.id ?? 'unknown-cell',
+      value: decodeXmlEntities(attributes.value).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
+      availableWidth,
+      availableHeight,
+      estimatedWidth: wrappedMetrics.estimatedWidth,
+      estimatedHeight: wrappedMetrics.estimatedHeight,
+    });
+  }
+
+  return blocks;
+}
+
+function findTextOverflowIssues(textBlocks) {
+  const issues = [];
+
+  for (const block of textBlocks) {
+    if (block.estimatedWidth > block.availableWidth + TEXT_OVERFLOW_TOLERANCE) {
+      issues.push({
+        type: 'text-overflow',
+        axis: 'width',
+        cellId: block.cellId,
+        available: block.availableWidth,
+        estimated: block.estimatedWidth,
+        label: block.value,
+      });
+    }
+
+    if (block.estimatedHeight > block.availableHeight + TEXT_OVERFLOW_TOLERANCE) {
+      issues.push({
+        type: 'text-overflow',
+        axis: 'height',
+        cellId: block.cellId,
+        available: block.availableHeight,
+        estimated: block.estimatedHeight,
+        label: block.value,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function resolveTargetPath(input) {
+  const resolved = path.resolve(process.cwd(), input);
+
+  if (resolved.toLowerCase().endsWith('.drawio')) {
+    return `${resolved}.svg`;
+  }
+
+  return resolved;
+}
+
+async function readCompanionDrawio(targetPath, originalInput) {
+  const candidates = [];
+
+  if (originalInput && originalInput.toLowerCase().endsWith('.drawio')) {
+    candidates.push(path.resolve(process.cwd(), originalInput));
+  }
+
+  candidates.push(
+    targetPath.replace(/\.svg$/i, ''),
+    targetPath.replace(/\.drawio\.svg$/i, '.drawio'),
+  );
+
+  for (const candidate of candidates) {
+    if (!candidate || candidate === targetPath) {
+      continue;
+    }
+
+    try {
+      return {
+        path: candidate,
+        text: await readFile(candidate, 'utf8'),
+      };
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return null;
+}
+
+function parseSvg(svgText) {
+  const cells = new Map();
+  const tagRegex = /<\/?([A-Za-z][\w:-]*)([^<>]*?)\/?>/g;
+  const stack = [{
+    cellId: null,
+    tx: 0,
+    ty: 0,
+  }];
+
+  function getCurrentCellId() {
+    for (let index = stack.length - 1; index >= 0; index -= 1) {
+      if (stack[index].cellId) {
+        return stack[index].cellId;
+      }
+    }
+    return null;
+  }
+
+  function getCurrentOffset() {
+    const top = stack[stack.length - 1];
+    return { x: top.tx, y: top.ty };
+  }
+
+  function ensureCell(cellId) {
+    if (!cells.has(cellId)) {
+      cells.set(cellId, {
+        cellId,
+        rects: [],
+        linePaths: [],
+      });
+    }
+
+    return cells.get(cellId);
+  }
+
+  for (const match of svgText.matchAll(tagRegex)) {
+    const [rawTag, rawName, rawAttributes = ''] = match;
+    const tagName = rawName.toLowerCase();
+    const closing = rawTag.startsWith('</');
+    const selfClosing = rawTag.endsWith('/>');
+
+    if (closing) {
+      if (stack.length > 1) {
+        stack.pop();
+      }
+      continue;
+    }
+
+    const attributes = parseAttributes(rawAttributes);
+    const currentCellId = attributes['data-cell-id'] ?? getCurrentCellId();
+    const inheritedOffset = getCurrentOffset();
+    const translate = parseTranslate(attributes.transform);
+    const nextContext = {
+      cellId: currentCellId,
+      tx: inheritedOffset.x + translate.x,
+      ty: inheritedOffset.y + translate.y,
+    };
+
+    if (tagName === 'rect' && currentCellId) {
+      const fill = getPaint(attributes, 'fill');
+      const stroke = getPaint(attributes, 'stroke');
+
+      if (!(isNone(fill) && isNone(stroke))) {
+        const cell = ensureCell(currentCellId);
+        cell.rects.push({
+          cellId: currentCellId,
+          x: toNumber(attributes.x) + inheritedOffset.x,
+          y: toNumber(attributes.y) + inheritedOffset.y,
+          width: toNumber(attributes.width),
+          height: toNumber(attributes.height),
+          fill,
+          stroke,
+          strokeWidth: toNumber(getPresentationValue(attributes, 'stroke-width'), 1),
+        });
+      }
+    }
+
+    if (tagName === 'path' && currentCellId) {
+      const fill = getPaint(attributes, 'fill');
+      const stroke = getPaint(attributes, 'stroke');
+      const d = attributes.d ?? '';
+
+      if ((fill === 'none' || fill === undefined) && !isNone(stroke) && d) {
+        const cell = ensureCell(currentCellId);
+        cell.linePaths.push({
+          cellId: currentCellId,
+          segments: parsePathData(d, inheritedOffset),
+          stroke,
+          strokeWidth: toNumber(getPresentationValue(attributes, 'stroke-width'), 1),
+        });
+      }
+    }
+
+    if (!selfClosing) {
+      stack.push(nextContext);
+    }
+  }
+
+  return cells;
+}
+
+function collectEdges(cells) {
+  const edges = [];
+
+  for (const cell of cells.values()) {
+    if (cell.linePaths.length === 0) {
+      continue;
+    }
+
+    for (const linePath of cell.linePaths) {
+      if (linePath.segments.length === 0) {
+        continue;
+      }
+
+      edges.push({
+        cellId: cell.cellId,
+        segments: linePath.segments,
+        strokeWidth: linePath.strokeWidth,
+      });
+    }
+  }
+
+  return edges;
+}
+
+function collectObstacleRects(cells) {
+  const rects = [];
+
+  for (const cell of cells.values()) {
+    for (const rect of cell.rects) {
+      if (!isBackgroundRect(rect)) {
+        rects.push(rect);
+      }
+    }
+  }
+
+  return rects;
+}
+
+function findEdgeOverlaps(edges) {
+  const issues = [];
+
+  for (let firstIndex = 0; firstIndex < edges.length; firstIndex += 1) {
+    for (let secondIndex = firstIndex + 1; secondIndex < edges.length; secondIndex += 1) {
+      const first = edges[firstIndex];
+      const second = edges[secondIndex];
+
+      if (first.cellId === second.cellId) {
+        continue;
+      }
+
+      for (const firstSegment of first.segments) {
+        const firstBounds = segmentBounds(firstSegment);
+
+        for (const secondSegment of second.segments) {
+          const secondBounds = segmentBounds(secondSegment);
+
+          if (!boundsOverlap(firstBounds, secondBounds)) {
+            continue;
+          }
+
+          const intersection = classifySegmentIntersection(firstSegment, secondSegment);
+
+          if (!intersection) {
+            continue;
+          }
+
+          issues.push({
+            type: 'edge-edge',
+            firstCellId: first.cellId,
+            secondCellId: second.cellId,
+            detail: intersection.detail,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+function findEdgeRectCollisions(edges, rects) {
+  const issues = [];
+
+  for (const edge of edges) {
+    for (const rect of rects) {
+      if (edge.cellId === rect.cellId) {
+        continue;
+      }
+
+      const bounds = rectBounds(rect);
+
+      for (const segment of edge.segments) {
+        if (!boundsOverlap(segmentBounds(segment), bounds)) {
+          continue;
+        }
+
+        const innerRect = insetRect(rect, borderContactTolerance(edge, rect));
+        const interiorLength = innerRect ? interiorLengthInsideRect(segment, innerRect) : 0;
+
+        if (interiorLength > BOX_INTERIOR_THRESHOLD) {
+          issues.push({
+            type: 'edge-rect',
+            edgeCellId: edge.cellId,
+            rectCellId: rect.cellId,
+            length: interiorLength,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+function findEdgeRectBorderOverlaps(edges, rects) {
+  const issues = [];
+
+  for (const edge of edges) {
+    for (const rect of rects) {
+      if (edge.cellId === rect.cellId) {
+        continue;
+      }
+
+      const tolerance = borderContactTolerance(edge, rect);
+      const expandedRectBounds = expandBounds(rectBounds(rect), tolerance);
+
+      for (const segment of edge.segments) {
+        if (!boundsOverlap(segmentBounds(segment), expandedRectBounds, tolerance)) {
+          continue;
+        }
+
+        for (const contact of findSegmentRectBorderContacts(segment, edge, rect)) {
+          issues.push({
+            type: 'edge-rect-border',
+            edgeCellId: edge.cellId,
+            rectCellId: rect.cellId,
+            side: contact.side,
+            length: contact.length,
+            offset: contact.offset,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+function summarizeIssues(issues) {
+  const summaries = new Map();
+
+  for (const issue of issues) {
+    if (issue.type === 'edge-edge') {
+      const key = `${issue.firstCellId}::${issue.secondCellId}`;
+
+      if (!summaries.has(key)) {
+        summaries.set(key, {
+          type: 'edge-edge',
+          firstCellId: issue.firstCellId,
+          secondCellId: issue.secondCellId,
+          details: new Set(),
+        });
+      }
+
+      summaries.get(key).details.add(issue.detail);
+      continue;
+    }
+
+    if (issue.type === 'text-overflow') {
+      const key = `${issue.cellId}::${issue.axis}`;
+
+      if (!summaries.has(key)) {
+        summaries.set(key, {
+          type: 'text-overflow',
+          axis: issue.axis,
+          cellId: issue.cellId,
+          available: issue.available,
+          estimated: issue.estimated,
+          label: issue.label,
+        });
+      } else {
+        const summary = summaries.get(key);
+        summary.available = Math.min(summary.available, issue.available);
+        summary.estimated = Math.max(summary.estimated, issue.estimated);
+      }
+
+      continue;
+    }
+
+    if (issue.type === 'edge-rect-border') {
+      const key = `${issue.type}::${issue.edgeCellId}::${issue.rectCellId}`;
+
+      if (!summaries.has(key)) {
+        summaries.set(key, {
+          type: 'edge-rect-border',
+          edgeCellId: issue.edgeCellId,
+          rectCellId: issue.rectCellId,
+          details: new Set(),
+        });
+      }
+
+      summaries.get(key).details.add(`${issue.side} overlap ${issue.length.toFixed(1)}px (offset ${issue.offset.toFixed(1)}px)`);
+      continue;
+    }
+
+    const key = `${issue.type}::${issue.edgeCellId}::${issue.rectCellId}`;
+
+    if (!summaries.has(key)) {
+      summaries.set(key, {
+        type: 'edge-rect',
+        edgeCellId: issue.edgeCellId,
+        rectCellId: issue.rectCellId,
+        maxLength: issue.length,
+        count: 1,
+      });
+      continue;
+    }
+
+    const summary = summaries.get(key);
+    summary.maxLength = Math.max(summary.maxLength, issue.length);
+    summary.count += 1;
+  }
+
+  return [...summaries.values()];
+}
+
+function formatIssue(issue) {
+  if (issue.type === 'edge-edge') {
+    const details = [...issue.details].sort();
+    return `- edge-edge: ${issue.firstCellId} <-> ${issue.secondCellId} (${details.length} contact(s): ${details.join('; ')})`;
+  }
+
+  if (issue.type === 'text-overflow') {
+    return `- text-overflow(${issue.axis}): ${issue.cellId} requires ${issue.estimated.toFixed(1)}px but only ${issue.available.toFixed(1)}px is available [${issue.label}]`;
+  }
+
+  if (issue.type === 'edge-rect-border') {
+    const details = [...issue.details].sort();
+    return `- edge-rect-border: ${issue.edgeCellId} -> ${issue.rectCellId} (${details.length} contact(s): ${details.join('; ')})`;
+  }
+
+  return `- edge-rect: ${issue.edgeCellId} -> ${issue.rectCellId} (max interior ${issue.maxLength.toFixed(1)}px across ${issue.count} segment(s))`;
+}
+
+function printUsage() {
+  console.log('Usage: node scripts/check-drawio-svg-overlaps.mjs <diagram.drawio|diagram.drawio.svg>');
+}
+
+async function main() {
+  const targetArg = process.argv[2];
+
+  if (!targetArg) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const targetPath = resolveTargetPath(targetArg);
+  const svgText = await readFile(targetPath, 'utf8');
+  const cells = parseSvg(svgText);
+  const edges = collectEdges(cells);
+  const rects = collectObstacleRects(cells);
+  const edgeIssues = findEdgeOverlaps(edges);
+  const rectIssues = findEdgeRectCollisions(edges, rects);
+  const rectBorderIssues = findEdgeRectBorderOverlaps(edges, rects);
+  const companionDrawio = await readCompanionDrawio(targetPath, targetArg);
+  const textBlocks = companionDrawio ? parseDrawioTextBlocks(companionDrawio.text) : [];
+  const textIssues = findTextOverflowIssues(textBlocks);
+  const issues = summarizeIssues([...edgeIssues, ...rectIssues, ...rectBorderIssues, ...textIssues]);
+
+  console.log(`[diagram:check] ${path.relative(process.cwd(), targetPath)}`);
+  console.log(`[diagram:check] parsed ${cells.size} cells, ${edges.length} edges, ${rects.length} obstacle rects`);
+
+  if (companionDrawio) {
+    console.log(`[diagram:check] parsed ${textBlocks.length} text block(s) from ${path.relative(process.cwd(), companionDrawio.path)}`);
+  }
+
+  if (issues.length === 0) {
+    console.log('[diagram:check] OK: no overlaps or text overflows detected by the current heuristics');
+    return;
+  }
+
+  console.log(`[diagram:check] found ${issues.length} issue(s)`);
+  for (const issue of issues) {
+    console.log(formatIssue(issue));
+  }
+
+  process.exitCode = 1;
+}
+
+await main();

--- a/skills/diagramming/scripts/convert-drawio-to-png.sh
+++ b/skills/diagramming/scripts/convert-drawio-to-png.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Convert .drawio files to .drawio.png
+generated_files=()
+
+for drawio in "$@"; do
+  png="${drawio%.drawio}.drawio.png"
+  echo "Converting $drawio to $png..."
+
+  # drawio CLI export to PNG with 2x scale for high quality
+  if ! drawio -x -f png -s 2 -t -o "$png" "$drawio" 2>/dev/null; then
+    echo "✗ drawio PNG export failed for $drawio" >&2
+    continue
+  fi
+
+  generated_files+=("$png")
+  echo "✓ Generated $png"
+done
+
+# Stage all generated files at once to avoid index.lock conflicts
+if [ ${#generated_files[@]} -gt 0 ]; then
+  git add "${generated_files[@]}"
+  echo "Staged ${#generated_files[@]} file(s)"
+fi

--- a/skills/diagramming/scripts/find_aws_icon.py
+++ b/skills/diagramming/scripts/find_aws_icon.py
@@ -1,0 +1,78 @@
+"""AWS アイコン検索スクリプト
+
+references/aws-icons.md からサービス名でアイコン情報を検索する。
+トークン効率を向上させるため、必要な情報のみを抽出する。
+
+Usage:
+    python find_aws_icon.py <service_name>
+    python find_aws_icon.py ec2
+    python find_aws_icon.py lambda
+    python find_aws_icon.py s3
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def load_icon_data() -> dict[str, str]:
+    """aws-icons.md からアイコンデータを読み込む"""
+    icons = {}
+    script_dir = Path(__file__).parent
+    aws_icons_path = script_dir.parent / "references" / "aws-icons.md"
+
+    if not aws_icons_path.exists():
+        return icons
+
+    content = aws_icons_path.read_text(encoding="utf-8")
+
+    # テーブル行からサービス名と resIcon を抽出
+    # | Amazon EC2 | mxgraph.aws4.ec2 |
+    pattern = r"\|\s*([^|]+?)\s*\|\s*(mxgraph\.aws4\.[a-z0-9_]+)\s*\|"
+    for match in re.finditer(pattern, content):
+        service_name = match.group(1).strip()
+        res_icon = match.group(2).strip()
+        icons[service_name.lower()] = {
+            "name": service_name,
+            "resIcon": res_icon,
+        }
+
+    return icons
+
+
+def search_icon(query: str) -> list[dict]:
+    """クエリに一致するアイコンを検索"""
+    icons = load_icon_data()
+    query_lower = query.lower()
+    results = []
+
+    for key, data in icons.items():
+        if query_lower in key or query_lower in data["resIcon"]:
+            results.append(data)
+
+    return results
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python find_aws_icon.py <service_name>")
+        print("Example: python find_aws_icon.py ec2")
+        sys.exit(1)
+
+    query = sys.argv[1]
+    results = search_icon(query)
+
+    if not results:
+        print(f"No icons found for: {query}")
+        sys.exit(1)
+
+    print(f"Found {len(results)} icon(s) for '{query}':\n")
+    for result in results:
+        print(f"Service: {result['name']}")
+        print(f"resIcon: {result['resIcon']}")
+        print(f"Style: shape=mxgraph.aws4.resourceIcon;resIcon={result['resIcon']};")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/drawio-local/SKILL.md
+++ b/skills/drawio-local/SKILL.md
@@ -2,28 +2,30 @@
 name: drawio-local
 license: MIT
 description: |
-  USE FOR: draw.io diagram creation, editing, and review. Use for .drawio XML editing, PNG/SVG/PDF export, layout adjustment, and AWS icon usage. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: draw.io compatibility trigger for XML editing, export, layout, and AWS icon workflows. Detailed owner: diagramming. DO NOT USE FOR: generated outputs.
 ---
 
 # Drawio Local
 
-**UTILITY SKILL:** Apply this skill to draw.io diagram creation, editing, and
-review. Use for .drawio XML editing, PNG/SVG/PDF export, layout adjustment, and
-AWS icon usage. Keep the task scoped to the requested domain and preserve
-existing repo conventions.
+Compatibility trigger for draw.io-specific diagram tasks. The durable
+implementation guidance now lives in `skills/diagramming/references/drawio.md`.
 
-**USE FOR:** draw.io diagram creation, editing, and review. Use for .drawio XML
-editing, PNG/SVG/PDF export, layout adjustment, and AWS icon usage; related file
-edits; verification and handoff in this skill domain.
+## Use For
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+- draw.io `.drawio` source creation, editing, and review.
+- XML layout adjustment and native `mxGraphModel` work.
+- PNG, SVG, and PDF export workflows.
+- AWS icon lookup and diagram asset references.
+
+## Do Not Use For
+
+- Broad diagramming work; use `diagramming`.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/diagramming/references/drawio.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,6 +37,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
+- `skills/diagramming/references/drawio.md`
 - [Aws Icons](references/aws-icons.md)
 - [Color Palette](references/color-palette.md)
 - [Layout Guidelines](references/layout-guidelines.md)

--- a/skills/mermaid-local/SKILL.md
+++ b/skills/mermaid-local/SKILL.md
@@ -2,28 +2,30 @@
 name: mermaid-local
 license: MIT
 description: |
-  USE FOR: Mermaid diagrams in Quarto revealjs .qmd files: sequenceDiagram, flowchart, pie; mmdc preview; %%{init}%% config; CSS color overrides. Use this skill when tasks need this repository-specific workflow. DO NOT USE FOR: unrelated tasks, broad rewrites outside the request, or generated runtime outputs.
+  USE FOR: Mermaid compatibility trigger for Quarto revealjs diagrams, mmdc preview, init config, CSS overrides, and layout checks. Detailed owner: diagramming.
 ---
 
 # Mermaid Local
 
-**UTILITY SKILL:** Apply this skill to Mermaid diagrams in Quarto revealjs .qmd
-files: sequenceDiagram, flowchart, pie; mmdc preview; %%{init}%% config; CSS
-color overrides. Keep the task scoped to the requested domain and preserve
-existing repo conventions.
+Compatibility trigger for Mermaid-specific diagram tasks. The durable
+implementation guidance now lives in
+`skills/diagramming/references/mermaid.md`.
 
-**USE FOR:** Mermaid diagrams in Quarto revealjs .qmd files: sequenceDiagram,
-flowchart, pie; mmdc preview; %%{init}%% config; CSS color overrides; related
-file edits; verification and handoff in this skill domain.
+## Use For
 
-**DO NOT USE FOR:** unrelated domains, broad rewrites outside the request,
-generated runtime outputs, or replacing repo-specific source of truth.
+- Mermaid diagrams in Quarto revealjs `.qmd` files.
+- `mmdc` preview and rendered dimension checks.
+- `%%{init}%%` configuration and revealjs CSS overrides.
+
+## Do Not Use For
+
+- Broad diagramming work; use `diagramming`.
+- Unrelated domains, broad rewrites, or generated runtime outputs.
 
 ## Workflow
 
 1. Inspect the relevant files, current repo conventions, and `git status`.
-2. Read [Preserved Guidance](references/preserved-guidance.md) before changing
-   behavior or giving detailed instructions.
+2. Read `skills/diagramming/references/mermaid.md`.
 3. Make the smallest scoped change that satisfies the request.
 4. Run the checks named in the preserved guidance or the nearest repo harness.
 5. Report verification results and any remaining risk.
@@ -35,7 +37,7 @@ source, run focused checks, and summarize the result.
 
 ## References
 
-- [Preserved Guidance](references/preserved-guidance.md)
+- `skills/diagramming/references/mermaid.md`
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add `skills/diagramming/` as the target owner for draw.io and Mermaid guidance.
- Move diagramming references, helper scripts, and reference assets under the target skill.
- Demote `skills/drawio-local/` and `skills/mermaid-local/` to trigger-focused compatibility entries and update `skills/classification.yaml`.

## Verification

- `bash bin/validate-skill-frontmatter.sh skills`
- `bash bin/validate-skill-private-content.sh --staged`
- `bash bin/validate-skill-description-length.sh --staged`
- `bash bin/validate-skill-waza.sh --staged`
- `git diff --cached --check`
- `nix run nixpkgs#rumdl -- check ...`
- `nix run nixpkgs#gh -- skill publish --dry-run`
- `nix run nixpkgs#pre-commit -- run --files $(git diff --cached --name-only)`

Closes https://github.com/i9wa4/dotfiles/issues/175
