### PR TITLE
Fix Claude bypass permission launch flags

### DIFF
--- a/config/vde/layout.yml
+++ b/config/vde/layout.yml
@@ -52,7 +52,7 @@ presets:
           focus: true
         - name: messenger
           title: messenger
-          command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+          command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
           delay: 500
 
   messenger-codex:
@@ -93,7 +93,7 @@ presets:
               delay: 500
             - name: worker-alt
               title: worker-alt
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
         - type: vertical
           ratio: [1, 1, 1, 1]
@@ -108,7 +108,7 @@ presets:
               delay: 500
             - name: critic
               title: critic
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model "opus[1m]" --effort high
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model "opus[1m]" --effort high
               delay: 500
             - name: diplomat
               title: diplomat
@@ -128,26 +128,26 @@ presets:
           panes:
             - name: orchestrator
               title: orchestrator
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
             - name: worker
               title: worker
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
             - name: worker-alt
               title: worker-alt
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
         - type: vertical
           ratio: [1, 1, 1, 1]
           panes:
             - name: approver
               title: approver
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500
             - name: guardian
               title: guardian
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model "opus[1m]" --effort high
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model "opus[1m]" --effort high
               delay: 500
             - name: critic
               title: critic
@@ -155,5 +155,5 @@ presets:
               delay: 500
             - name: diplomat
               title: diplomat
-              command: claude --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
+              command: claude --allow-dangerously-skip-permissions --dangerously-skip-permissions --add-dir "${SUBDIR}" --model sonnet --effort medium
               delay: 500

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -45,7 +45,8 @@ codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effo
 It starts the Claude critic pane with:
 
 ```sh
-claude --dangerously-skip-permissions --add-dir "${SUBDIR}" \
+claude --allow-dangerously-skip-permissions --dangerously-skip-permissions \
+  --add-dir "${SUBDIR}" \
   --model "opus[1m]" --effort xhigh
 ```
 
@@ -58,8 +59,8 @@ a version-specific verification proves that behavior. The `--add-dir` value
 extends the workspace surface for each session. The exact extra directory is
 chosen by the vde session environment, not by Home Manager agent config.
 
-The current local tool versions observed during this design pass were
-`codex-cli 0.135.0` and `Claude Code 2.1.156`.
+The current local tool versions observed during the 2026-07-14 refresh were
+`codex-cli 0.144.3` and `Claude Code 2.1.207`.
 
 ## 2. Current Codex Behavior
 
@@ -162,16 +163,18 @@ rules apply to built-in file tools and recognized file-reading shell commands,
 but not to arbitrary subprocesses that open files themselves.
 
 This deny set documents the current configured permission policy. The current
-critic pane is launched with `--dangerously-skip-permissions`, and installed
-Claude Code 2.1.156 help describes that option as bypassing all permission
-checks. Therefore the design treats `permissions.deny` as a non-bypass
-expectation unless a follow-up captures installed-version evidence that a
-specific deny rule still applies in bypass mode.
+critic pane is launched with `--allow-dangerously-skip-permissions` plus
+`--dangerously-skip-permissions`, and installed Claude Code 2.1.207 help
+describes the first flag as enabling bypass as an option and the second as
+selecting bypass mode. Therefore the design treats `permissions.deny` as a
+non-bypass expectation unless a follow-up captures installed-version evidence
+that a specific deny rule still applies in bypass mode.
 
 ### 3.2. Launch Mode And Hooks
 
-The vde launcher starts the Claude critic pane with
-`--dangerously-skip-permissions --add-dir "${SUBDIR}"`. That suppresses normal
+The vde launcher starts the Claude critic pane with the two bypass flags
+followed by `--add-dir "${SUBDIR}"`. The allow flag makes bypass mode
+selectable, and the dangerous skip flag selects it. That suppresses normal
 permission prompts and, per the installed help, bypasses permission checks for
 that pane. Do not use the current critic launch as evidence that
 `permissions.deny` is enforced.

--- a/skills/dotfiles/references/claude-changelog-tracking.md
+++ b/skills/dotfiles/references/claude-changelog-tracking.md
@@ -164,8 +164,8 @@ This reference preserves older review notes that support current
   auto-updater memory reduction, PR-linking and agent-view improvements, plus
   Windows worktree and background-agent reliability fixes. Auto mode remains
   unused by this repo.
-- v2.1.204: Headless `SessionStart` hook events now stream during hooks, avoiding
-  idle reaping of remote workers. Automatic; no config.
+- v2.1.204: Headless `SessionStart` hook events now stream during hooks,
+  avoiding idle reaping of remote workers. Automatic; no config.
 - v2.1.203: Manual permission-mode footer badge, MCP `roots/list` includes
   additional working directories, background-agent worktree/PATH/base-URL fixes,
   many agent-view and terminal-rendering fixes. Automatic; no config.

