### PR TITLE
feat(subagent-review): converge iterative reviews

### DIFF
--- a/nix/home-manager/agents/subagents/reviewer-historian.md
+++ b/nix/home-manager/agents/subagents/reviewer-historian.md
@@ -41,6 +41,15 @@ Project historian. Digs through context before passing judgment.
 4. Cross-reference: does the implementation match what was discussed?
 5. Check for regressions: does this undo something that was deliberately done?
 
+### 2.1. Blind-review channel
+
+When Guardian supplies a blind packet, use only its projected aliases and
+bounded neutral history digest. Do not request, infer, or emit real repository
+paths, filenames, issue/PR identifiers, URLs, commits, authors, branches,
+timestamps, or candidate identity. Report history evidence with the supplied
+alias and line reference (or `no file applicable`) so Guardian can bind it via
+the private control envelope.
+
 ## 3. Review Focus
 
 - Intent alignment: does the code do what the Issue/PR says it should?
@@ -50,6 +59,11 @@ Project historian. Digs through context before passing judgment.
 
 ## 4. Output Format
 
+### 4.1. Normal mode
+
+Use the normal format below when Guardian has not supplied a blind packet;
+Issue/PR/commit identifiers and repository paths are permitted.
+
 ```text
 ### [High/Medium/Low confidence] Issue Title
 
@@ -58,3 +72,11 @@ Project historian. Digs through context before passing judgment.
 - Problem: Misalignment or concern
 - Suggestion: How to reconcile
 ```
+
+### 4.2. Blind mode
+
+For a blind packet, return the same confidence, evidence, problem, and
+suggestion fields, but use only the supplied alias path and line reference (or
+`no file applicable`). Do not emit or infer Issue/PR/commit identifiers, real
+repository paths, filenames, URLs, authors, branches, timestamps, or candidate
+identity.

