### PR TITLE
harness: unify Claude/Codex native scrollback + deny AskUserQuestion, codify parity principle, catch up 2.1.196-2.1.202 / 0.142.x

### DIFF
--- a/config/vde/layout.yml
+++ b/config/vde/layout.yml
@@ -35,7 +35,7 @@ presets:
           focus: true
         - name: agent
           title: agent
-          command: codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=high
+          command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=high
           delay: 500
 
   messenger-claude:
@@ -69,7 +69,7 @@ presets:
           focus: true
         - name: messenger
           title: messenger
-          command: codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
+          command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
           delay: 500
 
   preset-p:
@@ -85,11 +85,11 @@ presets:
           panes:
             - name: orchestrator
               title: orchestrator
-              command: codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
+              command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
               delay: 500
             - name: worker
               title: worker
-              command: codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
+              command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
               delay: 500
             - name: worker-alt
               title: worker-alt
@@ -100,7 +100,7 @@ presets:
           panes:
             - name: guardian
               title: guardian
-              command: codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=high
+              command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=high
               delay: 500
             - name: critic
               title: critic
@@ -139,5 +139,5 @@ presets:
               delay: 500
             - name: critic
               title: critic
-              command: codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
+              command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
               delay: 500

--- a/nix/home-manager/agents/claude/default.nix
+++ b/nix/home-manager/agents/claude/default.nix
@@ -58,6 +58,12 @@ let
       CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "70";
       CLAUDE_CODE_DISABLE_AUTO_MEMORY = "true";
       CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "1";
+      # Keep the conversation in the terminal's native scrollback (tmux
+      # copy-mode / wheel) instead of the fullscreen alt-screen renderer, so
+      # long sessions can be scrolled back in tmux. Trades away alt-screen
+      # mouse support and auto-copy; adopted for tmux-first operation.
+      # (v2.1.132; see claude-code.md §11.1)
+      CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1";
       CLAUDE_CODE_DISABLE_FAST_MODE = "1";
       CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY = "true";
       CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "true";
