### PR TITLE
fix(nix): align cleanup retention policy

### DIFF
--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -51,12 +51,11 @@ in
           }:
           {
             nix = {
-              # Garbage collection via systemd timer (daily at noon, delete older than 1 day)
-              # cf. nix-darwin's nix.gc.interval in nix-darwin/default.nix
+              # Garbage collection is handled by programs.nh.clean in
+              # nix/home-manager/default.nix. Home Manager warns when both
+              # programs.nh.clean.enable and nix.gc.automatic are enabled.
               gc = {
-                automatic = true;
-                dates = "12:00";
-                options = "--delete-older-than 1d";
+                automatic = false;
               };
               settings = commonNixSettings // {
                 # Nix store optimisation via hard links (writes to ~/.config/nix/nix.conf)

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -173,6 +173,19 @@ in
     # nix-index-database: comma (run uninstalled commands via nix-index)
     nix-index-database.comma.enable = true;
 
+    # nh: unified Nix helper. On Linux/WSL, run a weekly user-profile cleanup
+    # with a conservative retention window. Darwin keeps the existing
+    # nix-darwin system GC; Home Manager's nh launchd wrapper passes
+    # extraArgs as one argument, so avoid enabling scheduled clean there.
+    nh = {
+      enable = true;
+      clean = {
+        enable = !pkgs.stdenv.isDarwin;
+        dates = "weekly";
+        extraArgs = "--keep-since 30d --keep-one";
+      };
+    };
+
     # direnv (auto-activate devShell when cd into project)
     # Note: zsh hook is loaded manually in modules/zsh.nix.
     direnv = {

--- a/nix/nix-darwin/default.nix
+++ b/nix/nix-darwin/default.nix
@@ -39,7 +39,9 @@
     #       and scheduled optimise can cause syspolicyd high CPU
     # cf. `https://github.com/nix-darwin/nix-darwin/issues/1252`
     optimise.automatic = false;
-    # Garbage collection (daily at noon, delete older than 1 day)
+    # Garbage collection (daily at noon, retain the last 30 days)
+    # Keep the retention window aligned with Home Manager's nh clean policy on
+    # Ubuntu/WSL while using nix-darwin's system GC path on macOS.
     # cf. https://mynixos.com/nix-darwin/option/nix.gc.interval
     gc = {
       automatic = true;
@@ -47,7 +49,7 @@
         Hour = 12;
         Minute = 0;
       };
-      options = "--delete-older-than 1d";
+      options = "--delete-older-than 30d";
     };
   };
 

--- a/skills/dotfiles/references/nix-operations.md
+++ b/skills/dotfiles/references/nix-operations.md
@@ -2,11 +2,11 @@
 
 ## 1. Daily Usage
 
-| Command              | Description                                                                                                                                                                                                                                               |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nix run '.#switch'` | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day. Scheduled daemon GC remains separate and uses 1 day on both Linux and macOS |
-| `nix run '.#update'` | Update flake inputs                                                                                                                                                                                                                                       |
-| `nix run '.#check'`  | Check flake configuration                                                                                                                                                                                                                                 |
+| Command              | Description                                                                                                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nix run '.#switch'` | Rebuild and activate configuration. After a successful switch, Linux expires Home Manager generations older than 1 day and macOS expires system generations older than 1 day; scheduled cleanup remains separate |
+| `nix run '.#update'` | Update flake inputs                                                                                                                                                                                              |
+| `nix run '.#check'`  | Check flake configuration                                                                                                                                                                                        |
 
 One-off host repair helpers are kept as explicit scripts rather than flake
 apps. For Ubuntu root LVM expansion, run from the dotfiles repository root:
@@ -18,7 +18,24 @@ sudo bash ./scripts/ubuntu/extend-root-lvm.sh --apply
 
 Use `--apply` only after reviewing the VG/LV target printed by `--check`.
 
-## 2. Manual Cache Cleanup
+## 2. Scheduled Nix Cleanup
+
+Cleanup uses the same 30 day retention threshold on Ubuntu/WSL and macOS, but
+the mechanisms are intentionally different.
+
+- Ubuntu/WSL: Home Manager enables `programs.nh.clean` on non-Darwin targets
+  with `dates = "weekly"` and `extraArgs = "--keep-since 30d --keep-one"`.
+  The standalone Home Manager `nix.gc.automatic` timer stays disabled in
+  `nix/flake-parts/modules/ubuntu.nix` to avoid overlapping cleanup timers.
+- macOS: nix-darwin owns system cleanup. It runs plain Nix GC daily at noon
+  with `--delete-older-than 30d` in `nix/nix-darwin/default.nix`.
+- Caveat: macOS is not using scheduled Home Manager `nh clean`. The current
+  Home Manager Darwin launchd wrapper passes `extraArgs` as one argument, so
+  the space-separated `--keep-since 30d --keep-one` policy is not enabled
+  there. Use nix-darwin GC, or add a custom split-argument launchd job if exact
+  `nh` parity is required.
+
+## 3. Manual Cache Cleanup
 
 There is no `.#cleanup` flake app. Keep cache deletion as an explicit manual
 operation so the operator can review the target paths first.
@@ -53,14 +70,14 @@ macOS-only additions:
 rm -rf "$HOME/Library/Caches/pre-commit" "$HOME/Library/Caches/ruff"
 ```
 
-## 3. Upgrade Nix
+## 4. Upgrade Nix
 
 Nix upgrade ownership differs by OS. On macOS, `nix-darwin` manages
 `nix-daemon` declaratively, so the daily `update` + `switch` flow covers
 upgrades. On Ubuntu, the system `nix-daemon` is outside home-manager's scope,
 so upgrade it separately from the root Nix profile.
 
-### 3.1. Ubuntu
+### 4.1. Ubuntu
 
 For a normal upgrade, do not re-run the curl installer. Upgrade the system Nix
 profile as root, then reload and restart `nix-daemon`. `--remove-all` avoids a
@@ -81,7 +98,7 @@ nix --version
 systemctl is-active nix-daemon.service nix-daemon.socket
 ```
 
-### 3.2. macOS
+### 4.2. macOS
 
 Part of the daily flow. `nix-darwin` rewrites
 `/Library/LaunchDaemons/org.nixos.nix-daemon.plist` and reloads the daemon
@@ -102,7 +119,7 @@ Verify:
 nix --version
 ```
 
-### 3.3. Recover After macOS Update
+### 4.3. Recover After macOS Update
 
 macOS updates can break nix-darwin in two ways:
 


### PR DESCRIPTION
## Summary

- replace Ubuntu/WSL scheduled `nix.gc` cleanup with weekly `nh clean user --keep-since 30d --keep-one`
- align macOS scheduled nix-darwin GC retention to 30 days
- document scheduled cleanup separately from post-switch 1-day generation expiry

## Background

Ubuntu/WSL and macOS both previously used a 1-day scheduled GC retention window. The cleanup policy is now aligned around a 30-day threshold while preserving platform-specific cleanup ownership.

## Verification

- `git diff --check`
- `nix fmt`
- `nix flake check --impure`
- `nix run '.#check' --impure`
- focused Ubuntu cleanup option evals
- focused Darwin cleanup option evals