--- a/skills/dotfiles/references/claude-changelog-tracking.md
+++ b/skills/dotfiles/references/claude-changelog-tracking.md
@@ -152,10 +152,10 @@ This reference preserves older review notes that support current
 - v2.1.207: Auto mode is available without `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in
   on Bedrock, Vertex AI, and Foundry; `autoMode` is no longer read from
   `.claude/settings.local.json`; plugin hooks/monitors/MCP `headersHelper`
-  reject shell-form `${user_config.*}` interpolation. Bypass permissions were
-  not default-disabled: `disableBypassPermissionsMode` remains an explicit
-  settings key, and the local harness keeps `--dangerously-skip-permissions`
-  launch paths. No source change.
+  reject shell-form `${user_config.*}` interpolation. Bypass permissions now
+  require the launcher opt-in flag `--allow-dangerously-skip-permissions` before
+  `--dangerously-skip-permissions` can activate bypass mode; VDE Claude launch
+  paths were updated to pass both.
 - v2.1.206: `/cd` path suggestions, `/doctor` checked-in `CLAUDE.md` trimming
   check, `/commit-push-pr` push-remote auto-allow, gateway `/login`, safer
   `EnterWorktree`, and many background-agent / MCP / model-picker fixes.

--- a/skills/dotfiles/references/claude-changelog-tracking.md
+++ b/skills/dotfiles/references/claude-changelog-tracking.md
@@ -149,6 +149,26 @@ This reference preserves older review notes that support current
 
 ## 2. Version Notes
 
+- v2.1.207: Auto mode is available without `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in
+  on Bedrock, Vertex AI, and Foundry; `autoMode` is no longer read from
+  `.claude/settings.local.json`; plugin hooks/monitors/MCP `headersHelper`
+  reject shell-form `${user_config.*}` interpolation. Bypass permissions were
+  not default-disabled: `disableBypassPermissionsMode` remains an explicit
+  settings key, and the local harness keeps `--dangerously-skip-permissions`
+  launch paths. No source change.
+- v2.1.206: `/cd` path suggestions, `/doctor` checked-in `CLAUDE.md` trimming
+  check, `/commit-push-pr` push-remote auto-allow, gateway `/login`, safer
+  `EnterWorktree`, and many background-agent / MCP / model-picker fixes.
+  User-invoked or automatic; no config.
+- v2.1.205: Auto-mode transcript-tampering rule, `/doctor` checkup alias,
+  auto-updater memory reduction, PR-linking and agent-view improvements, plus
+  Windows worktree and background-agent reliability fixes. Auto mode remains
+  unused by this repo.
+- v2.1.204: Headless `SessionStart` hook events now stream during hooks, avoiding
+  idle reaping of remote workers. Automatic; no config.
+- v2.1.203: Manual permission-mode footer badge, MCP `roots/list` includes
+  additional working directories, background-agent worktree/PATH/base-URL fixes,
+  many agent-view and terminal-rendering fixes. Automatic; no config.
 - v2.1.202: `/review` reverted to a fast single-pass review (use
   `/code-review <level> <pr#>` for the multi-agent pass); skill re-invocation no
   longer duplicates its instructions in context; dynamic workflow-size `/config`

--- a/skills/dotfiles/references/claude-optimization-tracking.md
+++ b/skills/dotfiles/references/claude-optimization-tracking.md
@@ -82,14 +82,11 @@ section. No package or generated config change is needed from this pass.
   Alternative considered and rejected: opt into an idle timeout via `/config`
   (keeps the tool for interactive sessions) - postman panes are the common
   case here, so a hard deny is the right default.
-- [x] v2.1.207 permission-mode review - no migration needed. Claude Code did
-  not default-disable bypass permissions in this review window:
-  `--dangerously-skip-permissions` and `--permission-mode bypassPermissions`
-  still appear in `claude --help`, user settings have no
-  `disableBypassPermissionsMode`, and no `/etc/claude-code/managed-settings*`
-  policy is present locally. `disableBypassPermissionsMode` remains an
-  explicit settings key for preventing bypass mode when an operator chooses to
-  enforce it.
+- [x] v2.1.207 permission-mode review - launcher migration applied. Claude Code
+  now exposes `--allow-dangerously-skip-permissions` as an explicit gate:
+  `--dangerously-skip-permissions` still selects bypass mode, but bypassing is
+  disabled by default until the allow flag is also present. Updated
+  `config/vde/layout.yml` so every Claude pane passes both flags.
 
 ### 1.2. Pending Considerations
 
@@ -272,10 +269,10 @@ section. No package or generated config change is needed from this pass.
 
 #### 1.2.5. v2.1.203 -> v2.1.207 candidates (added 2026-07-14)
 
