### PR TITLE
docs(agents): refine CLI tracking and role controls

### DIFF
--- a/skills/dotfiles/references/agent-hooks-architecture.md
+++ b/skills/dotfiles/references/agent-hooks-architecture.md
@@ -130,11 +130,12 @@ without being able to mutate the repo. It reads `pane_title` via
 roles when the target file is outside the allowlisted state
 directories.
 
-Codex does not yet have comparable enforcement because Codex's multi-agent
-model is different — there is no equivalent `pane_title` role contract to
-enforce against. This asymmetry is deliberate, not drift, and it should stay
-asymmetric unless Codex grows a role contract worth gating on or local payload
-observations prove that role-aware deny logic can be implemented reliably.
+Codex preserves the same tmux `pane_title` role identity by setting
+`tui.terminal_title = []`. It does not yet have comparable enforcement because
+the observed Codex write-hook payload has not supplied a validated mapping from
+that identity to a hook invocation, nor a validated deny/blocking result. This
+asymmetry is deliberate, not drift, and should remain until focused real-write
+validation proves both pieces.
 
 Codex's primary file-edit primitive is `apply_patch` (a single patch-applied
 tool), not the Write/Edit/NotebookEdit triple Claude exposes. The current Codex
@@ -144,6 +145,23 @@ unless `CODEX_HOOK_OBSERVE_DIR` overrides the directory; it does not deny. If
 enforcement is added later, the matcher and patch-shaped payload differ enough
 that the script body should stay separate from Claude's pane-title-aware
 deny-write hook.
+
+### 4.2. Codex Role Configuration Is Not Role-Based Enforcement
+
+Codex CLI v0.145.0 stabilizes multi-agent role configuration: `[agents]` can
+set subagent model, reasoning effort, and concurrency, and generated agent
+files provide per-role prompts. That is useful for assigning work, but it is
+not an authorization signal comparable to the tmux pane title consumed by
+`claude-pretooluse-deny-write.sh`.
+
+Keep the shared policy in `postman.md`, shared prompt sources, and the common
+Bash deny hook. Keep runtime enforcement deliberately different: Claude can
+apply the established pane-title write gate; Codex continues to observe actual
+write-hook payloads. Codex's documented `PreToolUse` matcher covers
+`apply_patch` (with `Edit` and `Write` aliases), but the observer has not yet
+supplied evidence for a dependable role-to-write mapping or blocking behavior.
+Do not convert the observer into a deny hook until a focused, real-write
+validation proves both.
 
 ## 5. Direction We Want To Keep Pulling In
 
@@ -167,7 +185,7 @@ The script directory naming convention we are converging on:
 | Prefix        | Meaning                                                                   |
 | ------------- | ------------------------------------------------------------------------- |
 | `claude-*.sh` | Claude-only by design (e.g. `claude-pretooluse-deny-write.sh`).           |
-| `codex-*.sh`  | Codex-only by design (none currently).                                    |
+| `codex-*.sh`  | Codex-only by design (e.g. `codex-pretooluse-observe-write.sh`).          |
 | `common-*.sh` | Shared, parameterised by runtime arg (e.g. `common-userpromptsubmit.sh`). |
 | `<no prefix>` | Shared, runtime-agnostic (e.g. `pretooluse-deny-bash.sh`).                |
 

--- a/skills/dotfiles/references/claude-optimization-tracking.md
+++ b/skills/dotfiles/references/claude-optimization-tracking.md
@@ -6,19 +6,22 @@ in `claude-changelog-tracking.md`.
 
 ## 1. Optimization Tracking
 
-Last reviewed Claude Code version: v2.1.210 (2026-07-15)
+Last reviewed Claude Code version: v2.1.220 (2026-07-25)
 
