### PR TITLE
Harden switch and cleanup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,9 +357,10 @@ profile as root, then reload and restart `nix-daemon`. `--remove-all` avoids a
 profile conflict with the `nix-manual` output from the original installer:
 
 ```sh
-sudo -i sh -c 'nix-channel --update && \
-  nix-env --install --remove-all --attr nixpkgs.nix nixpkgs.cacert && \
-  systemctl daemon-reload && \
+sudo -i sh -c 'nix-channel --update &&
+  nix-env --install --remove-all \
+    --attr nixpkgs.nix nixpkgs.cacert &&
+  systemctl daemon-reload &&
   systemctl restart nix-daemon'
 ```
 

--- a/README.md
+++ b/README.md
@@ -309,18 +309,20 @@ gh auth login --with-token
 | `nix run '.#cleanup' -- --dry-run`               | Preview low-risk user-cache cleanup                                                                                                                                                                                                                       |
 | `nix run '.#cleanup'`                            | Prune low-risk user caches shown by the cleanup app                                                                                                                                                                                                       |
 | `nix run '.#gc-roots-delete' -- --dry-run`       | Preview guarded stale Linux auto GC-root deletion                                                                                                                                                                                                         |
-| `nix run '.#gc-roots-delete'`                    | Delete only guarded current-user stale auto GC roots, then run Nix GC                                                                                                                                                                                     |
+| `nix run '.#gc-roots-delete' -- --apply`         | Delete only guarded current-user stale auto GC roots, then run Nix GC                                                                                                                                                                                     |
 
 Notes:
 
 - Keep `nix run '.#switch'` as the primary daily activation command. It expires
   old generations after a successful activation, but it does not run store GC.
+  CI verifies the command wiring; live Ubuntu/WSL2 and macOS expiry behavior
+  should still be checked on target hosts after switching.
 - Run `nix run '.#storage-report' -- --self --summary` before cleanup when
   investigating disk pressure.
 - `nix run '.#cleanup'` touches only the explicit low-risk cache surface. Use
   `--dry-run` or `--preview` first when you want a no-write check.
-- `nix run '.#gc-roots-delete'` is separate from `switch` and `cleanup`. Use
-  `--dry-run` first; apply mode re-classifies roots at execution time and skips
+- `nix run '.#gc-roots-delete'` is separate from `switch` and `cleanup`. It
+  defaults to dry-run; `--apply` re-classifies roots at execution time and skips
   protected Home Manager, profile, `.direnv`, `result`, `/tmp`, and active
   worktree roots.
 - `./bin/nix-profile-cleanup` is a legacy manual profile helper. Preview with

--- a/README.md
+++ b/README.md
@@ -303,9 +303,43 @@ gh auth login --with-token
 | Command                                          | Description                                                                                                                                                                                                                                               |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `nix run '.#switch'`                             | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day. Scheduled daemon GC remains separate and uses 1 day on both Linux and macOS |
-| `nix run '.#update'`                             | Update flake inputs                                                                                                                                                                                                                                       |
+| `nix run '.#update'`                             | Update flake inputs, latest-tag flake refs, and managed package pins                                                                                                                                                                                      |
 | `nix run '.#check'`                              | Check flake configuration                                                                                                                                                                                                                                 |
