### PR TITLE
ci: restore step parity in ci-nix-quick-install (#269)

### DIFF
--- a/.github/workflows/ci-nix-quick-install.yaml
+++ b/.github/workflows/ci-nix-quick-install.yaml
@@ -52,5 +52,10 @@ jobs:
       - name: Run nix flake check
         run: nix flake check --print-build-logs
 
+      - name: Validate Agent Skills spec conformance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: nix run nixpkgs#gh -- skill publish --dry-run
+
       - name: Run leak history scans
         run: nix develop .#ci --command bash -c 'gitleaks detect --verbose --redact && betterleaks git --verbose --redact'


### PR DESCRIPTION
Closes #269.

## Problem

The two workflows are an installer A/B test (`cachix/install-nix-action` daemon vs `nixbuild/nix-quick-install-action` single-user), but `ci.yaml` runs a `Validate Agent Skills spec conformance` step that `ci-nix-quick-install.yaml` lacks. Any runtime difference reflects unequal work, not the installer, so the comparison is invalid.

## How it drifted

- `6bb8aeef` forked the experiment from `ci.yaml` as "identical except the installer" (when `ci.yaml` had no skill step).
- `4cf8e3b8` later added `gh skill publish --dry-run` to `ci.yaml` only, so the copy silently drifted.

## Change

Add the skill-conformance step to `ci-nix-quick-install.yaml`. The two workflows now differ only by the `Install Nix` step, the name, and the cache-key prefix (necessarily derived from the installer). The step is kept in both — it is real validation not covered by the local pre-commit skill checks.

## Verification

`diff ci.yaml ci-nix-quick-install.yaml` shows only name / Install Nix / cache-prefix differing. The step has never run under `nix-quick-install-action`; both jobs must go green on this PR.