-Review confirmation (2026-07-15): local `claude --version` reported
-`2.1.210 (Claude Code)`, and the official
-`anthropics/claude-code` `CHANGELOG.md` contains the matching `2.1.210`
-section. This pass migrated file-edit deny rules from invalid
-`Write(path)` syntax to `Edit(path)` after v2.1.210 added startup warnings for
-`Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rules.
+Review confirmation (2026-07-25): local `claude --version` reported
+`2.1.220 (Claude Code)`, and the official
+`anthropics/claude-code` `CHANGELOG.md` contains the matching `2.1.220`
+section. This pass reviewed 2.1.211 through 2.1.220. The prior pass migrated
+file-edit deny rules from invalid `Write(path)` syntax to `Edit(path)` after
+v2.1.210 added startup warnings for `Write(path)`, `NotebookEdit(path)`, and
+`Glob(path)` permission rules.
 
 ### 1.1. Applied Optimizations
 
-- [x] Runtime-root instruction file removed; persona and scope now flow through
-  `config/tmux-a2a-postman/postman.md`
+- [x] The full runtime-root persona/scope prompt was removed; persona and scope
+  now flow through `config/tmux-a2a-postman/postman.md`. A minimal
+  direct-invocation fallback remains at `~/.claude/CLAUDE.md`, derived from
+  `nix/home-manager/agents/shared/AGENTS.md`.
 - [x] Skills installed through `shared/agent-skills.nix`
 - [x] Claude agents generated from
   `nix/home-manager/agents/subagents/*.md` plus
@@ -314,6 +317,23 @@ section. This pass migrated file-edit deny rules from invalid
 - [x] Background-agent attach, memory, MCP refresh, terminal rendering, and
   telemetry-redaction fixes through v2.1.210 - product reliability; current
   harness benefits automatically with no source change.
+
+#### 1.2.7. v2.1.211 -> v2.1.220 candidates (added 2026-07-25)
+
+- [x] Claude Opus 5 default, dynamic-workflow sizing, nested-subagent
+  forwarding, and related background-agent reliability changes (v2.1.211-
+  v2.1.220) - no managed setting change. Launchers retain their explicit
+  model/effort choices and the postman topology remains the authority for
+  orchestration.
+- [x] `DirectoryAdded` hook (v2.1.219) - no new hook. The existing role policy
+  is tied to tmux pane identity and tool use, not directory registration.
+- [ ] `sandbox.network.strictAllowlist` (v2.1.219) - defer. It is a useful
+  sandbox control, but these headless panes deliberately use bypass
+  permissions and have no reviewed end-to-end sandbox policy yet. They
+  therefore have no enforced egress allowlist. Do not add a partial allowlist
+  that could silently break MCP, package, or documentation
+  access.
+- [x] 2.1.220 bug-fix-only release - no source migration.
 
 For decision log ("Not Adopting") and per-version changelog,
 see [Claude Changelog Tracking](claude-changelog-tracking.md).

--- a/skills/dotfiles/references/codex-cli.md
+++ b/skills/dotfiles/references/codex-cli.md
@@ -168,22 +168,29 @@ Ignore any release entries for versions newer than `codex --version`.
   rejection tells the agent what to do next, not just what was blocked
 - YOU MUST: Treat Codex write-tool control as observational until local hook
   payloads prove enough structure for reliable deny logic
-- NOTE: As of Codex CLI v0.144.4, official docs say `PreToolUse` can match
+- NOTE: As of Codex CLI v0.145.0, official docs say `PreToolUse` can match
   canonical `Bash`, `apply_patch`, and MCP tool names; `apply_patch` also
-  matches `Edit` and `Write`. The Codex-only
-  `PreToolUse` matcher=`apply_patch|Edit|Write` observer remains observational
-  until local hook payloads prove enough structure for reliable deny logic. The
-  script is
+  matches `Edit` and `Write`. The Codex-only `PreToolUse`
+  matcher=`apply_patch|Edit|Write` observer remains observational until local
+  hook payloads prove enough structure for reliable deny logic and blocking
+  behavior. The script is
   `nix/home-manager/agents/scripts/codex-pretooluse-observe-write.sh`; it
-  appends metadata to the Codex write-tool observation log. A restarted
-  agent pane created and removed a temporary file with the Codex `apply_patch`
-  file tool on 2026-05-11; the observer log stayed at the single manual
-  script-test entry. Keep the hook installed because it is low-risk and will
-  reveal payload shape, but do not claim it currently controls real
-  `apply_patch` writes.
-- NEVER: Rely on unsupported `permissionDecision: "ask"` / `"allow"`,
-  `updatedInput`, or `additionalContext` fields for `PreToolUse`; the current
-  runtime parses them but fails open
+  appends metadata to
+  `~/.cache/codex/hook-observations/pretooluse-write-tools.jsonl`. Live
+  inspection on 2026-07-25 with
+  `jq -s '{record_count:length, tool_names:([.[].tool_name] | unique), most_recent:.[-1]}'`
+  reported 2,468 records, `tool_names: ["apply_patch"]`, and a most-recent
+  `PreToolUse` record at `2026-07-25T08:18:11Z` from another local repository
+  cwd. Its scalar paths included `cwd`, `tool_input.command`, `tool_name`,
+  `session_id`, and `turn_id`. This proves that real `apply_patch` activity
+  reaches the observer, but does not validate role-to-title mapping or blocking
+  enforcement; do not claim that the hook controls writes.
+- NEVER: Treat `permissionDecision: "ask"` as a supported `PreToolUse`
+  outcome. Current Codex documentation establishes that `PreToolUse` can
+  inspect JSON arguments and block or rewrite a local tool call. This repo has
+  not used or locally validated allow decisions, input rewrites, or additional
+  context for role-to-title mapping or blocking enforcement, so none is an
+  active local role-control guarantee.
 - NOTE: Official docs list `SessionStart`, `PreToolUse`, `PermissionRequest`,
   `PostToolUse`, `PreCompact`, `PostCompact`, `UserPromptSubmit`,
   `SubagentStart`, `SubagentStop`, and `Stop` as supported events. Matchers are

--- a/skills/dotfiles/references/codex-optimization-tracking.md
+++ b/skills/dotfiles/references/codex-optimization-tracking.md
@@ -5,19 +5,25 @@ and version history for Codex CLI. The runtime overview lives in `codex-cli.md`.
 
 ## 1. Optimization Tracking
 
-Last reviewed Codex CLI version: v0.144.4 (2026-07-15)
+Last reviewed Codex CLI version: v0.145.0 (2026-07-25)
 
-Review confirmation (2026-07-15): local `codex --version` reported
-`codex-cli 0.144.4`, and the official `openai/codex` release
-`rust-v0.144.4` is the latest stable release. Newer
-`rust-v0.145.0-alpha.*` releases are prereleases and are not treated as active
-local behavior.
+Review confirmation (2026-07-25): local `codex --version` reported
+`codex-cli 0.145.0`, and the official stable `openai/codex` release
+`rust-v0.145.0` was published on 2026-07-21. This pass excludes only releases
+newer than that installed version.
 
-### 1.1. Release Catch-up (v0.136.0 -> v0.144.4)
+### 1.1. Release Catch-up (v0.136.0 -> v0.145.0)
 
-Stable releases through the locally installed `codex-cli 0.144.4` add mostly
+Stable releases through the locally installed `codex-cli 0.145.0` add mostly
 product/runtime capabilities rather than required dotfiles config changes:
 
+- v0.145.0 stabilizes multi-agent V2, including configurable subagent models,
+  reasoning levels, concurrency, role restoration, and agent navigation. The
+  existing generated per-agent TOML remains the role-definition source; do not
+  add global `[agents]` defaults because they would broaden behavior beyond
+  the launcher and per-agent defaults already in use. This release does not
+  establish a role-to-tmux-pane identity mapping or a reliable role-based
+  write-deny output contract, so the Codex write hook remains observational.
 - v0.144.4 is a patch release with no user-facing changes.
 - v0.144.3 is a version-only release with no merged PR changes after v0.144.2.
 - v0.144.2 restores the previous Guardian auto-review policy, request format,
@@ -108,16 +114,23 @@ incident runbook is archived in the private vault
 
 ### 1.3. Applied Optimizations
 
-- [x] Runtime-root instruction file removed; persona and scope now flow through
-  `config/tmux-a2a-postman/postman.md`; applicable skills flow through the
-  generated `skill_path` catalog, while catch-all repo background lives in docs
-- [x] skills/ symlinked to Claude Code skills
+- [x] The full runtime-root persona/scope prompt was removed; persona and scope
+  now flow through `config/tmux-a2a-postman/postman.md`. A minimal
+  direct-invocation fallback remains at `~/.codex/AGENTS.md`, derived from
+  `nix/home-manager/agents/shared/AGENTS.md`; applicable skills flow through
+  the generated `skill_path` catalog, while catch-all repo background lives in
+  docs.
+- [x] Separate minimal/allowlisted Codex skills bundle materialized by
+  `nix/home-manager/agents/shared/agent-skills.nix`; Codex does not symlink or
+  consume Claude's full active skill set
 - [x] Shared Bash command-deny policy enforced through the Codex
   `PreToolUse` matcher=`Bash`; `default.rules` is not generated for the
   shared deny set.
-- [x] Home-level Codex hooks reduced to the load-bearing minimum:
-  `UserPromptSubmit` (shared `common-userpromptsubmit.sh codex`) and
-  `PreToolUse` matcher=`Bash` (shared `pretooluse-deny-bash.sh`).
+- [x] Home-level Codex hooks reduced to the load-bearing set:
+  `UserPromptSubmit` (shared `common-userpromptsubmit.sh codex`),
+  `PreToolUse` matcher=`Bash` (shared `pretooluse-deny-bash.sh`), and
+  `PreToolUse` matcher=`apply_patch|Edit|Write`
+  (`codex-pretooluse-observe-write.sh`, observational).
   Removed 2026-04-29: `SessionStart` (`codex-sessionstart-reload.sh`),
   `PostToolUse` matcher=`Bash` (`codex-posttooluse-review.sh`), and
   `Stop` (`codex-stop-save.sh`) — see commit `6add5abb`.
@@ -131,8 +144,9 @@ incident runbook is archived in the private vault
   and sed delimiter fixes). See commit `5fb7e44a`.
 - [x] Shared deny-bash justifications upgraded from bare denials to repair
   guidance for both Claude Code and Codex CLI
-- [x] Codex `UserPromptSubmit` now carries time, role, cwd, and git context
-  (via shared `common-userpromptsubmit.sh codex`)
+- [x] Codex `UserPromptSubmit` now carries time, role, cwd, git, launch
+  command, and add-dir path/context (via shared
+  `common-userpromptsubmit.sh codex`)
 - [x] `model_auto_compact_token_limit =
   builtins.floor (codexContextWindow * 0.7)` autocompact at 70% (190,400
   tokens for gpt-5.x 272k window)
@@ -140,8 +154,9 @@ incident runbook is archived in the private vault
   `pane_title` stays reserved for role identity (v0.117.0)
 - [x] `codexScriptsDir` switched from `codex-*` glob to explicit `ln` list
   (commit `5fb7e44a`). The old glob would have expanded to literal
-  `codex-*` after consolidation (no codex-prefixed scripts left) and
-  failed the `runCommand` build. The explicit list also documents the
+  `codex-*` after consolidation and failed the `runCommand` build. The
+  explicit list retains the Codex-only `codex-pretooluse-observe-write.sh`
+  observer and documents the
   Codex consumed surface in one place.
 - [x] Removed `features.apps = false` on 2026-05-31 to allow Codex Apps by
   default again. It had been added 2026-05-03 after observing `codex_apps` MCP
@@ -200,6 +215,9 @@ incident runbook is archived in the private vault
   are generated from `nix/home-manager/agents/subagents/*.md` plus
   `nix/home-manager/agents/subagents/metadata.nix` by
   `shared/install-manifest.nix` and installed by `codex/default.nix`
+- [x] Multi-agent V2 role configuration reviewed at v0.145.0. Per-agent
+  generated TOML and launcher model/effort choices remain the narrowest
+  configuration surface; no global `[agents]` default is required.
 - [x] Status line permission/approval indicators - adopted after v0.131.0 added
   native TUI status items; generated `config.toml` now renders `permissions`
   and `approval-mode` next to model/context/version so `--yolo` and sandbox
@@ -224,10 +242,19 @@ incident runbook is archived in the private vault
 - `tui.notifications_method` - keep default
 - `CLAUDE_CODE_DISABLE_CRON` env - N/A for Codex CLI
 - `approval_policy: on-failure` - deprecated (v0.102.0); not used in config
-- `PreToolUse` / `PostToolUse` matcher patterns like `Write|Edit` - current
-  Codex runtime only emits `Bash`, so these configs are misleading today
-- `permissionDecision: "ask"` / `"allow"` and `updatedInput` in `PreToolUse` -
-  current runtime parses them but does not enforce them
+- role-based write enforcement in Codex - v0.145.0 has stable role
+  configuration and `PreToolUse` can match `apply_patch` (including `Edit` and
+  `Write` aliases). Codex preserves the existing tmux pane-title role identity
+  through `tui.terminal_title = []`, but the observed hook payload does not yet
+  provide a validated role-to-title mapping or deny/blocking enforcement.
+  Keep the write hook as an observer until actual write-path payloads and a
+  deny result are validated.
+- `permissionDecision: "ask"` is not a supported `PreToolUse` outcome. The
+  current Codex manual documents JSON-argument inspection plus call blocking
+  and rewriting, but this repo has not used or locally validated allow
+  decisions, input rewrites, or additional context as a role-enforcement
+  mechanism. The managed configuration does not currently depend on any of
+  those capabilities for role-to-title mapping or blocking enforcement.
 - PostToolUse Bash hooks at all - the previous `codex-posttooluse-review.sh`
   feedback decorator was removed 2026-04-29 (commit `6add5abb`); the agent
   reads command failures directly from stdout/stderr without a hook
@@ -250,6 +277,12 @@ incident runbook is archived in the private vault
 
 ### 1.6. Version Notes
 
+- v0.145.0 (2026-07-21): Latest stable at review time; local `codex --version`
+  reported `codex-cli 0.145.0`. Stabilized multi-agent V2 with configurable
+  subagent models, reasoning, concurrency, restored roles, and improved agent
+  navigation. No runtime config change: generated per-agent TOML and launcher
+  defaults already define the active roles, while role-based write enforcement
+  remains deliberately unimplemented pending reliable hook validation.
 - v0.144.4 (2026-07-14): Latest stable at review time; patch release with no
   user-facing changes. Local `codex --version` reported `codex-cli 0.144.4`.
 - v0.144.3 (2026-07-13): Version-only release with no merged PR changes after

--- a/skills/dotfiles/references/operating-concepts.md
+++ b/skills/dotfiles/references/operating-concepts.md
@@ -225,8 +225,8 @@ Across Claude and Codex, hooks currently do two load-bearing jobs:
 The Claude side has the richer hook surface, so it carries one additional
 role-readonly guard:
 
-- `common-userpromptsubmit.sh claude` injects time, role, cwd, git, add-dir,
-  and usage context
+- `common-userpromptsubmit.sh claude` injects time, role, cwd, git, launch
+  command, and add-dir path/context
 - `pretooluse-deny-bash.sh` enforces the shared Bash deny policy
 - `claude-pretooluse-deny-write.sh` prevents non-worker role panes from
   mutating files outside approved state directories
@@ -235,9 +235,12 @@ role-readonly guard:
 
 The Codex side uses the hooks it has to approximate the same contract:
 
-- `common-userpromptsubmit.sh codex` injects time, role, cwd, git, and
-  add-dir context
+- `common-userpromptsubmit.sh codex` injects time, role, cwd, git, launch
+  command, and add-dir path/context
 - `pretooluse-deny-bash.sh` enforces the shared Bash deny policy
+- `codex-pretooluse-observe-write.sh` observes and logs `apply_patch|Edit|Write`
+  write-tool payloads; it is non-enforcing and does not provide locally
+  validated role-based write denial
 
 The hook surfaces are intentionally small after the 2026-04-29 reduction. The
 repo relies on durable `mkmd` artifacts and postman traffic for handoff state

--- a/skills/dotfiles/references/repo-ai-operating-contract.md
+++ b/skills/dotfiles/references/repo-ai-operating-contract.md
@@ -42,9 +42,13 @@ skill bodies live in top-level `skills/<name>/SKILL.md`; postman
 injects a generated catalog for that local skill tree through `skill_path`.
 
 <!-- private-content-scan: allow-next-line -->
-There is no generated root instruction file under `~/.claude/` or `~/.codex/`
-for this repo. Direct non-postman sessions rely on the installed runtime
-settings and skill trees until they receive a postman event.
+The full persona / language / scope prompt is not installed as a generated
+runtime-root instruction file under `~/.claude/` or `~/.codex/`. Minimal
+direct-invocation fallbacks remain: `~/.claude/CLAUDE.md` and
+`~/.codex/AGENTS.md`, both derived from
+`nix/home-manager/agents/shared/AGENTS.md`. Direct non-postman sessions use
+those fallbacks, installed runtime settings, and skill trees until they receive
+a postman event.
 
 ### 2.2. Declarative installation
 
@@ -190,7 +194,8 @@ surfaces allow:
 
 The Claude runtime currently carries:
 
-- `UserPromptSubmit` for role, cwd, git, and usage context
+- `UserPromptSubmit` for time, role, cwd, git, launch-command, and add-dir
+  path/context; `common-userpromptsubmit.sh` owns the complete payload
 - `PreToolUse` for shared Bash denials
 - `PreToolUse` for Claude-only role write denials
 
@@ -198,8 +203,10 @@ The Claude runtime currently carries:
 
 The Codex runtime currently carries:
 
-- `UserPromptSubmit` for role, cwd, and git context
+- `UserPromptSubmit` for time, role, cwd, git, launch-command, and add-dir
+  path/context; `common-userpromptsubmit.sh` owns the complete payload
 - `PreToolUse` for Bash denials
+- `PreToolUse` observer for `apply_patch|Edit|Write` write-tool payloads
 
 The surface is not identical, but the repo is aiming for equivalent operating
 discipline.


### PR DESCRIPTION
## Summary

- Refresh the Claude Code and Codex CLI reference material for role controls, hook behavior, optimization tracking, and operating contracts.
- Clarify the boundary between product hook capabilities and repository policy, including the current non-enforcing observer behavior.

## Why

These references needed to describe the current controls consistently so contributors can distinguish documented guidance from active enforcement.

## Impact

- Gives users and maintainers a clearer view of agent roles, hook context, and CLI-specific configuration boundaries.
- Documents the separate minimal Codex bundle and the limitations of the existing write observer.

## Limitations and non-changes

- Documentation only: this change adds no new live enforcement, permissions, hooks, or runtime behavior.
- Existing role-control limitations remain unchanged.

## Validation

- git diff --check
- nix run .#check