-| `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage                                                                                                                                                                                                                    |
+| `nix run '.#storage-report' -- --self --summary` | Summarize Linux home-directory storage before cleanup                                                                                                                                                                                                     |
+| `nix run '.#cleanup' -- --dry-run`               | Preview low-risk user-cache cleanup                                                                                                                                                                                                                       |
+| `nix run '.#cleanup'`                            | Prune low-risk user caches shown by the cleanup app                                                                                                                                                                                                       |
+| `nix run '.#gc-roots-delete' -- --dry-run`       | Preview guarded stale Linux auto GC-root deletion                                                                                                                                                                                                         |
+| `nix run '.#gc-roots-delete'`                    | Delete only guarded current-user stale auto GC roots, then run Nix GC                                                                                                                                                                                     |
+
+Notes:
+
+- Keep `nix run '.#switch'` as the primary daily activation command. It expires
+  old generations after a successful activation, but it does not run store GC.
+- Run `nix run '.#storage-report' -- --self --summary` before cleanup when
+  investigating disk pressure.
+- `nix run '.#cleanup'` touches only the explicit low-risk cache surface. Use
+  `--dry-run` or `--preview` first when you want a no-write check.
+- `nix run '.#gc-roots-delete'` is separate from `switch` and `cleanup`. Use
+  `--dry-run` first; apply mode re-classifies roots at execution time and skips
+  protected Home Manager, profile, `.direnv`, `result`, `/tmp`, and active
+  worktree roots.
+- `./bin/nix-profile-cleanup` is a legacy manual profile helper. Preview with
+  `bash ./bin/nix-profile-cleanup --dry-run` before `--apply`; normal managed
+  tool updates use `nix run '.#update'` plus `nix run '.#switch'`.
+- There is no separate `profile-update` app in this repo. Managed profile-like
+  state is updated through the flake update and switch flow.
+
+Rollback and recovery:
+
+- Linux Home Manager generations can be inspected with
+  `home-manager generations` and reactivated with the generation's activation
+  package when needed.
+- macOS system generations can be inspected through the Nix system profile; use
+  the previous generation's `activate` package or re-run `darwin-rebuild` from
+  the previous flake revision.
+- Cache cleanup has no data restore step by design; the removed paths are
+  rebuildable tool caches. Re-run the relevant tool, `repo-setup`, or
+  `nix run '.#switch'` to recreate them.
 
 ## 7. Upgrade Nix
 
@@ -321,7 +355,10 @@ profile as root, then reload and restart `nix-daemon`. `--remove-all` avoids a
 profile conflict with the `nix-manual` output from the original installer:
 
 ```sh
