### PR TITLE
docs(readme): update CI workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-[![CI](https://github.com/i9wa4/dotfiles/actions/workflows/ci.yaml/badge.svg)](https://github.com/i9wa4/dotfiles/actions/workflows/ci.yaml)
+[![CI](https://github.com/i9wa4/dotfiles/actions/workflows/ci-nix-quick-install.yaml/badge.svg)](https://github.com/i9wa4/dotfiles/actions/workflows/ci-nix-quick-install.yaml)
 [![Last Commit](https://img.shields.io/github/last-commit/i9wa4/dotfiles)](https://github.com/i9wa4/dotfiles/commits/main)
 [![Top Language](https://img.shields.io/github/languages/top/i9wa4/dotfiles)](https://github.com/i9wa4/dotfiles)
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/i9wa4/dotfiles)](https://github.com/i9wa4/dotfiles/commits/main)


### PR DESCRIPTION
## Summary

- Update `README.md` CI badge and link to the retained `.github/workflows/ci-nix-quick-install.yaml` workflow.

## Verification

- `git diff --check`
- Markdown formatter output matches `README.md`
- Commit hooks passed, including `markdown-formatter` and `rumdl-check`

Closes #305
