### PR TITLE
Repair ghq repo locks before update

### DIFF
--- a/config/zsh/snippet.zsh
+++ b/config/zsh/snippet.zsh
@@ -20,7 +20,7 @@ else
 fi
 __snippet_add "ll" "ll" "$__snippet_ll_body" ""
 unset __snippet_ll_body
-__snippet_add "update" "up" "ghq list | ghq get --update --parallel && ghq-repo-status" ""
+__snippet_add "update" "up" "ghq-repo-repair && ghq list | ghq get --update --parallel && ghq-repo-status" ""
 __snippet_add "(AWS) profile" "p" "--profile \$(aws configure list-profiles | fzf)" "^aws[[:space:]]"
 __snippet_add "(Git) graph" "lo" "log --graph --format='%C(auto)%h%C(auto)%d %C(auto)%s%n%C(brightblack)[%ai] %C(green)<%an> %C(brightblack)<%ae>' --name-status" "^git[[:space:]]"
 __snippet_add "(Git) graph --all" "la" "log --graph --format='%C(auto)%h%C(auto)%d %C(auto)%s%n%C(brightblack)[%ai] %C(green)<%an> %C(brightblack)<%ae>' --name-status --all" "^git[[:space:]]"

--- a/scripts/bin/ghq-repo-repair
+++ b/scripts/bin/ghq-repo-repair
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ghq-repo-repair [--dry-run] [--min-age SECONDS] [--keep-unknown-locks] [--no-clean-locks] [--no-prune-worktrees]
+
+Repair common transient Git state across ghq-managed repositories.
+
+By default this command:
+  1. removes stale Git lock files that have a dead core.lockfilePid sidecar,
+  2. removes PID-less Git lock files after a conservative age floor,
+  3. prunes stale git-worktree administrative entries.
+
+Locks with a live PID and intentional `git worktree lock` markers are
+respected, not removed.
+
+Options:
+  --dry-run              Inspect locks and worktree prune candidates without changing them.
+  --min-age SECONDS      Minimum lock age before removal. Default: 300.
+  --keep-unknown-locks   Do not remove old locks without a valid PID sidecar.
+  --no-clean-locks       Skip stale Git lock cleanup.
+  --no-prune-worktrees   Skip `git worktree prune`.
+  -h, --help             Show this help.
+EOF
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+
+  command -v "$command_name" >/dev/null 2>&1 ||
+    die "required command not found: ${command_name}"
+}
+
+ghq_root_with_trailing_slash() {
+  local root="$1"
+
+  [[ $root == */ ]] || root="${root}/"
+  printf '%s\n' "$root"
+}
+
+repo_label() {
+  local repo_path="$1"
+
+  case "$repo_path" in
+    "$ghq_root"*)
+      printf '%s\n' "${repo_path#"$ghq_root"}"
+      ;;
+    *)
+      printf '%s\n' "$repo_path"
+      ;;
+  esac
+}
+
+is_git_repository() {
+  local repo_path="$1"
+
+  [[ -d "${repo_path}/.git" || -f "${repo_path}/.git" ]]
+}
+
+print_nonempty_output() {
+  local heading="$1"
+  local output_file="$2"
+
+  [[ -s $output_file ]] || return 0
+  printf '%s\n' "$heading"
+  sed 's/^/  /' "$output_file"
+}
+
+repair_repo() {
+  local repo_path="$1"
+  local label
+  local locks_output
+  local prune_output
+  local -a clean_args
+
+  is_git_repository "$repo_path" || return 0
+  label=$(repo_label "$repo_path")
+
+  if [[ $clean_locks == "true" ]]; then
+    locks_output=$(mktemp /tmp/ghq-repo-repair-locks.XXXXXX)
+    if [[ $dry_run == "true" ]]; then
+      git-locks --repo "$repo_path" --all-worktrees --min-age "$min_age" >"$locks_output" 2>&1 || {
+        print_nonempty_output "[${label}] git-locks failed:" "$locks_output"
+        rm -f "$locks_output"
+        return 1
+      }
+    else
+      clean_args=(--clean-stale)
+      if [[ $clean_unknown_locks == "true" ]]; then
+        clean_args+=(--clean-unknown)
+      fi
+      git-locks --repo "$repo_path" --all-worktrees "${clean_args[@]}" --min-age "$min_age" >"$locks_output" 2>&1 || {
+        print_nonempty_output "[${label}] git-locks failed:" "$locks_output"
+        rm -f "$locks_output"
+        return 1
+      }
+    fi
+
+    if ! grep -qx 'No Git lock files found.' "$locks_output"; then
+      print_nonempty_output "[${label}] git locks:" "$locks_output"
+    fi
+    rm -f "$locks_output"
+  fi
+
+  if [[ $prune_worktrees == "true" ]]; then
+    prune_output=$(mktemp /tmp/ghq-repo-repair-prune.XXXXXX)
+    if [[ $dry_run == "true" ]]; then
+      GIT_OPTIONAL_LOCKS=0 git -C "$repo_path" worktree prune --dry-run --verbose >"$prune_output" 2>&1 || {
+        print_nonempty_output "[${label}] git worktree prune failed:" "$prune_output"
+        rm -f "$prune_output"
+        return 1
+      }
+    else
+      GIT_OPTIONAL_LOCKS=0 git -C "$repo_path" worktree prune --verbose >"$prune_output" 2>&1 || {
+        print_nonempty_output "[${label}] git worktree prune failed:" "$prune_output"
+        rm -f "$prune_output"
+        return 1
+      }
+    fi
+
+    print_nonempty_output "[${label}] worktree prune:" "$prune_output"
+    rm -f "$prune_output"
+  fi
+}
+
+repair_all_repositories() {
+  local repo_path
+  local failures=0
+
+  while IFS= read -r repo_path; do
+    [[ -n $repo_path ]] || continue
+    repair_repo "$repo_path" || failures=$((failures + 1))
+  done < <(ghq list -p)
+
+  if (( failures > 0 )); then
+    echo "Warning: repair failed for ${failures} repository/repositories." >&2
+    return 1
+  fi
+}
+
+dry_run="false"
+clean_locks="true"
+clean_unknown_locks="true"
+prune_worktrees="true"
+min_age=300
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    --min-age)
+      [[ $# -ge 2 ]] || die "--min-age requires a value"
+      min_age="$2"
+      [[ $min_age != *[!0-9]* ]] || die "--min-age must be a non-negative integer"
+      shift 2
+      ;;
+    --keep-unknown-locks)
+      clean_unknown_locks="false"
+      shift
+      ;;
+    --no-clean-locks)
+      clean_locks="false"
+      shift
+      ;;
+    --no-prune-worktrees)
+      prune_worktrees="false"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+require_command ghq
+require_command git
+require_command git-locks
+
+ghq_root_raw=$(ghq root 2>/dev/null) ||
+  die "could not determine ghq root"
+[[ -n $ghq_root_raw ]] || die "could not determine ghq root"
+ghq_root=$(ghq_root_with_trailing_slash "$ghq_root_raw")
+
+if [[ $dry_run == "true" ]]; then
+  echo "* Inspecting ghq repositories without changing files."
+else
+  echo "* Repairing ghq repositories before update."
+fi
+repair_all_repositories
+
+if [[ $dry_run == "true" ]]; then
+  echo "* Dry run complete."
+fi