-sudo -i sh -c 'nix-channel --update && nix-env --install --remove-all --attr nixpkgs.nix nixpkgs.cacert && systemctl daemon-reload && systemctl restart nix-daemon'
+sudo -i sh -c 'nix-channel --update && \
+  nix-env --install --remove-all --attr nixpkgs.nix nixpkgs.cacert && \
+  systemctl daemon-reload && \
+  systemctl restart nix-daemon'
 ```
 
 Verify:

--- a/bin/cleanup-safe-caches.sh
+++ b/bin/cleanup-safe-caches.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# What: prune only the repo's explicit safe_cache surface for user-owned caches.
+# When: run for low-risk reclaim after previewing the listed cache paths.
+# Example: CLEANUP_UV="$(command -v uv)" bash ./bin/cleanup-safe-caches.sh --dry-run
+
+dry_run=false
+
+usage() {
+  cat <<'EOF'
+Usage: cleanup-safe-caches.sh [--dry-run|--preview|--apply]
+
+Behavior:
+  Prunes only the repo's explicit safe_cache surface for user-owned caches.
+  --dry-run and --preview list the cleanup actions without removing anything.
+  --apply is accepted for explicit apply mode; omitting a mode also applies.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --dry-run | --preview)
+    dry_run=true
+    shift
+    ;;
+  --apply)
+    dry_run=false
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: Unknown argument: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+done
+
+remove_dir() {
+  target="$1"
+
+  if [[ -d $target ]]; then
+    if [[ $dry_run == true ]]; then
+      echo "Would remove $target"
+    else
+      echo "Removing $target"
+      rm -rf "$target"
+    fi
+  else
+    echo "Skipping missing $target"
+  fi
+}
+
+cleanup_uv="${CLEANUP_UV:-uv}"
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}"
+uv_cache_dir="$("$cleanup_uv" cache dir)"
+
+if command -v pgrep >/dev/null 2>&1 && pgrep -x uv >/dev/null 2>&1; then
+  echo "Skipping uv cache prune in $uv_cache_dir (active uv process detected)"
+else
+  if [[ $dry_run == true ]]; then
+    echo "Would prune uv cache in $uv_cache_dir"
+  else
+    echo "Pruning uv cache in $uv_cache_dir"
+    "$cleanup_uv" cache prune
+  fi
+fi
+
+remove_dir "$cache_root/pre-commit"
+remove_dir "$cache_root/ruff"
+
+if [[ $(uname -s) == Linux ]]; then
+  remove_dir "$cache_root/go-build"
+  remove_dir "$cache_root/nix"
+fi
+
+remove_dir "$HOME/.npm"
+
+if [[ -d $HOME/Library/Caches ]]; then
+  remove_dir "$HOME/Library/Caches/pre-commit"
+  remove_dir "$HOME/Library/Caches/ruff"
+fi
+
+if [[ $dry_run == true ]]; then
+  echo "Cleanup dry run complete; pass --apply or omit --dry-run to remove listed caches."
+else
+  echo "Cleanup complete."
+fi

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -6,7 +6,7 @@ set -o posix
 
 # What: classify auto-generated Nix GC roots and try direct current-user unlink for CANDIDATE roots.
 # When: run through gc-roots-delete before manual Nix store cleanup to remove only guarded stale candidates.
-# Example: nix run '.#gc-roots-delete' -- --dry-run
+# Example: nix run '.#gc-roots-delete' -- --apply
 
 usage() {
   cat <<'EOF'
@@ -14,18 +14,20 @@ Usage: list-stale-nix-gcroots.sh [--dry-run|--preview|--apply]
 
 Behavior:
   Re-classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
+  By default, list candidate actions without deleting anything
   In apply mode, attempt current-user unlink of current CANDIDATE symlink roots
   Warn and continue when a specific CANDIDATE root cannot be deleted
   In apply mode, run nix-collect-garbage after candidate deletion
 
 Examples:
-  nix run '.#gc-roots-delete' -- --dry-run
   nix run '.#gc-roots-delete'
+  nix run '.#gc-roots-delete' -- --dry-run
+  nix run '.#gc-roots-delete' -- --apply
 EOF
 }
 
 REAL_USER="${SUDO_USER:-$(id -un)}"
-dry_run=false
+dry_run=true
 
 safe_text() {
   value="$1"

--- a/bin/ubuntu/list-stale-nix-gcroots.sh
+++ b/bin/ubuntu/list-stale-nix-gcroots.sh
@@ -6,24 +6,26 @@ set -o posix
 
 # What: classify auto-generated Nix GC roots and try direct current-user unlink for CANDIDATE roots.
 # When: run through gc-roots-delete before manual Nix store cleanup to remove only guarded stale candidates.
-# Example: nix run '.#gc-roots-delete'
+# Example: nix run '.#gc-roots-delete' -- --dry-run
 
 usage() {
   cat <<'EOF'
-Usage: list-stale-nix-gcroots.sh
+Usage: list-stale-nix-gcroots.sh [--dry-run|--preview|--apply]
 
 Behavior:
   Re-classify auto GC roots as KEEP, CANDIDATE, or BLOCKED
-  Attempt current-user unlink of current CANDIDATE symlink roots
+  In apply mode, attempt current-user unlink of current CANDIDATE symlink roots
   Warn and continue when a specific CANDIDATE root cannot be deleted
-  Run nix-collect-garbage after candidate deletion
+  In apply mode, run nix-collect-garbage after candidate deletion
 
 Examples:
+  nix run '.#gc-roots-delete' -- --dry-run
   nix run '.#gc-roots-delete'
 EOF
 }
 
 REAL_USER="${SUDO_USER:-$(id -un)}"
+dry_run=false
 
 safe_text() {
   value="$1"
@@ -45,6 +47,14 @@ run_as_real_user() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+  --dry-run | --preview)
+    dry_run=true
+    shift
+    ;;
+  --apply)
+    dry_run=false
+    shift
+    ;;
   -h | --help)
     usage
     exit 0
@@ -202,11 +212,15 @@ EOF
   printf '%s\t%s\t%s\t%s\t%s\n' "$state" "$reason" "$root_path" "$link_path" "$target_path" >>"$output_file"
 
   if [[ $state == CANDIDATE ]]; then
-    echo "DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
-    if unlink "$root_path" 2>/dev/null; then
-      delete_count=$((delete_count + 1))
+    if [[ $dry_run == true ]]; then
+      echo "WOULD_DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
     else
-      echo "WARNING root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=unlink-failed"
+      echo "DELETE root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=$(safe_text "$reason")"
+      if unlink "$root_path" 2>/dev/null; then
+        delete_count=$((delete_count + 1))
+      else
+        echo "WARNING root=$(safe_text "$root_path") link=$(safe_text "$link_path") reason=unlink-failed"
+      fi
     fi
   fi
 done <"$roots_file"
@@ -222,6 +236,10 @@ while IFS=$'\t' read -r state reason root_path link_path target_path; do
 done <"$sorted_output_file"
 
 echo "SUMMARY keep=${keep_count} candidate=${candidate_count} blocked=${blocked_count}"
-echo "GC start deleted_roots=${delete_count}"
-/nix/var/nix/profiles/default/bin/nix-collect-garbage
-echo "GC done deleted_roots=${delete_count}"
+if [[ $dry_run == true ]]; then
+  echo "GC skipped dry_run=true deleted_roots=0"
+else
+  echo "GC start deleted_roots=${delete_count}"
+  /nix/var/nix/profiles/default/bin/nix-collect-garbage
+  echo "GC done deleted_roots=${delete_count}"
+fi

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -360,13 +360,16 @@ Approved action only, after the retention policy is known:
 
 ```sh
 nix run '.#switch'