@@ -110,6 +116,11 @@ let
     outputStyle = "Explanatory";
     permissions = {
       deny = deniedBash.claudeCode.denyPermissions ++ [
+        # v2.1.200 made AskUserQuestion dialogs no longer auto-continue by
+        # default, so in headless / tmux-a2a-postman panes a question stalls
+        # the turn indefinitely with no human to answer. Deny the tool so the
+        # agent proceeds on its own judgement instead. (see claude-code.md §11.1)
+        "AskUserQuestion"
         "Read(**/*key*)"
         "Read(**/*token*)"
         "Read(.env*)"

--- a/skills/dotfiles/references/agent-config-philosophy.md
+++ b/skills/dotfiles/references/agent-config-philosophy.md
@@ -115,8 +115,28 @@ When per-engine config is unavoidable:
 When a feature is exclusive to one engine, treat that as a cost to
 amortise, not a capability to lean on.
 
+The active form of this principle: when one engine ships a behavior the other
+lacks and it makes the two behave differently, neutralize it — disable the
+feature, or reproduce its effect on the other engine — so a worker behaves the
+same regardless of which engine runs it. A vendor-only feature that cannot be
+neutralized is recorded as an accepted asymmetry, not left as silent drift.
+Parity is of intent, not mechanism: the same outcome may be delivered by an env
+var on one engine and a launch flag on the other. The living map of what is
+aligned, still open, or intentionally different is the parity matrix in
+`skills/dotfiles/references/operating-concepts.md` §5.
+
 What this looks like in the current repo:
 
+- Interfering vendor defaults are disabled in matched pairs so both engines
+  stay quiet and predictable: fast mode, telemetry/analytics, feedback surveys,
+  terminal-title writes, and co-author attribution are all off on both.
+- Where only one engine has the feature, it is neutralized on that side alone:
+  Claude's `AskUserQuestion` is denied (Codex has no such tool), and Claude's
+  built-in git instructions are disabled (`includeGitInstructions=false`) so the
+  `collaboration` skill is the single git authority on both.
+- The same intent can take different mechanisms: native terminal scrollback is
+  an env var on Claude (`CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`) and a launch
+  flag on Codex (`--no-alt-screen` in `config/vde/layout.yml`).
 - Hooks are configured for both engines with the same five jobs:
   context injection, deny enforcement, observation, handoff save,
   handoff reload. The hook surfaces differ but the intent mirrors.
@@ -150,6 +170,9 @@ What to avoid:
 - Adding a setting only because one engine ships a knob, without
   checking whether the same effect can be achieved through a prompt
   or through the shared SSOT.
+- Adding a setting to one engine without checking the other side. A one-sided
+  toggle silently creates the asymmetry this principle exists to prevent; pair
+  it, or record it in the parity matrix (operating-concepts.md §5).
 
 ## 2. How These Principles Were Applied Recently
 

--- a/skills/dotfiles/references/changelog-tracking.md
+++ b/skills/dotfiles/references/changelog-tracking.md
@@ -148,6 +148,30 @@ This reference preserves older review notes that support current
 
 ## 2. Version Notes
 
+- v2.1.202: `/review` reverted to a fast single-pass review (use
+  `/code-review <level> <pr#>` for the multi-agent pass); skill re-invocation no
+  longer duplicates its instructions in context; dynamic workflow-size `/config`
+  setting; many background-agent / Remote Control / workflow-parse fixes.
+  User-invoked or automatic; no source change.
+- v2.1.201: Claude Sonnet 5 sessions drop the mid-conversation system role for
+  harness reminders. Informational.
+- v2.1.200: **AskUserQuestion dialogs no longer auto-continue by default** (opt
+  into an idle timeout via `/config`) - drove the `AskUserQuestion` deny in
+  `claude/default.nix` (see claude-code.md §11.1), since headless postman panes
+  have no human to answer. "default" permission mode renamed to "Manual"
+  (`default` / `"defaultMode": "manual"` still accepted; repo runs bypass, no
+  change). tmux 3.4+ synchronized-output flicker fix (automatic).
+- v2.1.199: stacked slash-skill loading (up to 5 leading skills); TLS / stream /
+  subagent error-surfacing fixes; background-agent daemon self-kill and
+  cold-start fixes. Automatic; no config.
+- v2.1.198: subagents run in the background by default; Explore inherits the
+  main model capped at opus; `/dataviz` bundled skill; background-agent
+  `Notification` hook events. Matches current usage; no source change.
+- v2.1.197: Claude Sonnet 5 introduced as the default model (1M-token context).
+  Repo pins the model at launch, so informational.
+- v2.1.196: org default models; `claude mcp list`/`get` no longer spawn
+  self-approved `.mcp.json` servers (security); background-job transcript-probe
+  data-loss fix. Automatic; no config.
 - v2.1.195: `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` for fullscreen mouse
   click/drag/hover opt-out; **hook matcher fix for hyphenated identifiers**
   now exact-matches (`mcp__brave-search__.*` needed for all tools from such a

--- a/skills/dotfiles/references/claude-code.md
+++ b/skills/dotfiles/references/claude-code.md
@@ -233,7 +233,7 @@ When adding/removing files in skills/, agents/, or commands/:
 
 ## 11. Optimization Tracking
 
-Last reviewed Claude Code version: v2.1.195 (2026-06-29)
+Last reviewed Claude Code version: v2.1.202 (2026-07-07)
 
 ### 11.1. Applied Optimizations
 
@@ -292,6 +292,18 @@ Last reviewed Claude Code version: v2.1.195 (2026-06-29)
   v2.1.195 hyphenated hook matcher exact-match fix does not affect this repo.
   Keep plugin, auto-mode, sandbox, and Remote/agent-team additions as
   user-invoked/product defaults unless a measured harness need appears.
+- [x] `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1"` (v2.1.132) - keeps the
+  conversation in the terminal's native scrollback instead of the fullscreen
+  alt-screen renderer, so tmux copy-mode / wheel can scroll back over long
+  sessions. Adopted 2026-07-07 for tmux-first operation; trades away
+  alt-screen mouse support and auto-copy. Moved up from §11.2.2 deferred.
+- [x] `AskUserQuestion` denied via `permissions.deny` - v2.1.200 changed these
+  dialogs to no longer auto-continue by default, so a question in a headless
+  or `tmux-a2a-postman` pane stalls the turn indefinitely with no human to
+  answer. Denying the tool makes the agent proceed on its own judgement.
+  Alternative considered and rejected: opt into an idle timeout via `/config`
+  (keeps the tool for interactive sessions) - postman panes are the common
+  case here, so a hard deny is the right default.
 
 ### 11.2. Pending Considerations
 
@@ -374,10 +386,10 @@ Last reviewed Claude Code version: v2.1.195 (2026-06-29)
 - [ ] `settings.autoMode.hard_deny` rules (v2.1.136) - auto-mode classifier
   hard deny that cannot be allow-overridden. We don't use auto mode, but
   worth tracking if we ever migrate away from `dontAsk`
-- [ ] `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` env (v2.1.132) - keep the
-  conversation in the terminal's native scrollback instead of the fullscreen
-  alt-screen renderer. Quality-of-life tradeoff with mouse support and
-  auto-copy; defer until measured
+- [x] `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` env (v2.1.132) - ADOPTED
+  2026-07-07 (see §11.1). Keeps the conversation in the terminal's native
+  scrollback instead of the fullscreen alt-screen renderer. Accepted the
+  mouse-support / auto-copy tradeoff for tmux-first operation.
 - [ ] `CLAUDE_CODE_SESSION_ID` in Bash tool subprocess env (v2.1.132) -
   enables session-aware Bash scripts. No current consumer in
   `scripts/`; flag for future hook design
@@ -445,6 +457,32 @@ Last reviewed Claude Code version: v2.1.195 (2026-06-29)
 - [x] Background-agent, worktree, MCP, plugin, skill hot-reload, and
   subagent-depth fixes through v2.1.195 - mostly product reliability. Current
   harness should benefit automatically; no source change.
+
+#### 11.2.4. v2.1.196 -> v2.1.202 candidates (added 2026-07-07)
+
+- [x] AskUserQuestion no longer auto-continues by default (v2.1.200) - acted
+  on: denied the tool via `permissions.deny` (see §11.1) because headless
+  postman panes have no human to answer.
+- [x] `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN` (v2.1.132, revisited) - adopted
+  (see §11.1).
+- [x] tmux 3.4+ synchronized-output flicker fix (v2.1.200) - automatic, no
+  config; complements the alt-screen scrollback change for tmux-first use.
+- [ ] "default" permission mode renamed to "Manual" (v2.1.200) -
+  informational. `default` / `"defaultMode": "manual"` both still accepted;
+  this repo runs bypass permissions, so no config change.
+- [ ] Claude Sonnet 5 is now the default model (v2.1.197) - informational;
+  model is pinned at launch (`--model opus`), so the default does not apply.
+- [x] Subagents background-by-default; Explore inherits opus (v2.1.198) -
+  matches current usage, no config. `/dataviz` ships as a bundled skill.
+- [x] `claude mcp list`/`get` no longer spawn self-approved `.mcp.json`
+  servers (v2.1.196, security) - beneficial automatically; no config.
+- [x] Skill re-invocation no longer duplicates instructions in context
+  (v2.1.202) - product fix; benefits sessions automatically.
+- [ ] `/review` reverted to single-pass; `/code-review <level> <pr#>` for the
+  multi-agent pass (v2.1.202) - user-invoked commands only; flag for
+  orchestrator-runbook awareness. Remaining background-agent / Remote Control /
+  workflow-parse fixes through v2.1.202 are product reliability; no source
+  change.
 
 For decision log ("Not Adopting") and per-version changelog,
 see [Changelog Tracking](changelog-tracking.md).

--- a/skills/dotfiles/references/codex-cli.md
+++ b/skills/dotfiles/references/codex-cli.md
@@ -209,13 +209,17 @@ Check the following when editing postman prompt blocks or `config.toml`:
 
 ## 9. Optimization Tracking
 
-Last reviewed Codex CLI version: v0.142.3 (2026-06-29)
+Last reviewed Codex CLI version: v0.142.5 (2026-07-07)
 
-### 9.1. Release Catch-up (v0.136.0 -> v0.142.3)
+### 9.1. Release Catch-up (v0.136.0 -> v0.142.5)
 
-Stable releases through the locally installed `codex-cli 0.142.3` add mostly
+Stable releases through the locally installed `codex-cli 0.142.5` add mostly
 product/runtime capabilities rather than required dotfiles config changes:
 
+- v0.142.5 is a maintenance patch that redacts full Responses WebSocket request
+  payloads from trace logs (openai/codex #30771). No user-facing behavior
+  change; no config change.
+- v0.142.4 has no user-facing changes.
 - v0.142.3 is a maintenance-only patch with no user-facing changes after
   v0.142.2.
 - v0.142.2 turns MCP tool search on by default when supported, adds opt-in

--- a/skills/dotfiles/references/operating-concepts.md
+++ b/skills/dotfiles/references/operating-concepts.md
@@ -255,6 +255,34 @@ The result is parity of intent rather than byte-for-byte sameness. The repo is
 trying to make a worker on Claude and a worker on Codex behave comparably under
 the same local expectations.
 
+### 5.1. Parity matrix (living)
+
+This is the concrete form of the "make the parity boundary explicit" direction
+in section 8.2, and the map referenced by `agent-config-philosophy.md` §1.3.
+"Aligned" means a worker behaves the same regardless of engine; the mechanism
+may differ (an env var on one side, a launch flag on the other). Keep this table
+current whenever an interfering vendor default is neutralized on either engine.
+
+| Intent                      | Claude                                            | Codex                                   | Status                                |
+| --------------------------- | ------------------------------------------------- | --------------------------------------- | ------------------------------------- |
+| Co-author attribution off   | `attribution.commit/pr=""`                        | `command_attribution="disable"`         | aligned                               |
+| Fast mode off               | `CLAUDE_CODE_DISABLE_FAST_MODE=1`                 | `features.fast_mode=false`              | aligned                               |
+| Telemetry / analytics off   | `CLAUDE_CODE_ENABLE_TELEMETRY=false`              | `analytics.enabled=false`               | aligned                               |
+| Feedback survey off         | `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=true`        | `feedback.enabled=false`                | aligned                               |
+| Terminal-title writes off   | `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=true`         | `tui.terminal_title=[]`                 | aligned                               |
+| Autocompact at 70%          | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=70`              | `model_auto_compact_token_limit` at 70% | aligned                               |
+| MCP tool search on          | `ENABLE_TOOL_SEARCH=auto`                         | default-on (v0.142.2)                   | aligned                               |
+| Native TUI scrollback       | `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` (env)    | `--no-alt-screen` (VDE launch flag)     | aligned, different mechanism          |
+| Effort pinned, no auto-swap | `DISABLE_ADAPTIVE_THINKING=1` + launch `--effort` | launch `model_reasoning_effort`         | aligned, different mechanism          |
+| Single git authority        | `includeGitInstructions=false`                    | no built-in git instructions            | aligned, Claude-only knob             |
+| Ask-to-continue tool        | `AskUserQuestion` denied                          | no equivalent tool                      | aligned, Claude-only                  |
+| Auto-memory off             | `CLAUDE_CODE_DISABLE_AUTO_MEMORY=true`            | not yet disabled                        | open                                  |
+| Bundled skills              | on; `disableBundledSkills` available              | on; disable available (v0.114.0)        | accepted; revisit if surfaces diverge |
+
+Intentional product-surface differences (not drift): Claude MCP servers vs Codex
+Apps (both fed from `shared/mcp-servers.nix`), `outputStyle` vs `personality`,
+and Codex sandbox surfaces (`network_access`, `web_search`).
+
 ## 6. The review stack is part of the operating concept
 
 This repo treats review as a built artifact, not ad hoc human ceremony.


### PR DESCRIPTION
Closes #275

## What

Homogenize Claude Code and Codex behavior, write down the principle that drives it, and record the runtime catch-up that surfaced the changes.

### 1. Native TUI scrollback on both engines
- Claude: `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` (env in `claude/default.nix`).
- Codex: `--no-alt-screen` added to every Codex launch in `config/vde/layout.yml` (inline mode preserves terminal scrollback). Codex exposes no config.toml equivalent, so the launch flag is the mechanism.
- Same intent, different mechanism (env vs launch flag) — the canonical parity case.

### 2. Deny AskUserQuestion (Claude-only tool)
- v2.1.200 stopped these dialogs auto-continuing by default, so a question in a headless / `tmux-a2a-postman` pane would stall the turn with no human to answer. Denied via `permissions.deny`. Codex has no equivalent tool.

### 3. Codify the parity principle
- `agent-config-philosophy.md` §1.3: sharpen from "avoid vendor features" to the **active** form — neutralize interfering vendor-only features (disable, or reproduce on the other engine) so a worker behaves the same on either engine; record un-neutralizable ones as accepted asymmetry. Adds a guard against one-sided toggles.
- `operating-concepts.md` §5.1: **living parity matrix** (the concrete form of §8.2) listing aligned / open / accepted knobs.

### 4. Catch-up tracking (Claude 2.1.196-2.1.202, Codex 0.142.4-0.142.5)
- `claude-code.md`, `codex-cli.md`, `changelog-tracking.md`: bump Last reviewed, log decisions, per-version notes.

## Known-open follow-up (tracked, not in this PR)
- Auto-memory asymmetry: Claude `CLAUDE_CODE_DISABLE_AUTO_MEMORY=true`, Codex memory not yet disabled. Bundled skills left on both. Recorded as `open` / `accepted` in the parity matrix.

## Verification
- pre-commit: all gates green across commits (statix, deadnix, treefmt, check-yaml, markdown-formatter, rumdl, waza, private-content-scan).
- `nix flake check`: all checks passed (run before the VDE/docs commits, which do not touch flake evaluation).
- Behavior takes effect after `nix run '.#switch'` + a session restart (Claude env) / next Codex launch (VDE flag).

## Commits
- `e6baea93` feat(claude): native TUI scrollback + deny AskUserQuestion in headless panes
- `438b5d18` docs(harness): catch up Claude 2.1.196-2.1.202 and Codex 0.142.4-0.142.5
- `60a15a46` feat(vde): launch Codex in inline mode for scrollback parity with Claude
- `0481de69` docs(harness): codify active Claude/Codex parity principle + living matrix