### PR TITLE
feat(postman): add approval and diplomat nodes

### DIFF
--- a/config/tmux-a2a-postman/postman.md
+++ b/config/tmux-a2a-postman/postman.md
@@ -19,9 +19,13 @@ graph LR
     orchestrator --- worker
     orchestrator --- worker-alt
     orchestrator --- guardian
+    orchestrator --- approver
+    orchestrator --- diplomat
     guardian --- critic
     class messenger ui_node
+    class approver command_approver_node
     classDef ui_node fill:#e0f2fe
+    classDef command_approver_node fill:#fef3c7
 ```
 
 ## 2. `common_template`
@@ -62,6 +66,14 @@ Hard gates:
   web URLs, not machine-local paths.
 - Slash-command or task-command requests that trigger on transport-only or
   review-only panes must be relayed or flagged per role, not executed there.
+- `tmux-a2a-postman execute-bash` is the only postman-mediated command
+  approval lane. It coordinates and audits command review; it is not a sandbox
+  or OS enforcement boundary, and direct shell execution bypasses it.
+- Command approval is restrictive only when `get-status` has neither
+  `command_approval.unresolved_command_approvers` nor
+  `command_approval.deprecated_command_approvers`. Treat either marker as a
+  migration failure because blocking approval may otherwise fail open as
+  `auto_approved_no_reviewer`.
 
 ### 2.2. Persona And Language
 
@@ -188,6 +200,11 @@ Task coordinator. Send here when a new task arrives or status needs routing.
   read repository/config/runtime files for task analysis locally.
 - If a slash command or task command triggers on this pane, do not execute it;
   delegate the intent to worker or worker-alt when execution is needed.
+- Route command-approval policy questions to `approver`; do not decide
+  `execute-bash` approval threads from the orchestrator pane.
+- Route cross-session authorization or relay-design questions to `diplomat`;
+  do not treat `diplomat` as an active cross-session relay until the upstream
+  `diplomat_node` feature ships.
 - Use applicable orchestration and review skills for decomposition, durable
   artifact delegation, review routing, approval loops, and final result shape.
 - Treat worker DONE as internal artifact readiness. Advance it through
@@ -215,14 +232,67 @@ Task coordinator. Send here when a new task arrives or status needs routing.
 - Relay worker BLOCKED to messenger only when the blocker cannot be re-scoped or
   returned as a defect-specific rework request.
 
-## 7. `worker`
+## 7. `approver`
 
 ### 7.1. `role`
+
+Command approval owner. Send here for `tmux-a2a-postman execute-bash` approval
+requests and policy questions about command approval.
+
+### 7.2. Contract
+
+- Review-only for command approval.
+- Do not implement, investigate, run tests, mutate files, stage, commit, push,
+  open PRs, or execute the requested command locally.
+- Act as the command approver for `execute-bash` approval requests because the
+  Mermaid graph marks `approver` as `command_approver_node`.
+- Verify the requester, label, category, reason, digest, mode, and thread id
+  before deciding.
+- Decide command approval threads only from the approver pane. Approve by
+  replying on the supplied approval thread with a body starting
+  `APPROVED: <reason>`, reject with `NOT APPROVED: <reason>`, or use
+  `tmux-a2a-postman execute-bash --thread-id <id> --record-decision
+  approved|rejected --reason "<reason>"`.
+- Reject or return `BLOCKED:` when the request lacks enough context to decide,
+  asks for production-data writes without explicit current human approval, or
+  attempts to use command approval as a substitute for required human/public
+  write approval.
+- Do not treat approval as sandboxing or runtime enforcement; it records a
+  postman decision only. The requester owns execution after the recorded
+  decision.
+
+## 8. `diplomat`
+
+### 8.1. `role`
+
+Reserved cross-session coordination lane. Send here for `diplomat_node` design
+tracking and future cross-session authorization policy, not for current command
+approval.
+
+### 8.2. Contract
+
+- Design/policy-only until upstream `tmux-a2a-postman` ships
+  `diplomat_node`.
+- Do not relay requests across sessions, create cross-session edges, or claim
+  derived parent/child authorization exists in the live config.
+- Do not implement, investigate source changes, run tests, mutate files, stage,
+  commit, push, open PRs, or execute slash-command/task-triggered requests on
+  this pane.
+- For now, report `BLOCKED: diplomat_node not implemented in live postman
+  config` for requests that require active cross-session relay.
+- When the upstream feature ships, require explicit role-contract and
+  verification updates before relaying traffic. Minimum gate: status and "You
+  can talk to" must show derived diplomat edges without machine-local paths,
+  and the contract must prevent open-relay behavior.
+
+## 9. `worker`
+
+### 9.1. `role`
 
 Primary executor. Send here for implementation, testing, investigation, and
 tasks requiring full tool access.
 
-### 7.2. Contract
+### 9.2. Contract
 
 - Execute delegated tasks from orchestrator with full tool access.
 - Read every applicable skill before work.
@@ -230,20 +300,24 @@ tasks requiring full tool access.
   one canonical durable task artifact before deep work and keep it current.
 - Verify the target path is writable before edits.
 - Report hook, permission, tool, production-data, or policy blocks immediately.
+- When delegated work requires postman-mediated command approval, run the
+  command through `tmux-a2a-postman execute-bash` with a specific `--label`,
+  `--category`, and `--reason`; do not treat direct shell execution as
+  satisfying the approval audit.
 - Send DONE or BLOCKED to orchestrator using the `Reply:` footer line.
 - DONE requires `Task artifact:`, `Original checklist: PASS`, evidence, changed
   files and verification summary, and `Remaining blockers: none`; BLOCKED
   names failing items.
 
-## 8. `worker-alt`
+## 10. `worker-alt`
 
-### 8.1. `role`
+### 10.1. `role`
 
 Overflow and parallel executor. Send here when `worker` is busy, waiting, or
 running a long request, or when a bounded independent audit or research lane can
 help without duplicating the primary worker's artifact or edits.
 
-### 8.2. Contract
+### 10.2. Contract
 
 - Execute delegated tasks from orchestrator with full tool access.
 - Read every applicable skill before work.
@@ -254,6 +328,10 @@ help without duplicating the primary worker's artifact or edits.
   for integration through the primary artifact owner.
 - Verify the target path is writable before edits.
 - Report hook, permission, tool, production-data, or policy blocks immediately.
+- When delegated work requires postman-mediated command approval, run the
+  command through `tmux-a2a-postman execute-bash` with a specific `--label`,
+  `--category`, and `--reason`; do not treat direct shell execution as
+  satisfying the approval audit.
 - Send DONE or BLOCKED to orchestrator using the `Reply:` footer line.
 - DONE requires `Task artifact:`, `Original checklist: PASS`, evidence, changed
   files and verification summary, and `Remaining blockers: none`; BLOCKED

--- a/config/vde/layout.yml
+++ b/config/vde/layout.yml
@@ -96,8 +96,12 @@ presets:
               command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
         - type: vertical
-          ratio: [1, 1]
+          ratio: [1, 1, 1, 1]
           panes:
+            - name: approver
+              title: approver
+              command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
+              delay: 500
             - name: guardian
               title: guardian
               command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=high
@@ -105,6 +109,10 @@ presets:
             - name: critic
               title: critic
               command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model "opus[1m]" --effort high
+              delay: 500
+            - name: diplomat
+              title: diplomat
+              command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
               delay: 500
 
   preset-w:
@@ -131,8 +139,12 @@ presets:
               command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
         - type: vertical
-          ratio: [1, 1]
+          ratio: [1, 1, 1, 1]
           panes:
+            - name: approver
+              title: approver
+              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              delay: 500
             - name: guardian
               title: guardian
               command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model "opus[1m]" --effort high
@@ -140,4 +152,8 @@ presets:
             - name: critic
               title: critic
               command: codex --yolo --no-alt-screen --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=medium
+              delay: 500
+            - name: diplomat
+              title: diplomat
+              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -1,8 +1,22 @@
 # Agent Command Approval Design
 
 This design documents the current command approval and writable-surface model
-for Codex CLI and Claude Code, then defines the first follow-up shape. It is
-documentation for issue #201 only; it does not change runtime behavior.
+for Codex CLI, Claude Code, and the postman-mediated command approval layer.
+The May 2026 sections describe runtime permission design for issue #201; the
+July 2026 update records the adopted `tmux-a2a-postman execute-bash` contract.
+
+Update checked on 2026-07-13:
+
+- Local `tmux-a2a-postman --version`: `git-c928f9d`.
+- Adjacent `tmux-a2a-postman` source repo recent changes include command
+  approval through `execute-bash`, reply-delivered approval requests, and the
+  migration of the approver marker to the Mermaid `command_approver_node`
+  class.
+- `diplomat_node` is a separate, not-yet-shipped design issue for
+  cross-session edge authorization. Do not configure it in dotfiles until that
+  issue lands in `tmux-a2a-postman`.
+- This repo currently has `config/tmux-a2a-postman/postman.md` only; there is
+  no checked-in `postman.toml` policy file.
 
 Sources checked on 2026-05-30:
 
@@ -210,6 +224,123 @@ Claude profile.
 | Human review lane                    | `postman.md` approval route and review skills                                        | Codex `approvals_reviewer = "auto_review"` is Codex-only                                                                                                         | Auto-review may assist Codex approval prompts, but it must not replace guardian/critic/human approval gates.                                                                                             |
 | Role-based write restrictions        | `postman.md` role contract                                                           | Claude has `claude-pretooluse-deny-write.sh`; Codex currently observes write payloads only                                                                       | Keep Claude enforcement. Add Codex enforcement only after the observed write payloads support a reliable rule.                                                                                           |
 
+### 4.1. Postman Command Approval Layer
+
+`tmux-a2a-postman execute-bash` is now the shared command-approval wrapper for
+postman sessions. It records requester, reviewer audit label, label, category,
+mode, command digest, reason, expiry, approval thread id, decision, and exit
+status, then runs the command through `bash -lc` only when the selected mode
+allows it.
+
+This wrapper is coordination and audit, not a security boundary. It does not
+sandbox Bash, block direct shell execution, or prevent another process from
+running the same command. Keep runtime enforcement in Codex sandboxing, Claude
+permissions/sandboxing, or the shared PreToolUse hooks when the rule must hold
+against bypass.
+
+The real approver is not the `reviewer` field in a policy or CLI flag.
+`reviewer` is an audit label. The authenticated approver is the single node
+marked in the `postman.md` Mermaid graph:
+
+```mermaid
+graph LR
+    messenger --- orchestrator
+    orchestrator --- worker
+    orchestrator --- approver
+    class approver command_approver_node
+    classDef command_approver_node fill:#fef3c7
+```
+
+This repo marks the dedicated `approver` node as that singleton. All command
+approval policies share the same approver. Per-policy approver routing is not
+supported.
+
+The fail-open rule is the most important operational detail: `advisory`,
+`warn-only`, and `blocking` become restrictive only when the Mermaid
+`command_approver_node` resolves to a real configured node. If the marker is
+absent or misspelled, every wrapper-mediated command runs and is recorded as
+`auto_approved_no_reviewer`, including commands requested in `blocking` mode.
+Migration is complete only when `tmux-a2a-postman get-status` has neither
+`command_approval.unresolved_command_approvers` nor
+`command_approval.deprecated_command_approvers`.
+
+When a command needs approval and a valid approver exists, `execute-bash`
+delivers a reply-required approval request to that approver. The approver can
+decide by replying on the approval thread with a body starting
+`APPROVED: <reason>` or `NOT APPROVED: <reason>`, preserving the supplied
+`thread_id` in frontmatter. The approver can also decide from its own pane:
+
+```sh
+tmux-a2a-postman execute-bash \
+  --thread-id command-approval-... \
+  --record-decision approved \
+  --reason "digest reviewed"
+```
+
+Decision identity always comes from the calling tmux pane title or the reply
+sender, never from `--reviewer`. A decision attempted from any pane other than
+the resolved `command_approver_node` is refused or recorded as wrong reviewer.
+
+Current dotfiles adoption:
+
+- `config/tmux-a2a-postman/postman.md` adds a dedicated `approver` node and
+  marks it with
+  `command_approver_node`.
+- `config/vde/layout.yml` starts an `approver` pane in the standard `preset-p`
+  and `preset-w` team layouts. This is required: a Mermaid approver marker that
+  has no live pane title resolves as unavailable and can leave blocking command
+  approval in fail-open mode.
+- `config/vde/layout.yml` also starts a reserved `diplomat` pane so future
+  cross-session design traffic has a stable node name, but no `diplomat_node`
+  routing is configured yet.
+- The common template states that `execute-bash` is the only postman-mediated
+  command approval lane and that direct shell execution bypasses its audit.
+- The approver role contract tells approver to approve or reject command
+  approval threads, and not to run the requested command locally while acting
+  as approver.
+- The orchestrator role contract routes command-approval policy questions to
+  `approver` rather than deciding approval threads itself.
+- Worker roles must use `execute-bash` with a specific `--label`,
+  `--category`, and `--reason` when delegated work requires this approval lane.
+- There is still no checked-in `postman.toml` command policy. Any future
+  blocking policy must be added alongside a verification showing the valid
+  Mermaid approver marker survives config load.
+
+### 4.2. Diplomat Node Status
+
+`diplomat_node` is not part of command approval. It is an open
+`tmux-a2a-postman` design for tree-derived cross-session authorization:
+sessions declared through `[[postman.workspace_tree]]` would each name one
+`diplomat_node`, and those diplomats would be allowed to communicate across
+parent/child session boundaries derived from the workspace tree.
+
+Do not add a `diplomat_node` class or active cross-session authorization to
+this repo yet. As of the 2026-07-13 check:
+
+- The workspace tree prerequisite is present in `tmux-a2a-postman` through
+  issue #504 / PR #622.
+- The diplomat design itself remains open as issue #624.
+- Related trust-ledger accountability work remains open as issue #614, and the
+  diplomat design names that work as relevant to confused-deputy risk.
+- `config/tmux-a2a-postman/postman.md` reserves a `diplomat` node for future
+  design and policy routing only. It must report blocked for active
+  cross-session relay until upstream support lands and this repo adds explicit
+  verification gates.
+
+When `diplomat_node` ships, the dotfiles follow-up should be separate from
+command approval and should update:
+
+- `config/tmux-a2a-postman/postman.md` only if the shipped syntax uses the
+  Markdown topology file.
+- `config/vde/layout.yml` if the existing reserved `diplomat` pane needs a
+  different runtime, pane title, or launch placement for the shipped feature.
+- A checked-in `postman.toml` only if the shipped syntax stays under
+  `[[postman.workspace_tree]]`.
+- The role contracts for whichever node is allowed to relay cross-session
+  traffic, including explicit anti-open-relay instructions.
+- Verification that status output and "You can talk to" include the derived
+  diplomat edges without exposing filesystem paths.
+
 ## 5. Follow-Up Implementation Shape
 
 The first implementation should be an opt-in profile or preset, not a default
@@ -266,6 +397,10 @@ repo-relative paths:
   changelog and operational notes.
 - `config/tmux-a2a-postman/postman.md` only if the human approval or worker
   operating contract changes.
+- `config/vde/layout.yml` whenever adding a postman node that must exist as a
+  live pane; topology-only nodes are not enough for command approval identity.
+- A future checked-in `postman.toml`, if command approval policies become
+  declarative rather than per-command `execute-bash` flags.
 
 ## 7. Representative Verification Scenarios
 
@@ -279,3 +414,15 @@ from a disposable issue worktree or scratch repository, not from `main`.
 | Package operations       | Routine local checks such as `nix run '.#check'` work in the intended profile. Networked package or cache operations either work only when intentionally allowed or route through approval.                            | Package checks follow the selected permission mode. If sandboxing is enabled, Bash child processes stay inside the configured filesystem and network boundary.                                      | Run the repo check surface and one package-manager command with expected network behavior documented.                                                                                      |
 | Denied commands          | `git push`, `git reset`, `git rebase`, `git commit --amend`, `rm`, `sudo`, `aws sso login`, `git -C`, and `tmux select-pane -T` remain blocked by the shared hook or future Codex-native forbidden rules.              | The shared PreToolUse hook should block the same command set when hooks run. The high-consequence `permissions.deny` subset is a non-bypass expectation unless a bypass-mode test proves otherwise. | Execute harmless dry forms where possible, or use hook/unit command checks that prove the deny rule fires without side effects; record hook-layer and permission-layer results separately. |
 | Postman state operations | `tmux-a2a-postman pop` and `tmux-a2a-postman send-heredoc` remain usable. Heredoc bodies that mention denied commands do not trigger false positives. Direct mailbox file edits remain outside the operating contract. | Same as Codex. `--dangerously-skip-permissions` must not be required for legitimate postman state traffic once an alternative profile exists.                                                       | Pop a ping/status message in a test session, send a heredoc containing command-like text, and confirm the shared Bash deny hook does not block message transport.                          |
+
+Postman command approval scenario:
+
+- Codex expectation: `execute-bash --mode blocking` does not fail open after
+  config load when `approver` is the resolved `command_approver_node`. Direct
+  shell remains a documented bypass, not a tested approval path.
+- Claude expectation: same as Codex because approval identity comes from tmux
+  pane title, not runtime vendor settings.
+- Evidence to capture: restart the postman daemon after config changes, run
+  `get-status`, confirm no unresolved/deprecated command approval markers,
+  create a harmless blocking request, approve or reject from `approver`, and
+  inspect the recorded thread.

--- a/skills/dotfiles/references/harness-guidance.md
+++ b/skills/dotfiles/references/harness-guidance.md
@@ -26,6 +26,8 @@ installed, validated, or explained.
 ## 2. Source Map
 
 - Harness principles: `skills/dotfiles/references/agent-config-philosophy.md`
+- Command approval and writable surface:
+  `skills/dotfiles/references/agent-command-approval-design.md`
 - Operating model: `skills/dotfiles/references/operating-concepts.md`
 - AI workflow and artifacts:
   `skills/dotfiles/references/repo-ai-operating-contract.md`

--- a/skills/dotfiles/references/orchestrator-runbook.md
+++ b/skills/dotfiles/references/orchestrator-runbook.md
@@ -38,6 +38,8 @@ The approval workflow has these standing role nodes:
 
 - `messenger`
 - `orchestrator`
+- `approver`
+- `diplomat`
 - `worker`
 - `worker-alt`
 - `critic`
@@ -50,7 +52,12 @@ Reachability is strict:
 
 - `messenger` talks only to `orchestrator`.
 - `orchestrator` talks to `messenger`, `worker`, `worker-alt`, `guardian`,
-  and auxiliary `agent`.
+  `approver`, `diplomat`, and auxiliary `agent`.
+- `approver` receives command-approval traffic and policy questions; it does
+  not execute the requested command locally.
+- `diplomat` is reserved for future cross-session authorization work; it does
+  not relay live cross-session traffic until the upstream `diplomat_node`
+  feature and this repo's verification gates exist.
 - `critic` talks only to `guardian`.
 - `guardian` receives review requests from `orchestrator`, sends review
   packages to `critic`, receives critic review evidence, aggregates the


### PR DESCRIPTION
## Summary

- Add dedicated `approver` and reserved `diplomat` nodes to the postman topology.
- Start matching `approver` and `diplomat` panes in both standard VDE team presets.
- Document the command approval boundary, fail-open verification gate, and current `diplomat_node` upstream status.

## Notes

`approver` is marked as the singleton `command_approver_node`. `diplomat` is intentionally only a reserved design/policy lane until upstream `diplomat_node` support ships.

## Verification

- `bash scripts/validation/validate-skill-private-content.sh skills/dotfiles config/tmux-a2a-postman/postman.md config/vde/layout.yml`
- `bash scripts/validation/validate-skill-frontmatter.sh skills/dotfiles`
- `git diff --check`
- `nix run '.#check'`