--- a/scripts/bin/git-locks
+++ b/scripts/bin/git-locks
@@ -6,21 +6,23 @@ set -o pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  git-locks [--all-worktrees] [--clean-stale] [--min-age SECONDS]
+  git-locks [--repo PATH] [--all-worktrees] [--clean-stale] [--clean-unknown] [--min-age SECONDS]
 
 Inspect Git lock files for the current repository. By default this reports
 locks for the current worktree git-dir and the shared common git-dir.
 
 Options:
+  --repo PATH         Inspect PATH instead of the current directory.
   --all-worktrees    Also inspect every linked worktree in this repository.
   --clean-stale      Remove locks whose core.lockfilePid PID is no longer alive.
-  --min-age SECONDS  Minimum lock age before --clean-stale removes it. Default: 5.
+  --clean-unknown    Remove locks without a valid PID sidecar after --min-age.
+  --min-age SECONDS  Minimum lock age before cleanup removes it. Default: 5.
   -h, --help         Show this help.
 EOF
 }
 
 git_readonly() {
-  GIT_OPTIONAL_LOCKS=0 git "$@"
+  GIT_OPTIONAL_LOCKS=0 git -C "$repo_path" "$@"
 }
 
 die() {
@@ -31,11 +33,7 @@ die() {
 file_mtime_epoch() {
   local path="$1"
 
-  if stat -c %Y "$path" >/dev/null 2>&1; then
-    stat -c %Y "$path"
-  else
-    stat -f %m "$path"
-  fi
+  stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null
 }
 
 format_age() {
@@ -133,17 +131,28 @@ add_scan_dir() {
 }
 
 clean_stale="false"
+clean_unknown="false"
 all_worktrees="false"
 min_age=5
+repo_path="."
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || die "--repo requires a path"
+      repo_path="$2"
+      shift 2
+      ;;
     --all-worktrees)
       all_worktrees="true"
       shift
       ;;
     --clean-stale)
       clean_stale="true"
+      shift
+      ;;
+    --clean-unknown)
+      clean_unknown="true"
       shift
       ;;
     --min-age)
