### PR TITLE
fix(worktree): guard issue branch upstreams

### DIFF
--- a/bin/issue-worktree-create
+++ b/bin/issue-worktree-create
@@ -88,11 +88,18 @@ find_worktree_for_branch() {
 ensure_remote_tracking_branch() {
   local branch=$1
   local upstream="origin/${branch}"
+  local actual_upstream
 
   if git show-ref --verify --quiet "refs/heads/${branch}"; then
     git branch --set-upstream-to="${upstream}" "${branch}"
   else
     git branch --track "${branch}" "${upstream}"
+  fi
+
+  actual_upstream=$(branch_upstream "${branch}")
+  if [[ $actual_upstream != "$upstream" ]]; then
+    echo "Error: local issue branch upstream is '${actual_upstream}', expected '${upstream}'." >&2
+    return 1
   fi
 }
 
@@ -105,6 +112,45 @@ same_checkout_path() {
   left_physical=$(cd "$left" && pwd -P)
   right_physical=$(cd "$right" && pwd -P)
   [[ $left_physical == "$right_physical" ]]
+}
+
+branch_upstream() {
+  local branch=$1
+
+  git for-each-ref --format='%(upstream:short)' "refs/heads/${branch}" 2>/dev/null || true
+}
+
+same_name_remote_exists() {
+  local branch=$1
+
+  git show-ref --verify --quiet "refs/remotes/origin/${branch}"
+}
+
+ensure_issue_branch_upstream_invariant() {
+  local branch=$1
+  local upstream
+  local expected_upstream="origin/${branch}"
+
+  upstream=$(branch_upstream "${branch}")
+
+  if [[ -z $upstream ]]; then
+    echo "* Branch upstream: none"
+    return 0
+  fi
+
+  if [[ $upstream == "$expected_upstream" ]] && same_name_remote_exists "${branch}"; then
+    echo "* Branch upstream: ${upstream}"
+    return 0
+  fi
+
+  if [[ $upstream == "$expected_upstream" ]]; then
+    echo "* Clearing stale same-name upstream without remote: ${upstream}"
+  else
+    echo "* Clearing unsafe issue branch upstream: ${upstream}"
+  fi
+
+  git branch --unset-upstream "${branch}"
+  echo "* Branch upstream: none"
 }
 
 run_repo_setup_for_worktree() {
@@ -295,6 +341,13 @@ ${issue_comments}
     esac
 
     worktree_path=$desired_worktree_path
+  fi
+
+  if ! ensure_issue_branch_upstream_invariant "${branch_name}"; then
+    echo "Error: Could not verify issue branch upstream safety for '${branch_name}'. Skipping." >&2
+    echo ""
+    had_failure="true"
+    continue
   fi
 
   if [[ -n $existing_worktree_path ]]; then

--- a/docs/worktree-development.md
+++ b/docs/worktree-development.md
@@ -52,18 +52,23 @@ For the adoption decision behind the current tool stack, see
 6. Otherwise it tries to generate a short kebab-case slug with `claude`.
    If Claude is unavailable or returns nothing usable, it falls back to
    `issue-<number>`.
-7. Existing remote issue branches are configured as upstream. New local issue
-   branches are created from the currently checked-out branch in the invoking
-   checkout. Git resolves that invoking checkout from the current working
-   directory, so running the command from a subdirectory still uses that
-   checkout's root and current branch. Running it from inside an existing
-   linked worktree uses that linked worktree's root and current branch, and any
-   new issue worktree is created under that linked worktree's own
-   `.worktrees/` directory. Run the command from the checkout whose branch and
-   managed worktree root you intend to use. New local issue branches
-   intentionally start without an upstream because Git defaults do not
-   auto-create one. First publication should use an explicit same-name
-   destination refspec:
+7. Existing same-name remote issue branches are configured as upstream. New
+   local issue branches are created from the currently checked-out branch in the
+   invoking checkout. Git resolves that invoking checkout from the current
+   working directory, so running the command from a subdirectory still uses that
+   checkout's root and current branch. Running it from inside an existing linked
+   worktree uses that linked worktree's root and current branch, and any new
+   issue worktree is created under that linked worktree's own `.worktrees/`
+   directory. Run the command from the checkout whose branch and managed
+   worktree root you intend to use. The wrapper enforces the issue branch
+   upstream invariant after branch preparation: a branch may track
+   `origin/<same-branch-name>` only when that remote branch exists; otherwise it
+   starts without an upstream. If local Git configuration or a stale branch
+   setting makes a new or reused local issue branch track `origin/main`,
+   `origin/dev`, or another non-matching upstream, the wrapper clears that
+   upstream before reporting the worktree ready. First publication through
+   lazygit is the expected happy path when lazygit publishes to `origin` with
+   the same branch name. The equivalent command-line shape is:
    `git push --set-upstream origin HEAD:refs/heads/<same-branch-name>`.
 8. It resolves an existing branch worktree with `git worktree list
    --porcelain`. If no worktree exists, it creates one under `.worktrees/`
@@ -95,9 +100,21 @@ For the adoption decision behind the current tool stack, see
    exists.
 
 Before asking a human to publish an issue branch, verify that the current
-branch is the intended feature branch, that any existing upstream is
-`origin/<same-branch-name>`, and that the remote destination is neither
-`refs/heads/main` nor `refs/heads/dev`.
+branch is the intended feature branch, that any existing upstream is either
+absent or `origin/<same-branch-name>`, and that the remote destination is
+neither `refs/heads/main` nor `refs/heads/dev`.
+
+```sh
+git branch --show-current
+git status --short --branch
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+```
+
+For a brand-new local issue branch, the upstream command should fail with "no
+upstream configured" until first publication. In lazygit, check the branch panel
+or status header before publishing: the branch should show no upstream, or it
+should show `origin/<same-branch-name>` for an already existing remote issue
+branch.
 
 Local Git config is only a safety default, not a remote trust boundary. Protect
 shared remote branches such as `main` and `dev` with GitHub rulesets or branch

--- a/skills/agent-harness-engineering/references/workspace-worktree-workflow.md
+++ b/skills/agent-harness-engineering/references/workspace-worktree-workflow.md
@@ -57,10 +57,13 @@ Expect it to:
 - refresh `main`
 - reuse `origin/issue-<number>` when present, otherwise reuse the first
   `origin/issue-<number>-*` branch when present
-- set existing remote issue branches as upstream
+- set existing same-name remote issue branches as upstream
 - leave new local issue branches without an upstream until explicit same-name
   publication with:
   `git push --set-upstream origin HEAD:refs/heads/<same-branch-name>`
+- clear unsafe or stale issue branch upstreams after branch preparation. Issue
+  branches must not track `origin/main`, `origin/dev`, or any other upstream
+  except an existing `origin/<same-branch-name>` branch.
 - create a new linked worktree when needed
 - copy the source checkout's `.envrc` when available and the checked-out branch
   did not already provide one, including for non-Nix repositories
@@ -103,6 +106,8 @@ For a reused remote issue branch, the upstream must be
 tracks `origin/main`, `origin/dev`, or another non-issue upstream. New local
 issue branches created by the wrapper intentionally have no upstream until
 explicit publication; verify they started from current `main` before editing.
+First publication from lazygit is allowed and expected when it publishes to
+`origin/<same-branch-name>`.
 
 Before creating a PR, verify `origin/<feature-branch>` exists, the PR base is
 the intended base branch, and the PR head is the feature branch.


### PR DESCRIPTION
## Summary

- enforce issue branch upstream safety in `bin/issue-worktree-create`
- keep `origin/<same-branch-name>` tracking only when that remote branch exists
- document lazygit same-name publication and upstream verification in worktree guidance

## Validation

- `bash -n bin/issue-worktree-create`
- `nix run nixpkgs#shellcheck -- bin/issue-worktree-create`
- unsafe-upstream smoke test with `branch.autoSetupMerge=always`
- same-name remote branch smoke test
- `bash scripts/validation/validate-skill-waza.sh skills/agent-harness-engineering/SKILL.md`
- `bash scripts/validation/validate-skill-private-content.sh skills/agent-harness-engineering/references/workspace-worktree-workflow.md docs/worktree-development.md bin/issue-worktree-create`
- `git diff --check`
- `nix flake check --print-build-logs`

Closes #264