+nix run '.#gc-roots-delete' -- --dry-run
 nix run '.#gc-roots-delete'
 ```
 
 For normal daily maintenance, prefer the repo's switch/update flow and the
 explicit GC-root delete surface. User-profile cleanup is no longer part of the
 flake app surface because this repository no longer uses a manual user Nix
-profile for managed tools. Do not use ad hoc `rm` under `/nix`.
+profile for managed tools. If a legacy manual profile needs cleanup, preview
+with `bash ./bin/nix-profile-cleanup --dry-run` before using `--apply`. Do not
+use ad hoc `rm` under `/nix`.
 
 #### 1.12.7. `/home` Ownership
 
@@ -406,12 +409,14 @@ Use these only after the user approves the exact action.
 Low-risk rebuildable cache cleanup:
 
 ```sh
+nix run '.#cleanup' -- --dry-run
 nix run '.#cleanup'
 ```
 
 Guarded stale GC-root cleanup:
 
 ```sh
+nix run '.#gc-roots-delete' -- --dry-run
 nix run '.#gc-roots-delete'
 ```
 
@@ -457,20 +462,24 @@ Use the single delete-focused command surface to remove stale auto GC roots.
 ### 2.1. Command
 
 ```sh
+nix run '.#gc-roots-delete' -- --dry-run
 nix run '.#gc-roots-delete'
 ```
 
-The interface has no flags. It attempts current-user unlink directly and never
-asks for escalation. Every invocation re-classifies roots as:
+The interface supports `--dry-run`, `--preview`, and `--apply`. Omitting a mode
+uses apply mode for backward compatibility. Every invocation re-classifies roots
+as:
 
 - `KEEP`
 - `CANDIDATE`
 - `BLOCKED`
 
 Each line includes a reason, the auto-root path, the original linked path, and
-the resolved target. The command unlinks only current `CANDIDATE` auto-root
-symlinks that the current user can delete, prints a `WARNING` for roots that
-cannot be removed, and then runs `nix-collect-garbage`.
+the resolved target. In dry-run mode, the command prints `WOULD_DELETE` for
+current `CANDIDATE` auto-root symlinks and skips `nix-collect-garbage`. In
+apply mode, it unlinks only current `CANDIDATE` auto-root symlinks that the
+current user can delete, prints a `WARNING` for roots that cannot be removed,
+and then runs `nix-collect-garbage`.
 
 ### 2.2. Protected Root Classes
 
@@ -488,8 +497,10 @@ links such as `profile-*` stay `KEEP`.
 ### 2.3. Operator Notes
 
 - This delete surface is explicit and never scheduled.
-- It re-runs the classification and active-worktree checks at execution time.
-- It has no preview mode and no flag-based delete switch.
+- It re-runs the classification and active-worktree checks at execution time in
+  both dry-run and apply mode.
+- Use `--dry-run` or `--preview` before apply mode when investigating storage
+  pressure.
 - It attempts deletion as the current user and keeps going when a specific root
   cannot be removed.
 

--- a/docs/storage-hygiene.md
+++ b/docs/storage-hygiene.md
@@ -361,7 +361,7 @@ Approved action only, after the retention policy is known:
 ```sh
 nix run '.#switch'
 nix run '.#gc-roots-delete' -- --dry-run