@@ -164,6 +173,7 @@ done
 
 repo_root=$(git_readonly rev-parse --show-toplevel 2>/dev/null) ||
   die "not inside a Git repository"
+repo_path="$repo_root"
 git_dir=$(git_readonly rev-parse --path-format=absolute --git-dir)
 git_common_dir=$(git_readonly rev-parse --path-format=absolute --git-common-dir)
 now=$(date +%s)
@@ -180,7 +190,7 @@ fi
 if [[ $all_worktrees == "true" ]]; then
   while IFS= read -r worktree_path; do
     [[ -n $worktree_path ]] || continue
-    worktree_git_dir=$(git -C "$worktree_path" rev-parse --path-format=absolute --git-dir 2>/dev/null || true)
+    worktree_git_dir=$(GIT_OPTIONAL_LOCKS=0 git -C "$worktree_path" rev-parse --path-format=absolute --git-dir 2>/dev/null || true)
     [[ -n $worktree_git_dir ]] || continue
     add_scan_dir "$scan_dirs" "worktree:${worktree_path##*/}" "$worktree_git_dir"
   done < <(git_readonly worktree list --porcelain | awk '/^worktree / { sub(/^worktree /, ""); print }')
@@ -215,7 +225,7 @@ while IFS=$'\t' read -r label scan_dir; do
     found="true"
     relative_path=$(relative_lock_path "$scan_dir" "$lock_file")
     display_path="${label}:${relative_path}"
-    mtime=$(file_mtime_epoch "$lock_file")
+    mtime=$(file_mtime_epoch "$lock_file") || continue
     age_seconds=$((now - mtime))
     age=$(format_age "$age_seconds")
     pid_file="${lock_file%.lock}~pid.lock"
@@ -223,6 +233,7 @@ while IFS=$'\t' read -r label scan_dir; do
     state="unknown:no-pid-file"
     action="kept"
     stale="false"
+    unknown="false"
 
     if pid_value=$(read_lock_pid "$pid_file"); then
       pid="$pid_value"
@@ -241,9 +252,11 @@ while IFS=$'\t' read -r label scan_dir; do
       case $? in
         1)
           state="unknown:no-pid-file"
