### PR TITLE
feat(harness): publish approval policy and Herdr support

### DIFF
--- a/config/tmux-a2a-postman/postman.md
+++ b/config/tmux-a2a-postman/postman.md
@@ -246,8 +246,26 @@ requests and policy questions about command approval.
   open PRs, or execute the requested command locally.
 - Act as the command approver for `execute-bash` approval requests because the
   Mermaid graph marks `approver` as `command_approver_node`.
-- Verify the requester, label, category, reason, digest, mode, and thread id
-  before deciding.
+- Before deciding, read and apply the prohibited-command policy and rationale:
+  the shared Bash deny SSOT is
+  `nix/home-manager/agents/shared/denied-bash-commands.nix`, and the layer
+  rationale is `skills/dotfiles/references/deny-bash-design.md` plus
+  `skills/dotfiles/references/agent-command-approval-design.md`. The deny list
+  is a guardrail, not the full approval policy.
+- Verify the requester, reviewer, label, category, reason, command digest,
+  mode, thread id, branch/ref or target surface when relevant, and approval
+  evidence before deciding.
+- Reject or return `BLOCKED:` for public GitHub writes unless the request
+  includes explicit current human approval for that specific action. This
+  includes remote ref updates, branch publication, PR creation or update,
+  GitHub comments/reviews, tags, releases, and equivalent commands through
+  `gh`, `git`, scripts, or wrapper lanes.
+- Reject or return `BLOCKED:` for production-data writes unless the request
+  includes explicit current human approval for that specific production action.
+- Treat arbitrary shell through wrapper lanes, including
+  `tmux-a2a-postman execute-bash`, as high-risk unless the inner command and
+  requested side effects are clear. Do not approve a wrapper merely because the
+  wrapper itself is allowed by the Bash deny hook.
 - Decide command approval threads only from the approver pane. Approve by
   replying on the supplied approval thread with a body starting
   `APPROVED: <reason>`, reject with `NOT APPROVED: <reason>`, or use

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -121,6 +121,7 @@ in
       llmAgents.ccusage
       llmAgents.claude-code
       llmAgents.codex
+      llmAgents.herdr
     ]
     ++ lib.optionals (!pkgs.stdenv.isDarwin) [
       pkgs.mise

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -241,6 +241,30 @@ running the same command. Keep runtime enforcement in Codex sandboxing, Claude
 permissions/sandboxing, or the shared PreToolUse hooks when the rule must hold
 against bypass.
 
+Approver policy therefore has two separate sources:
+
+- Structured deny data belongs in
+  `nix/home-manager/agents/shared/denied-bash-commands.nix` when the rule is a
+  concrete Bash pattern that should be blocked before execution in both
+  runtimes. Each entry carries its repair-oriented rationale.
+- Human approval gates belong in `config/tmux-a2a-postman/postman.md` because
+  they depend on intent, target surface, provenance, and current human approval
+  evidence rather than only argv tokens.
+
+Do not collapse these into one JSON command list. A structured list is useful
+for deterministic command-pattern denies, but it is the wrong shape for public
+write approval because `gh`, `git`, scripts, and wrapper lanes can express the
+same side effect in many forms. Keep the prose approver contract as the policy
+that interprets side effects and evidence, and keep the Nix deny list as the
+runtime guardrail for concrete prohibited Bash patterns.
+
+The approver contract must reject or block any request that lacks explicit
+current human approval for public GitHub writes, remote ref updates, branch
+publication, PR creation or update, GitHub comments/reviews, tags, releases,
+or production-data writes. `tmux-a2a-postman execute-bash` does not make a
+command safe; the approver must inspect the inner command and requested side
+effects before deciding.
+
 The real approver is not the `reviewer` field in a policy or CLI flag.
 `reviewer` is an audit label. The authenticated approver is the single node
 marked in the `postman.md` Mermaid graph:

--- a/skills/dotfiles/references/harness-guidance.md
+++ b/skills/dotfiles/references/harness-guidance.md
@@ -39,6 +39,7 @@ installed, validated, or explained.
 - Claude workspace trust: `claude-workspace-trust.md`
 - Codex runtime config: `nix/home-manager/agents/codex/default.nix` and
   `codex-cli.md`
+- Herdr terminal workspace manager: `herdr.md`
 - Claude optimization tracking: `claude-optimization-tracking.md`
 - Claude changelog decisions: `claude-changelog-tracking.md`
 - Codex optimization tracking: `codex-optimization-tracking.md`
@@ -81,6 +82,7 @@ Full diagnosis and commands live in
 - Codex CLI runtime details, hook limitations, and settings categories live in
   [Codex CLI](codex-cli.md); current release decisions live in
   [Codex CLI Optimization Tracking](codex-optimization-tracking.md).
+- Herdr terminal workspace manager notes live in [Herdr](herdr.md).
 - Older Claude Code changelog decisions and release notes live in
   [Claude Changelog Tracking](claude-changelog-tracking.md).
 
@@ -124,5 +126,6 @@ Full diagnosis and commands live in
 - [Claude Workspace Trust](claude-workspace-trust.md)
 - [Codex CLI](codex-cli.md)
 - [Codex CLI Optimization Tracking](codex-optimization-tracking.md)
+- [Herdr](herdr.md)
 - [Claude Changelog Tracking](claude-changelog-tracking.md)
 - [Orchestrator Runbook](orchestrator-runbook.md)

--- a/skills/dotfiles/references/herdr.md
+++ b/skills/dotfiles/references/herdr.md
@@ -1,0 +1,25 @@
+# Herdr Harness Reference
+
+Herdr is a terminal workspace manager for AI coding agents. This dotfiles repo
+installs it as part of the shared Home Manager package set so it is available
+from normal shells.
+
+## 1. Source Of Truth
+
+- Binary package: `llmAgents.herdr` in `nix/home-manager/default.nix`
+- Upstream project: <https://github.com/ogulcancelik/herdr>
+- Upstream docs: <https://herdr.dev/docs/>
+
+The package comes from the `llm-agents.nix` flake input, matching the existing
+agent CLI package source used for Claude Code, Codex CLI, and related tools.
+
+## 2. Local Use
+
+Start Herdr in the repository or workspace directory:
+
+```sh
+herdr
+```
+
+Herdr manages panes and long-running agent sessions in the terminal. Use the
+upstream quick start and configuration docs for workflow-specific setup.


### PR DESCRIPTION
## Summary
- tighten the postman approver contract for public GitHub writes, production-data writes, and wrapper-mediated shell commands
- document why Bash deny rules and human approval gates remain separate policy layers
- install Herdr through the existing `llm-agents.nix` package source and add a short harness reference

## Verification
- `nix fmt`
- `git diff --check`
- `bash scripts/validation/validate-skill-frontmatter.sh skills/dotfiles`
- `nix flake check --print-build-logs`

## Notes
- This combines the previously separated harness approval policy and Herdr follow-up work onto one branch because the publication approval covered one remote branch publication.
- Public write approval was limited to publishing `agent/harness-herdr-followups` and creating this PR.