### PR TITLE
ci: source gh from the .#ci devshell for the skill check (#271)

### DIFF
--- a/.github/workflows/ci-nix-quick-install.yaml
+++ b/.github/workflows/ci-nix-quick-install.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Validate Agent Skills spec conformance
         env:
           GH_TOKEN: ${{ github.token }}
-        run: nix run nixpkgs#gh -- skill publish --dry-run
+        run: nix develop .#ci --command gh skill publish --dry-run
 
       - name: Run leak history scans
         run: nix develop .#ci --command bash -c 'gitleaks detect --verbose --redact && betterleaks git --verbose --redact'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Validate Agent Skills spec conformance
         env:
           GH_TOKEN: ${{ github.token }}
-        run: nix run nixpkgs#gh -- skill publish --dry-run
+        run: nix develop .#ci --command gh skill publish --dry-run
 
       - name: Run leak history scans
         run: nix develop .#ci --command bash -c 'gitleaks detect --verbose --redact && betterleaks git --verbose --redact'

--- a/flake.nix
+++ b/flake.nix
@@ -146,9 +146,11 @@
                 ${config.pre-commit.installationScript}
               '';
             };
-            # CI environment (no pre-commit hooks needed, but includes gitleaks for history scan)
+            # CI environment (no pre-commit hooks needed; gitleaks for history
+            # scan, gh for the skill spec-conformance check)
             ci = pkgs.mkShell {
               packages = [
+                pkgs.gh
                 pkgs.gitleaks
               ]
               ++ pkgs.lib.optionals (config.packages ? betterleaks) [


### PR DESCRIPTION
Closes #271.

## Problem

The `Validate Agent Skills spec conformance` step takes ~22s in both workflows. The step log shows the time is a `nixpkgs-unstable` fetch, not validation:

```
unpacking 'https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz' into the Git cache...
Dry run complete. Use without --dry-run to publish.
```

`nix run nixpkgs#gh` resolves the flake-registry nixpkgs (unstable), a separate uncached input from `flake.lock`, so it re-downloads every run.

## Change

- `flake.nix`: add `pkgs.gh` to the `.#ci` devShell.
- both workflows: skill step now runs `nix develop .#ci --command gh skill publish --dry-run`, so `gh` comes from the locked flake and is served from the warm store cache.

Changed identically in `ci.yaml` and `ci-nix-quick-install.yaml` to preserve the installer-comparison parity from #269/#270.

## Verification

Local: pinned `gh` is 2.96.0 and provides `gh skill publish`; `nix flake check` passes; `diff` of the two workflows shows only name / Install Nix / cache-prefix differing. CI: both jobs green; the skill step should drop from ~22s to ~1-2s once the `.#ci` cache is warm (the first run rebuilds the closure since `flake.nix` changed the hash).