+          unknown="true"
           ;;
         2)
           state="unknown:bad-pid-file"
+          unknown="true"
           ;;
       esac
     fi
@@ -255,8 +268,17 @@ while IFS=$'\t' read -r label scan_dir; do
       else
         action="kept:younger-than-${min_age}s"
       fi
+    elif [[ $clean_unknown == "true" && $unknown == "true" ]]; then
+      if (( age_seconds >= min_age )); then
+        rm -f -- "$lock_file" "$pid_file"
+        action="cleaned:unknown"
+      else
+        action="kept:younger-than-${min_age}s"
+      fi
     elif [[ $stale == "true" ]]; then
       action="candidate:--clean-stale"
+    elif [[ $unknown == "true" ]]; then
+      action="candidate:--clean-unknown"
     fi
 
     display_path=$(shorten "$display_path" 42)

--- a/skills/dotfiles/references/workspace-guidance.md
+++ b/skills/dotfiles/references/workspace-guidance.md
@@ -187,6 +187,14 @@ inspection, cleanup, and baseline verification.
 Use `scripts/bin/git-locks` when a Git command reports an existing lock such as
 `.git/index.lock`.
 
+For the common ghq-wide update case, run `ghq-repo-repair` before
+`ghq get --update --parallel`. It scans every ghq-managed repository, removes
+stale PID-backed locks, removes sufficiently old PID-less lock files, and
+prunes stale worktree administrative entries. The `up` zsh snippet expands to
+`ghq-repo-repair && ghq list | ghq get --update --parallel && ghq-repo-status`.
+Use `ghq-repo-repair --dry-run` to inspect the cleanup candidates without
+changing files.
+
 `git-locks` inspects the current repository with `GIT_OPTIONAL_LOCKS=0`, so the
 diagnostic read should not create optional index locks. By default it scans the
 current worktree git-dir plus the shared common git-dir. Pass
@@ -213,9 +221,11 @@ git-locks --all-worktrees --clean-stale
 ```
 
 Cleanup removes only locks with a valid PID sidecar whose process is not
-running. Locks without a PID sidecar are reported as unknown and are not removed
-automatically. The default cleanup age floor is 5 seconds; override it only for
-tests or when you have just verified the race is impossible:
+running. `--clean-unknown` also removes PID-less or invalid-PID locks after the
+configured age floor; this is intended for old, clearly abandoned locks such as
+failed ghq-wide updates, not for active repositories. The default cleanup age
+floor is 5 seconds; override it only for tests or when you have just verified
+the race is impossible:
 
 ```bash
 git-locks --clean-stale --min-age 0


### PR DESCRIPTION
## Summary

- Add `ghq-repo-repair` to clean stale Git lock files and prune stale worktree metadata across ghq-managed repositories.
- Expand the `up` zsh snippet to run `ghq-repo-repair && ghq list | ghq get --update --parallel && ghq-repo-status`.
- Extend `git-locks` with `--repo` and `--clean-unknown`, and make lock scans tolerate disappearing lock files.
- Document the ghq-wide repair flow in `skills/dotfiles/references/workspace-guidance.md`.

## Why

`ghq get --update --parallel` can fail when a repository or linked worktree has an abandoned Git lock. The new preflight repair command handles the common stale-lock and worktree-prune cases before running the existing update/status workflow.

## Verification

- `bash -n scripts/bin/ghq-repo-repair scripts/bin/git-locks scripts/bin/ghq-repo-status`
- `shellcheck scripts/bin/ghq-repo-repair scripts/bin/git-locks scripts/bin/ghq-repo-status`
- `git diff --check`
- `PATH="$PWD/scripts/bin:$PATH" ghq-repo-repair --dry-run`
- `PATH="$PWD/scripts/bin:$PATH" ghq-repo-repair && ghq list | ghq get --update --parallel && PATH="$PWD/scripts/bin:$PATH" ghq-repo-status`
