### PR TITLE
ci: separate Nix cache keys per installer (#267)

### DIFF
--- a/.github/workflows/ci-nix-quick-install.yaml
+++ b/.github/workflows/ci-nix-quick-install.yaml
@@ -46,13 +46,11 @@ jobs:
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          primary-key: nix-quick-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-quick-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run nix flake check
         run: nix flake check --print-build-logs
 
-      - name: Run gitleaks history scan
-        run: nix develop .#ci --command gitleaks detect --verbose --redact
-
-      - name: Run betterleaks history scan
-        run: nix develop .#ci --command betterleaks git --verbose --redact
+      - name: Run leak history scans
+        run: nix develop .#ci --command bash -c 'gitleaks detect --verbose --redact && betterleaks git --verbose --redact'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,8 @@ jobs:
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          primary-key: nix-daemon-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-daemon-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run nix flake check
         run: nix flake check --print-build-logs
@@ -56,8 +57,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: nix run nixpkgs#gh -- skill publish --dry-run
 
-      - name: Run gitleaks history scan
-        run: nix develop .#ci --command gitleaks detect --verbose --redact
-
-      - name: Run betterleaks history scan
-        run: nix develop .#ci --command betterleaks git --verbose --redact
+      - name: Run leak history scans
+        run: nix develop .#ci --command bash -c 'gitleaks detect --verbose --redact && betterleaks git --verbose --redact'


### PR DESCRIPTION
Closes #267.

## Problem

`ci.yaml` fails `nix flake check` with `opening lock file "/nix/var/nix/temproots/<pid>": Permission denied`, while `ci-nix-quick-install.yaml` passes on the same commit.

Both workflows used an identical `cache-nix-action` primary key, so the daemon (`cachix/install-nix-action`) and single-user (`nix-quick-install-action`) jobs shared one cache namespace. A `runner`-owned single-user `/nix` restored into the daemon job leaves the unprivileged client unable to write `temproots`. `install-nix-action` is already pinned to the latest release, so a version bump is not the fix.

## Change

- `ci.yaml`: cache key prefix `nix-daemon-*` + `restore-prefixes-first-match`.
- `ci-nix-quick-install.yaml`: cache key prefix `nix-quick-*` + `restore-prefixes-first-match`.
- Both: combine the gitleaks + betterleaks steps into a single `nix develop .#ci` entry.

Distinct prefixes eliminate cross-installer contamination (root fix). The prefix fallback keeps cache hits warm when `hashFiles` changes instead of forcing a cold rebuild.

## Verification

Verifiable only on the runner. Both `ci` and `ci-nix-quick-install` must go green on this PR before merge.