### PR TITLE
Add Antigravity CLI to managed agent tools

### DIFF
--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -108,6 +108,8 @@ in
       pkgs.zoxide
       # AI agent CLIs (versions tracked by flake.lock; was previously installed via nix profile)
       # ccusage includes Codex usage subcommands.
+      # Antigravity exposes the `agy` command.
+      llmAgents.antigravity
       llmAgents.ccusage
       llmAgents.claude-code
       llmAgents.codex


### PR DESCRIPTION
## Summary

- Add `llmAgents.antigravity` to the Home Manager package list for managed AI agent tools.
- Note that the package exposes the `agy` command.

## Verification

- `nix run nixpkgs#statix -- check nix/home-manager/default.nix`
- `nix run nixpkgs#deadnix -- --fail nix/home-manager/default.nix`
- `nix build --no-link` for the current-system Antigravity package
- `nix flake check --print-build-logs`

Closes #219