-nix run '.#gc-roots-delete'
+nix run '.#gc-roots-delete' -- --apply
 ```
 
 For normal daily maintenance, prefer the repo's switch/update flow and the
@@ -370,6 +370,10 @@ flake app surface because this repository no longer uses a manual user Nix
 profile for managed tools. If a legacy manual profile needs cleanup, preview
 with `bash ./bin/nix-profile-cleanup --dry-run` before using `--apply`. Do not
 use ad hoc `rm` under `/nix`.
+
+CI verifies the command wiring for generation expiry. Confirm the resulting
+Ubuntu/WSL2 Home Manager and macOS system generation state on target hosts
+after `nix run '.#switch'`.
 
 #### 1.12.7. `/home` Ownership
 
@@ -417,7 +421,7 @@ Guarded stale GC-root cleanup:
 
 ```sh
 nix run '.#gc-roots-delete' -- --dry-run
-nix run '.#gc-roots-delete'
+nix run '.#gc-roots-delete' -- --apply
 ```
 
 Managed swap reduction from 16GiB to 8GiB:
@@ -453,7 +457,8 @@ Use one-off deletion only to exit the emergency. The durable controls are:
   while the VG has free extents, extend it before treating normal usage as a
   storage-pressure incident.
 - Use explicit Nix cleanup surfaces, such as the daily switch flow and
-  `nix run '.#gc-roots-delete'`, instead of deleting Nix store paths directly.
+  `nix run '.#gc-roots-delete' -- --apply`, instead of deleting Nix store paths
+  directly.
 
 ## 2. Guarded GC-Root Delete
 
@@ -463,12 +468,11 @@ Use the single delete-focused command surface to remove stale auto GC roots.
 
 ```sh
 nix run '.#gc-roots-delete' -- --dry-run
