### PR TITLE
Add nh switch evaluation apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,44 @@ gh auth login --with-token
 | Command                                          | Description                                                                                                                                                                                                                                               |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `nix run '.#switch'`                             | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day. Scheduled daemon GC remains separate and uses 1 day on both Linux and macOS |
+| `nix run '.#switch-nh'`                          | Trial `nh` switch path with confirmation, package diff output, activation logs, and the same post-switch generation expiry as `switch`                                                                                                                    |
+| `nix run '.#cleanup-nh-preview'`                 | Dry-run `nh clean user` for comparison. It does not run store GC and does not replace `cleanup`, `gc-roots-delete`, or scheduled daemon GC                                                                                                                |
 | `nix run '.#update'`                             | Update flake inputs                                                                                                                                                                                                                                       |
 | `nix run '.#check'`                              | Check flake configuration                                                                                                                                                                                                                                 |
 | `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage                                                                                                                                                                                                                    |
+
+### 6.1. nh Evaluation
+
+`nix run '.#switch'` remains the daily fallback on macOS and Ubuntu or WSL2
+while `nh` is evaluated. `nix run '.#switch-nh'` is the trial surface.
+
+On Ubuntu or WSL2, `switch-nh` runs `nh home switch --configuration ubuntu .`
+with `--impure`, `--backup-extension backup`, confirmation, package diff
+output, and activation logs. It preserves the existing GitHub token handling by
+reading `gh auth token` and forwarding `--access-tokens` plus
+`"github.com=$access_token"` to the underlying Nix build. After a successful
+activation, it still expires Home Manager generations older than 1 day.
+
+On macOS, `switch-nh` prompts for `macos-p` or `macos-w`, then runs
+`nh darwin switch --hostname <profile> .` with `--impure`, confirmation,
+package diff output, and activation logs. After a successful activation, it
+still expires nix-darwin system generations older than 1 day.
+
+`nix run '.#cleanup-nh-preview'` evaluates `nh clean user` separately from
+switching. It runs with `--dry`, `--ask`, `--keep 1`, `--keep-since 1d`, and
+`--no-gc`, so it previews generation and GC-root candidates without changing the
+store or replacing the current explicit cleanup commands.
+
+Rollback path: return to the existing flow with `nix run '.#switch'`. If an
+`nh` activation already completed and needs to be rolled back, Ubuntu or WSL2
+can run `home-manager switch --rollback`; macOS can run
+`sudo darwin-rebuild --rollback`.
+
+Comparison status: the Ubuntu or WSL2 path has been checked locally with
+`nh home build --configuration ubuntu . --impure --backup-extension backup`
+plus forwarded `--access-tokens`. The macOS nix-darwin activation path remains
+pending until it can be run on a macOS host; Linux-side validation only checks
+the generated app and nix-darwin evaluation surfaces.
 
 ## 7. Upgrade Nix
 

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -5,10 +5,13 @@
 #   nix run '.#switch'       -- rebuild and activate configuration
 #                               (Linux expires Home Manager generations older than 1 day;
 #                                macOS expires system generations older than 1 day)
+#   nix run '.#switch-nh'    -- trial nh-based switch with the same post-switch generation expiry
 #   nix run '.#update'       -- update flake inputs and Waza release pins
 #   nix run '.#profile-update' -- install or upgrade entries listed in `profilePackages`
 #   nix run '.#check'        -- check flake configuration
 #   nix run '.#cleanup'      -- prune low-risk local caches
+#   nix run '.#cleanup-nh-preview'
+#                             -- dry-run nh cleanup without replacing the current cleanup policy
 #   nix run '.#gc-roots-delete'
 #                             -- attempt Linux auto GC-root cleanup through the dedicated command
 #   nix run '.#storage-report' -- summarize Linux home-directory storage
@@ -61,13 +64,55 @@
               else
                 ''
                   access_token=$(${lib.getExe pkgs.gh} auth token)
-                  nix run --access-tokens "github.com=$access_token" \
+                  ${nix} run --access-tokens "github.com=$access_token" \
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
-                  nix run --access-tokens "github.com=$access_token" \
+                  ${nix} run --access-tokens "github.com=$access_token" \
                     home-manager -- expire-generations '-1 days'
                 ''
             }
           ''}/bin/switch";
+        };
+
+        # What: Trial nh switch path for comparing output, package diffs, activation logs, and confirmation UX.
+        #       The existing `switch` app remains the fallback and production daily command.
+        # When: Run only when evaluating nh behavior on the current host.
+        # Example: nix run '.#switch-nh'
+        switch-nh = {
+          type = "app";
+          program = "${pkgs.writeShellScriptBin "switch-nh" ''
+            set -euo pipefail
+
+            ${
+              if isDarwin then
+                ''
+                  profile=$(echo -e "macos-p\nmacos-w" | ${lib.getExe pkgs.fzf} --prompt="Select profile: ")
+                  sudo -H ${lib.getExe pkgs.nh} darwin switch \
+                    --bypass-root-check \
+                    --hostname "$profile" \
+                    --ask \
+                    --diff always \
+                    --show-activation-logs \
+                    --impure \
+                    .
+                  sudo -H ${pkgs.nix}/bin/nix-env --profile /nix/var/nix/profiles/system --delete-generations 1d
+                ''
+              else
+                ''
+                  access_token=$(${gh} auth token)
+                  ${lib.getExe pkgs.nh} home switch \
+                    --configuration ubuntu \
+                    --backup-extension backup \
+                    --ask \
+                    --diff always \
+                    --show-activation-logs \
+                    --impure \
+                    . \
+                    -- --access-tokens "github.com=$access_token"
+                  nix run --access-tokens "github.com=$access_token" \
+                    home-manager -- expire-generations '-1 days'
+                ''
+            }
+          ''}/bin/switch-nh";
         };
 
         update = {
@@ -168,6 +213,25 @@
 
             echo "Cleanup complete."
           ''}/bin/cleanup";
+        };
+
+        # What: Preview nh cleanup candidates without changing generations, GC roots, or the store.
+        #       The existing `cleanup` app and scheduled Nix GC remain the active cleanup policy.
+        # When: Run during nh cleanup evaluation only.
+        # Example: nix run '.#cleanup-nh-preview'
+        cleanup-nh-preview = {
+          type = "app";
+          program = "${pkgs.writeShellScriptBin "cleanup-nh-preview" ''
+            set -euo pipefail
+
+            exec ${lib.getExe pkgs.nh} clean user \
+              --dry \
+              --ask \
+              --keep 1 \
+              --keep-since 1d \
+              --no-gc \
+              "$@"
+          ''}/bin/cleanup-nh-preview";
         };
       }
       // lib.optionalAttrs isLinux {


### PR DESCRIPTION
## Summary

- Add evaluation apps for nh-based switch and cleanup workflows.
- Document the trial flow while preserving the current switch path as fallback.

## Verification

- Not run during PR creation; this step only creates the PR for the pushed branch.

Closes #200