-- [x] Bypass permission mode default check (v2.1.207) - no config change. The
-  upstream change was not a default disablement of bypass permissions. The
-  relevant managed/user settings key is still `disableBypassPermissionsMode`,
-  and it is unset locally.
+- [x] Bypass permission mode default check (v2.1.207) - config change applied.
+  `--allow-dangerously-skip-permissions` must accompany
+  `--dangerously-skip-permissions` in launcher commands; otherwise Claude Code
+  reports bypass permissions as disabled by default.
 - [ ] Auto mode availability and `autoMode` scope changes (v2.1.207) -
   informational for now. Auto mode is now available without
   `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in on Bedrock, Vertex AI, and Foundry, and

--- a/skills/dotfiles/references/claude-optimization-tracking.md
+++ b/skills/dotfiles/references/claude-optimization-tracking.md
@@ -6,11 +6,11 @@ in `claude-changelog-tracking.md`.
 
 ## 1. Optimization Tracking
 
-Last reviewed Claude Code version: v2.1.202 (2026-07-07)
+Last reviewed Claude Code version: v2.1.207 (2026-07-14)
 
-Review confirmation (2026-07-07): local `claude --version` reported
-`2.1.202 (Claude Code)`, and the official
-`anthropics/claude-code` `CHANGELOG.md` contains the matching `2.1.202`
+Review confirmation (2026-07-14): local `claude --version` reported
+`2.1.207 (Claude Code)`, and the official
+`anthropics/claude-code` `CHANGELOG.md` contains the matching `2.1.207`
 section. No package or generated config change is needed from this pass.
 
 ### 1.1. Applied Optimizations
@@ -82,6 +82,14 @@ section. No package or generated config change is needed from this pass.
   Alternative considered and rejected: opt into an idle timeout via `/config`
   (keeps the tool for interactive sessions) - postman panes are the common
   case here, so a hard deny is the right default.
+- [x] v2.1.207 permission-mode review - no migration needed. Claude Code did
+  not default-disable bypass permissions in this review window:
+  `--dangerously-skip-permissions` and `--permission-mode bypassPermissions`
+  still appear in `claude --help`, user settings have no
+  `disableBypassPermissionsMode`, and no `/etc/claude-code/managed-settings*`
+  policy is present locally. `disableBypassPermissionsMode` remains an
+  explicit settings key for preventing bypass mode when an operator chooses to
+  enforce it.
 
 ### 1.2. Pending Considerations
 
@@ -261,6 +269,25 @@ section. No package or generated config change is needed from this pass.
   orchestrator-runbook awareness. Remaining background-agent / Remote Control /
   workflow-parse fixes through v2.1.202 are product reliability; no source
   change.
+
+#### 1.2.5. v2.1.203 -> v2.1.207 candidates (added 2026-07-14)
+
+- [x] Bypass permission mode default check (v2.1.207) - no config change. The
+  upstream change was not a default disablement of bypass permissions. The
+  relevant managed/user settings key is still `disableBypassPermissionsMode`,
+  and it is unset locally.
+- [ ] Auto mode availability and `autoMode` scope changes (v2.1.207) -
+  informational for now. Auto mode is now available without
+  `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in on Bedrock, Vertex AI, and Foundry, and
+  `autoMode` is no longer read from `.claude/settings.local.json`; if this repo
+  ever adopts auto mode, place policy in `~/.claude/settings.json` or managed
+  settings, not local/project settings.
+- [x] Plugin `${user_config.*}` shell-form rejection (v2.1.207) - no local
+  migration. Repo search found no plugin hook, monitor, MCP `headersHelper`,
+  or `pluginConfigs` usage of `user_config`.
+- [x] Background-agent, Remote Control, worktree, MCP timeout, and terminal
+  rendering fixes through v2.1.207 - product reliability; current harness should
+  benefit automatically with no source change.
 
 For decision log ("Not Adopting") and per-version changelog,
 see [Claude Changelog Tracking](claude-changelog-tracking.md).

--- a/skills/dotfiles/references/deny-bash-design.md
+++ b/skills/dotfiles/references/deny-bash-design.md
@@ -71,7 +71,8 @@ Claude Code normally recognises certain dangerous patterns
 dangerous primitives, redirects to `/dev/tcp/...`, `find -exec`,
 `find -delete`, etc.) and surfaces permission prompts or denial behavior.
 
-Installed Claude Code 2.1.156 help describes
+Installed Claude Code 2.1.207 help describes
+`--allow-dangerously-skip-permissions` as enabling bypass as an option, and
 `--dangerously-skip-permissions` as bypassing all permission checks. Therefore
 this design does not claim that the built-in safety classifier or
 `permissions.deny` rules remain active in bypass-launched panes without


### PR DESCRIPTION
## Summary
- add the Claude Code v2.1.207 `--allow-dangerously-skip-permissions` gate to every VDE Claude launch that selects bypass mode
- update Claude harness tracking docs to record the v2.1.207 permission-mode behavior and corrected launch contract
- refresh related command-approval and deny-bash references with current local tool versions

## Background
Claude Code v2.1.207 reports bypass permissions as disabled by default when `--dangerously-skip-permissions` is used without the new explicit allow flag. The VDE presets still launched Claude panes with only the dangerous skip flag, so headless panes could fail before entering the expected high-autonomy mode.

## Verification
- `claude --help` confirmed `--allow-dangerously-skip-permissions` and `--dangerously-skip-permissions` semantics
- `vde-layout --config config/vde/layout.yml list`
- `vde-layout --config config/vde/layout.yml --dryRun preset-w`
- `git diff --check`
- `bash scripts/validation/validate-skill-frontmatter.sh skills/dotfiles`