-nix run '.#gc-roots-delete'
+nix run '.#gc-roots-delete' -- --apply
 ```
 
 The interface supports `--dry-run`, `--preview`, and `--apply`. Omitting a mode
-uses apply mode for backward compatibility. Every invocation re-classifies roots
-as:
+uses dry-run mode. Every invocation re-classifies roots as:
 
 - `KEEP`
 - `CANDIDATE`
@@ -499,8 +503,8 @@ links such as `profile-*` stay `KEEP`.
 - This delete surface is explicit and never scheduled.
 - It re-runs the classification and active-worktree checks at execution time in
   both dry-run and apply mode.
-- Use `--dry-run` or `--preview` before apply mode when investigating storage
-  pressure.
+- Bare invocation, `--dry-run`, and `--preview` do not delete roots.
+- Use `--apply` only after reviewing dry-run output during storage pressure.
 - It attempts deletion as the current user and keeps going when a specific root
   cannot be removed.
 

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -7,6 +7,8 @@
 #                                macOS expires system generations older than 1 day)
 #   nix run '.#update'       -- update flake inputs, latest-tag flake refs, and Waza release pins
 #   nix run '.#check'        -- check flake configuration
+#   nix run '.#cleanup' -- --dry-run
+#                             -- preview low-risk local cache cleanup
 #   nix run '.#cleanup'      -- prune low-risk local caches
 #   nix run '.#gc-roots-delete'
 #                             -- attempt Linux auto GC-root cleanup through the dedicated command
@@ -88,50 +90,98 @@
 
         # What: Prune only the explicit safe_cache surface for user-owned caches.
         # When: Run for low-risk reclaim without touching review_first or preserve buckets.
+        # Preview: nix run '.#cleanup' -- --dry-run
         cleanup = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "cleanup" ''
-            set -euo pipefail
+                        set -euo pipefail
 
-            remove_dir() {
-              target="$1"
-              if [ -d "$target" ]; then
-                echo "Removing $target"
-                rm -rf "$target"
-              else
-                echo "Skipping missing $target"
-              fi
-            }
+                        dry_run=false
 
-            cache_root="''${XDG_CACHE_HOME:-$HOME/.cache}"
-            uv_cache_dir="$(${lib.getExe pkgs.uv} cache dir)"
+                        usage() {
+                          cat <<'EOF'
+            Usage: cleanup [--dry-run|--preview|--apply]
 
-            if command -v pgrep >/dev/null 2>&1 && pgrep -x uv >/dev/null 2>&1; then
-              echo "Skipping uv cache prune in $uv_cache_dir (active uv process detected)"
-            else
-              echo "Pruning uv cache in $uv_cache_dir"
-              ${lib.getExe pkgs.uv} cache prune
-            fi
+            Behavior:
+              Prunes only the repo's explicit safe_cache surface for user-owned caches.
+              --dry-run and --preview list the cleanup actions without removing anything.
+              --apply is accepted for explicit apply mode; omitting a mode also applies.
+            EOF
+                        }
 
-            remove_dir "$cache_root/pre-commit"
-            remove_dir "$cache_root/ruff"
-            ${
-              if isLinux then
-                ''
-                  remove_dir "$cache_root/go-build"
-                  remove_dir "$cache_root/nix"
-                ''
-              else
-                ""
-            }
-            remove_dir "$HOME/.npm"
+                        while [ "$#" -gt 0 ]; do
+                          case "$1" in
+                            --dry-run | --preview)
+                              dry_run=true
+                              shift
+                              ;;
+                            --apply)
+                              dry_run=false
+                              shift
+                              ;;
+                            -h | --help)
+                              usage
+                              exit 0
+                              ;;
+                            *)
+                              echo "ERROR: Unknown argument: $1" >&2
+                              usage >&2
+                              exit 1
+                              ;;
+                          esac
+                        done
 
-            if [ -d "$HOME/Library/Caches" ]; then
-              remove_dir "$HOME/Library/Caches/pre-commit"
-              remove_dir "$HOME/Library/Caches/ruff"
-            fi
+                        remove_dir() {
+                          target="$1"
+                          if [ -d "$target" ]; then
+                            if [ "$dry_run" = true ]; then
+                              echo "Would remove $target"
+                            else
+                              echo "Removing $target"
+                              rm -rf "$target"
+                            fi
+                          else
+                            echo "Skipping missing $target"
+                          fi
+                        }
 
-            echo "Cleanup complete."
+                        cache_root="''${XDG_CACHE_HOME:-$HOME/.cache}"
+                        uv_cache_dir="$(${lib.getExe pkgs.uv} cache dir)"
+
+                        if command -v pgrep >/dev/null 2>&1 && pgrep -x uv >/dev/null 2>&1; then
+                          echo "Skipping uv cache prune in $uv_cache_dir (active uv process detected)"
+                        else
+                          if [ "$dry_run" = true ]; then
+                            echo "Would prune uv cache in $uv_cache_dir"
+                          else
+                            echo "Pruning uv cache in $uv_cache_dir"
+                            ${lib.getExe pkgs.uv} cache prune
+                          fi
+                        fi
+
+                        remove_dir "$cache_root/pre-commit"
+                        remove_dir "$cache_root/ruff"
+                        ${
+                          if isLinux then
+                            ''
+                              remove_dir "$cache_root/go-build"
+                              remove_dir "$cache_root/nix"
+                            ''
+                          else
+                            ""
+                        }
+                        remove_dir "$HOME/.npm"
+
+                        if [ -d "$HOME/Library/Caches" ]; then
+                          remove_dir "$HOME/Library/Caches/pre-commit"
+                          remove_dir "$HOME/Library/Caches/ruff"
+                        fi
+
+                        if [ "$dry_run" = true ]; then
+                          echo "Cleanup dry run complete; pass --apply or omit --dry-run to remove listed caches."
+                        else
+                          echo "Cleanup complete."
+                        fi
           ''}/bin/cleanup";
         };
       }

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -10,7 +10,7 @@
 #   nix run '.#cleanup' -- --dry-run
 #                             -- preview low-risk local cache cleanup
 #   nix run '.#cleanup'      -- prune low-risk local caches
-#   nix run '.#gc-roots-delete'
+#   nix run '.#gc-roots-delete' -- --apply
 #                             -- attempt Linux auto GC-root cleanup through the dedicated command
 #   nix run '.#storage-report' -- summarize Linux home-directory storage
 #   nix run '.#root-lvm-extend' -- check/extend Ubuntu root LVM free space
@@ -29,6 +29,7 @@
       gh = lib.getExe pkgs.gh;
       jq = lib.getExe pkgs.jq;
       nix = lib.getExe pkgs.nix;
+      cleanupScript = ./../../../bin/cleanup-safe-caches.sh;
       gcRootsReviewScript = ./../../../bin/ubuntu/list-stale-nix-gcroots.sh;
       storagePressureReportScript = ./../../../bin/ubuntu/storage-pressure-report.sh;
       rootLvmExtendScript = ./../../../bin/ubuntu/extend-root-lvm.sh;
@@ -94,101 +95,16 @@
         cleanup = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "cleanup" ''
-                        set -euo pipefail
-
-                        dry_run=false
-
-                        usage() {
-                          cat <<'EOF'
-            Usage: cleanup [--dry-run|--preview|--apply]
-
-            Behavior:
-              Prunes only the repo's explicit safe_cache surface for user-owned caches.
-              --dry-run and --preview list the cleanup actions without removing anything.
-              --apply is accepted for explicit apply mode; omitting a mode also applies.
-            EOF
-                        }
-
-                        while [ "$#" -gt 0 ]; do
-                          case "$1" in
-                            --dry-run | --preview)
-                              dry_run=true
-                              shift
-                              ;;
-                            --apply)
-                              dry_run=false
-                              shift
-                              ;;
-                            -h | --help)
-                              usage
-                              exit 0
-                              ;;
-                            *)
-                              echo "ERROR: Unknown argument: $1" >&2
-                              usage >&2
-                              exit 1
-                              ;;
-                          esac
-                        done
-
-                        remove_dir() {
-                          target="$1"
-                          if [ -d "$target" ]; then
-                            if [ "$dry_run" = true ]; then
-                              echo "Would remove $target"
-                            else
-                              echo "Removing $target"
-                              rm -rf "$target"
-                            fi
-                          else
-                            echo "Skipping missing $target"
-                          fi
-                        }
-
-                        cache_root="''${XDG_CACHE_HOME:-$HOME/.cache}"
-                        uv_cache_dir="$(${lib.getExe pkgs.uv} cache dir)"
-
-                        if command -v pgrep >/dev/null 2>&1 && pgrep -x uv >/dev/null 2>&1; then
-                          echo "Skipping uv cache prune in $uv_cache_dir (active uv process detected)"
-                        else
-                          if [ "$dry_run" = true ]; then
-                            echo "Would prune uv cache in $uv_cache_dir"
-                          else
-                            echo "Pruning uv cache in $uv_cache_dir"
-                            ${lib.getExe pkgs.uv} cache prune
-                          fi
-                        fi
-
-                        remove_dir "$cache_root/pre-commit"
-                        remove_dir "$cache_root/ruff"
-                        ${
-                          if isLinux then
-                            ''
-                              remove_dir "$cache_root/go-build"
-                              remove_dir "$cache_root/nix"
-                            ''
-                          else
-                            ""
-                        }
-                        remove_dir "$HOME/.npm"
-
-                        if [ -d "$HOME/Library/Caches" ]; then
-                          remove_dir "$HOME/Library/Caches/pre-commit"
-                          remove_dir "$HOME/Library/Caches/ruff"
-                        fi
-
-                        if [ "$dry_run" = true ]; then
-                          echo "Cleanup dry run complete; pass --apply or omit --dry-run to remove listed caches."
-                        else
-                          echo "Cleanup complete."
-                        fi
+            set -euo pipefail
+            export CLEANUP_UV=${lib.getExe pkgs.uv}
+            exec ${pkgs.bash}/bin/bash ${cleanupScript} "$@"
           ''}/bin/cleanup";
         };
       }
       // lib.optionalAttrs isLinux {
         # What: Keep Linux stale GC-root cleanup on one explicit command separate from switch.
         # When: Run it directly to attempt guarded stale-root deletion as the current user.
-        # Example: nix run '.#gc-roots-delete'
+        # Example: nix run '.#gc-roots-delete' -- --apply
         gc-roots-delete = {
           type = "app";
           program = "${pkgs.writeShellScriptBin "gc-roots-delete" ''


### PR DESCRIPTION
## Summary

- Document the daily switch and cleanup path.
- Add preview/dry-run paths for cleanup decisions and make `gc-roots-delete` default to dry-run.
- Require explicit `--apply` for stale GC-root unlink/GC and extract safe cache cleanup into a script.

## Verification

- `bash -n bin/cleanup-safe-caches.sh bin/ubuntu/list-stale-nix-gcroots.sh`
- `nix run nixpkgs#shellcheck -- bin/cleanup-safe-caches.sh bin/ubuntu/list-stale-nix-gcroots.sh`
- `nix run nixpkgs#statix -- check nix/flake-parts/modules/apps.nix`
- `nix run nixpkgs#rumdl -- check README.md docs/storage-hygiene.md`
- `nix run .#cleanup -- --dry-run`
- `nix run .#gc-roots-delete`
- `nix run .#check`

Closes #238
