### PR TITLE
release: create a GitHub Release on tag events (#273)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,8 @@ jobs:
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2 # zizmor: ignore[cache-poisoning] tag-only workflow; untrusted PRs cannot reach this job.
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          primary-key: nix-daemon-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-daemon-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run nix flake check
         run: nix flake check --print-build-logs
@@ -47,10 +48,10 @@ jobs:
       - name: Validate Agent Skills publish dry-run
         env:
           GH_TOKEN: ${{ github.token }}
-        run: nix run nixpkgs#gh -- skill publish --dry-run
+        run: nix develop .#ci --command gh skill publish --dry-run
 
-      - name: Publish Agent Skills catalog
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}
-        run: nix run nixpkgs#gh -- skill publish --tag "$TAG_NAME"
+        run: nix develop .#ci --command gh release create "$TAG_NAME" --generate-notes --verify-tag


### PR DESCRIPTION
## Problem

A `v*` tag push never produces a GitHub Release (`/releases` is empty), despite tags `v0.1.0`-`v0.1.3` existing. The release workflow has three issues:

1. **Fatal (tag collision):** the publish step runs `gh skill publish --tag "$TAG_NAME"`, but `gh skill publish --tag` *creates* the tag as part of making the Release. The workflow triggers on tag events, so the tag already exists -> `tag vX already exists; choose a different version` -> exit 1, before any Release is created.
2. **temproots permission (intermittent):** the cache step still uses the old shared key `nix-${runner.os}-${runner.arch}-...`, so it restores a stale single-user-contaminated cache into this daemon-mode job (same root cause fixed for ci in #268). Caused the v0.1.2 failure.
3. **Slow + topic 403:** uses `nix run nixpkgs#gh` (re-fetches nixpkgs-unstable each run, ~22s; fixed for ci in #271), and the topic-add sub-step returns HTTP 403 (job token is `contents: write` only).

## Fix (keep the tag-based UX)

`gh skill publish --tag` cannot be used with a pre-existing tag. Keep the tag trigger and split its responsibilities:

- Keep `nix flake check`.
- Validate: `nix develop .#ci --command gh skill publish --dry-run` (spec conformance; cached gh).
- Release: `nix develop .#ci --command gh release create "$TAG_NAME" --generate-notes --verify-tag` (creates the Release for the existing tag).
- Cache key -> `nix-daemon-*` + `restore-prefixes-first-match` (shares the warm daemon cache with ci).
- Drop the failing topic-add step; add the `agent-skills` topic once manually.

Skill discoverability comes from the repo topic + `SKILL.md` files at the tagged ref; the Release is the version marker, so `gh release create` + a one-time topic is equivalent to `gh skill publish` for consumers.

## Notes

- Tags `v0.1.0`-`v0.1.3` are immutable (release-tags ruleset blocks deletion) and left as-is; first real release is `v0.1.4`.
- The release workflow triggers only on tag events, so PR CI will not exercise it. End-to-end verification is the `v0.1.4` release after merge.

## Verification

Local: `nix develop .#ci --command gh skill publish --dry-run` passes; `nix flake check` passes; actionlint/ghalint pass. Post-merge: cut `v0.1.4`, confirm the run is green and a Release appears on `/releases`.