--- a/skills/dotfiles/references/prompt-blocks.md
+++ b/skills/dotfiles/references/prompt-blocks.md
@@ -159,7 +159,39 @@ finalizing.
 </dig_deeper_nudge>
 ```
 
-## 14. `progress_updates`
+## 14. `decision_quality_check`
+
+Use for research, diagnosis, recommendation, or review prompts where the agent
+must reach a defensible conclusion without overstating certainty.
+
+```xml
+<decision_quality_check>
+Run at least two genuinely independent checks before relying on a conclusion;
+if only one is feasible, say so and lower confidence.
+Do not relabel the same evidence as independent confirmation.
+For consequential work, keep a cumulative finding ledger across the task:
+claims and assumptions, supporting and conflicting evidence, confidence or
+uncertainty, discarded alternatives, and newly discovered relevant issues.
+Revisit the accumulated ledger before later decisions and self-audits. Add new
+relevant findings as they emerge; mark resolved items closed only when closure
+is supported by evidence.
+In a review workflow, only Guardian/critic synthesis owns that authoritative
+ledger. Reviewer checks are packet-local: they cannot create, close, or change
+Guardian ledger IDs.
+Challenge the load-bearing assumption only when a concrete alternative, failure
+mode, or counterexample could change the decision.
+State a direct recommendation when evidence supports one, then name material
+uncertainty and what would change the conclusion.
+Do not expose private chain-of-thought. For the decision-quality audit summary
+only, report at most three concise bullets: lead claim, disconfirming check or
+why none was feasible, and decision impact. This cap does not limit required
+review findings, attestations, or task output sections.
+Use neutral language: no pressure, flattery, shame, false urgency, or emotional
+steering.
+</decision_quality_check>
+```
+
+## 15. `progress_updates`
 
 Use when the run may take a while.
 

--- a/skills/dotfiles/references/review-output-contract.md
+++ b/skills/dotfiles/references/review-output-contract.md
@@ -11,6 +11,7 @@ review-oriented prompt.
 
 ```json
 {
+  "perspective": "architecture",
   "verdict": "approve",
   "summary": "Terse ship or no-ship assessment.",
   "findings": [
@@ -41,8 +42,19 @@ review-oriented prompt.
   speculation.
 - Every finding must include file and line coordinates, honest confidence, and
   a concrete recommendation.
+- A blind reviewer uses a projection-relative alias path and line coordinates;
+  use `no file applicable` when no inspected file supports the finding. The
+  Guardian control envelope binds aliases to real repository paths after review.
 - Keep claims grounded in inspected files or tool output.
 - Prefer one strong finding over several weak ones.
+
+### 2.1. Normal and blind modes
+
+Normal mode uses real repository paths and any inspected Issue/PR/commit
+evidence. Blind mode uses exactly one identity-safe representation: a supplied
+projection-relative alias path and line coordinates, or `no file applicable`.
+Blind mode never emits or infers real paths, filenames, Issue/PR/commit IDs,
+URLs, authors, branches, timestamps, or candidate identity.
 
 ## 3. Severity Guidance
 

--- a/skills/subagent-review/SKILL.md
+++ b/skills/subagent-review/SKILL.md
@@ -3,46 +3,42 @@ name: subagent-review
 license: MIT
 metadata:
   version: "1.0.0"
-description: "USE FOR: Guardian/critic reviews: native multi-perspective reviewer waves, peer critic review evidence, guardian verdict aggregation, synthesis of blocking findings. DO NOT USE FOR: implementation, dispatcher fan-out, model/tier overrides, or public posting."
+description: "USE FOR: Guardian/critic native multi-perspective review workflow, peer critic evidence, material-finding convergence, and blocking-finding synthesis. DO NOT USE FOR: implementation, dispatcher fan-out, overrides, or public posting."
 ---
 
 # Subagent Review
 
-Native reviewer perspectives: security, architecture, historian, code, QA.
-No implementation, approval, fan-out, or overrides.
+## 1. Ledger
 
-## 1. Workflow
+1. Before review, guardian freezes target, criteria, scope, and the
+   design/public boundary. Broadening is recorded, never inferred.
+2. Guardian owns a never-reused ledger (`F-001`); use the
+   [contract](references/review-topology.md) for required fields and reports.
+3. Guardian alone decides materiality and convergence; packets supply
+   observations, evidence, and risk signals. Nits never gate rework. Invalid
+   packets, missing evidence, authority gaps, cap exhaustion, and criterion
+   changes are guardian-recorded states.
 
-1. Run the cheapest verifier first.
-2. Each role: five subagent perspectives + one self-review (six inputs).
-   Guardian uses five Codex; critic uses guardian-specified (default: all
-   five). Guardian narrows; critic never self-selects.
-3. Self-review accompanies the wave, never replaces it. Direct-only applies
-   to guardian-labeled trivials; self-review still required.
-4. Subagent waves run in parallel; close before role self-review and
-   second-wave validators.
-5. Add the data reviewer only for specialized questions; give each
-   subagent bounded read-only paths, context, and output shape.
-6. Deduplicate per role; produce the critic packet (six) or guardian
-   verdict (twelve).
+## 2. Review to Convergence
 
-## 2. Role Rules
+1. Run cheapest verification. Guardian defines the required perspective set;
+   critic is guardian-specified and never self-selects. Waves are parallel.
+2. Deduplicate. Guardian MUST request critic for substantive review; critic
+   returns its set plus self-review; guardian aggregates both sets. Reviewers
+   never edit, commit, push, approve, or decide materiality. See the packet
+   schema and blind-projection contract in
+   [contract](references/review-topology.md).
+3. Each round reconciles every prior ID: recurrence, regression, new discovery,
+   closure, supersession, accepted risk, or unchanged; record changed criteria.
+4. Review the full change, then deduplicate material findings and freeze IDs,
+   closure conditions, and reproducible verification in one executor batch.
+   After rework, verify and review only that set unless scope/criteria changed.
+5. Repeat batched fix → verification → diff-review until closure, then final
+   confirmation. Cap: initial plus two failed reworks. At cap/unavailable
+   evidence, `BLOCKED` includes IDs, gap, authority needed, and next owner.
+   Quarantine invalid packets before a round; they consume no rework slot.
 
-- Guardian: five Codex subagents + one self-review (six); aggregates all six
-  into the intermediary result. MUST request critic for substantive reviews.
-- Critic: guardian-specified subagents (default: all five) + one self-review
-  (six); sends all six to guardian for twelve-input aggregation.
-- Guardian aggregates twelve (six + six) into the final verdict.
-- Postman request to critic authorizes launches. On block: `BLOCKED:
-  perspective launch not permitted`; no direct-only fallback.
-- Trivials may omit subagents when guardian so labels; self-review still
-  required.
-- Critic sends result to guardian, not orchestrator.
-- Reviewer subagents must not edit, commit, push, or approve.
-- If <five subagents complete, return `BLOCKED: fewer than required subagent
-  perspectives completed` unless pre-authorized. Critic replies include
-  `Required perspectives`, `Perspectives launched`, `Self-review: complete`.
+## 3. Round Report
 
-## 3. Output
-
-Perspective, paths, evidence, severity, confidence.
+Each round follows the [contract](references/review-topology.md): frozen
+scope/criteria/targets, ledger, evidence, batch, verdict, and next action.

--- a/skills/subagent-review/evals/tasks/negative-trigger-2.yaml
+++ b/skills/subagent-review/evals/tasks/negative-trigger-2.yaml
@@ -1,0 +1,15 @@
+id: negative-trigger-002
+name: Negative Trigger 2 — Cosmetic Micro-edits
+description: Curated trigger-accuracy prompt for this skill.
+tags:
+  - negative-trigger
+inputs:
+  prompt: "Dispatch a fan-out of routing agents to assign implementation tasks across the repository."
+expected:
+  should_trigger: false
+graders:
+  - type: trigger
+    name: negative-trigger
+    config:
+      skill_path: skills/subagent-review/SKILL.md
+      mode: negative

--- a/skills/subagent-review/evals/tasks/positive-trigger-3.yaml
+++ b/skills/subagent-review/evals/tasks/positive-trigger-3.yaml
@@ -1,0 +1,15 @@
+id: positive-trigger-003
+name: Positive Trigger 3
+description: Curated trigger-accuracy prompt for this skill.
+tags:
+  - positive-trigger
+inputs:
+  prompt: "Run parallel guardian/critic reviewer waves to convergence: preserve stable finding IDs, batch all material defects, reconcile fixes against frozen verification targets, quarantine invalid packets, handle missing evidence, authority gaps, cap exhaustion, and criterion changes, then perform final confirmation."
+expected:
+  should_trigger: true
+graders:
+  - type: trigger
+    name: positive-trigger
+    config:
+      skill_path: skills/subagent-review/SKILL.md
+      mode: positive

--- a/skills/subagent-review/references/review-topology.md
+++ b/skills/subagent-review/references/review-topology.md
@@ -1,0 +1,93 @@
+# Review Contract
+
+## 1. Perspective Set and Routing
+
+- Guardian defines the required perspective set. If omitted, it defaults to
+  security, architecture, historian, code, and QA; do not substitute fixed
+  five/six/twelve counts after narrowing.
+- Self-review accompanies every wave and never replaces it. Guardian-labeled
+  trivials may omit subagents; otherwise no direct-only fallback.
+- Every ordinary CODE, SECURITY, QA, HISTORIAN, or ARCHITECTURE reviewer launch
+  receives bounded read-only paths, bounded context, and a required output
+  shape. The specialized data reviewer remains bounded and read-only.
+- A Postman request authorizes critic launch; otherwise return
+  `BLOCKED: perspective launch not permitted`. Critic sends guardian, not
+  orchestrator. Critic reports `Required perspectives`, `Perspectives
+  launched`, and `Self-review: complete`; incomplete coverage is
+  `BLOCKED: fewer than required perspectives completed`.
+- Use the data reviewer only for specialized questions.
+
+## 2. Blind Projection and Reviewer Packet
+
+- Guardian creates a blind packet with a fresh `packet_alias`, frozen
+  scope/criteria, and projected files named only by projection-relative aliases
+  such as `files/001`. Real repository paths, filenames, diff headers, branch,
+  commit, author, issue/PR, transport/session, timestamp, correlation, and
+  lineage fields are identity-bearing and rejected if present.
+- Guardian alone retains the minimal control envelope: `packet_alias`,
+  `candidate_id`, the alias-to-repository-path map, frozen scope/criteria,
+  lineage, and routing metadata. It is never sent to reviewers. Guardian uses
+  the map when recording repository coordinates in the authoritative ledger.
+- Historian receives only a bounded blind evidence digest: aliases, neutral
+  decision excerpts, and permitted projected history facts. It excludes real
+  paths, filenames, issue/PR identifiers, URLs, commits, authors, branches,
+  timestamps, and candidate identity; its output uses aliases for Guardian to
+  bind through the control envelope.
+- Every ordinary reviewer packet contains `perspective`, `verdict`, findings,
+  projection-relative path plus line evidence (or `no file applicable`),
+  severity, confidence, and recommendation/required correction. A projected
+  path is repo-relative within the blind projection, never a real repository
+  path. Packets contain no authoritative ledger IDs.
+
+## 3. Ledger, Batch, and Report
+
+- Every stable entry has severity, materiality, `OPEN`/`CLOSED`, closure
+  disposition (`fixed`, `accepted`, `deferred`, or `rejected`), rationale, exact
+  path/evidence coordinates, closure condition/evidence, and accepted-risk
+  authority/owner. `superseded` is a reconciliation relation naming
+  successor/reason.
+- Track the evidence owner separately from the reviewer. Reviewer packets
+  contain observations, evidence, and risk signals only; Guardian alone
+  decides materiality, closure, rework, escalation, and convergence. A
+  reviewer cannot satisfy an authority gap, accept risk, publish, or mark
+  unavailable external evidence as closed without the named owner.
+- Keep candidate identity separate from review packets: strip source identity,
+  history, transport/session metadata, and timestamps before blind review.
+  Guardian keeps the identity-bearing control envelope and records the mapping
+  in the ledger; reviewers do not infer or reconstruct it.
+- Before the single material batch, review the complete change and ledger.
+  Freeze material IDs, scope/criteria, and reproducible named cheap/full
+  verification commands or targets. Change them only after an explicitly
+  recorded scope or criterion change.
+- Every round and final confirmation reports frozen scope, criteria, targets,
+  complete ledger/reconciliation (recurrence, regression, new discovery, or
+  changed criterion), material batch, verification evidence, verdict
+  (`CONVERGED`, `REWORK`, or `ESCALATE`/`BLOCKED`), and explicit next action.
+- For substantive verdicts, apply the `decision_quality_check` prompt block in
+  `skills/dotfiles/references/prompt-blocks.md`. Only Guardian/critic synthesis
+  may update or close the authoritative ledger; reviewer use is packet-local.
+
+## 4. Failure-Mode Handling
+
+- Invalid review packets enter `QUARANTINED`, a non-substantive pre-round
+  rejection that consumes no failed-rework slot. Do not trust packet-supplied
+  finding IDs or treat the packet as approval, a finding wave, or rework.
+  Guardian records the packet alias, missing/rejected fields, and required
+  resubmission: fresh alias, required packet fields, projected evidence, and
+  the cheapest verifier needed to make it reviewable.
+- Missing evidence keeps the affected ID `OPEN` unless the ledger records a
+  named accepted-risk owner. Local fixtures, repository read-back, external
+  read-back, publication receipts, and production evidence are distinct
+  evidence tiers.
+- Authority gaps are `BLOCKED` or `ESCALATE`: name the exact decision owner,
+  the IDs affected, and the smallest manual decision required. Reviewers do not
+  approve their own authority gaps.
+- Rework must address one frozen material batch. New material discoveries are
+  classified and added to the ledger, but do not silently broaden the current
+  closure target.
+- Cap exhaustion stops the loop with `BLOCKED`: include attempted rounds, open
+  IDs, remaining evidence gaps, and the owner who can authorize another round
+  or accept/defer risk.
+- Criterion changes create a new ledger entry or explicit changed-criterion
+  reconciliation. Preserve the old closure condition, new closure condition,
+  reason, and owner; do not re-use a closed ID as if it were unchanged.


### PR DESCRIPTION
## Summary

- Define guardian-owned finding convergence, invalid-packet quarantine, and reviewer/dispatcher boundaries in `skills/subagent-review/SKILL.md`.
- Add blind-review packet and normal/blind Historian contracts in `skills/subagent-review/references/review-topology.md`, `nix/home-manager/agents/subagents/reviewer-historian.md`, and `skills/dotfiles/references/review-output-contract.md`.
- Add positive and negative trigger coverage for review waves and dispatcher fan-out, plus Guardian/critic ledger guidance in `skills/dotfiles/references/prompt-blocks.md`.

## Verification

- `git diff --check`
- Waza readiness, trigger evaluations, frontmatter/private-content validation
- Repository pre-commit checks and `nix run .#check`

Closes #301