### PR TITLE
Add agent-task Gist memo policy

### DIFF
--- a/nix/flake-parts/modules/pre-commit.nix
+++ b/nix/flake-parts/modules/pre-commit.nix
@@ -181,6 +181,13 @@
             pass_filenames = false;
             require_serial = true;
           };
+          agent-task-gist-policy-check = {
+            enable = true;
+            entry = "${pkgs.bash}/bin/bash scripts/validation/validate-agent-task-gist-policy.sh";
+            files = "^(skills/dotfiles/(SKILL\\.md|references/resume-handoff\\.md|evals/.*)|scripts/validation/validate-agent-task-gist-policy\\.sh)$";
+            types = [ "file" ];
+            pass_filenames = false;
+          };
           # NOTE: flake-check removed from pre-commit (too slow). Runs in CI only.
 
           # === Markdown linter ===

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -18,21 +18,27 @@ contains_public_gist_command() {
   local file=$1
   local command=
   local line=
+  local continuation=0
   while IFS= read -r line || [ -n "$line" ]; do
     line=${line%"${line##*[![:space:]]}"}
-    if [ -n "$command" ]; then
-      command="$command ${line%\\}"
+    if [ "$continuation" -eq 1 ]; then
+      command="$command$line"
     else
-      command=${line%\\}
+      command=$line
     fi
     case "$line" in
-    *\\) continue ;;
+    *\\)
+      command=${command%\\}
+      continuation=1
+      continue
+      ;;
     esac
     if command_has_public_gist_flag "$command"; then
       printf '%s\n' "$command"
       return 0
     fi
     command=
+    continuation=0
   done <"$file"
   if [ -n "$command" ] && command_has_public_gist_flag "$command"; then
     printf '%s\n' "$command"
@@ -374,6 +380,21 @@ run_public_mode_fixtures() {
     "gh gist create '--public' task.md"
   assert_fixture_rejected quote-spliced-public-create \
     'gh gist create --pub"lic" task.md'
+  assert_fixture_rejected split-public-continuation-create \
+    "gh gist create --pub$continuation" \
+    'lic task.md'
+  assert_fixture_rejected split-quote-spliced-gh-continuation-create \
+    "g$continuation" \
+    '"h" gist create --public task.md'
+  assert_fixture_rejected split-quote-spliced-gist-continuation-create \
+    "gh g$continuation" \
+    '"ist" create --public task.md'
+  assert_fixture_rejected split-assignment-prefix-continuation-create \
+    "TOKEN=$continuation" \
+    '"x" gh gist create --public task.md'
+  assert_fixture_rejected split-env-assignment-continuation-create \
+    "env \"TOKEN=$continuation" \
+    'x" gh gist create --public task.md'
   assert_fixture_rejected separated-public-create \
     'printf x; gh gist create --public task.md'
   assert_fixture_rejected assignment-prefixed-public-create \
@@ -403,6 +424,9 @@ run_public_mode_fixtures() {
   assert_fixture_allowed allowed-list 'gh gist list --secret --limit 100'
   assert_fixture_allowed allowed-publicity-token \
     'gh gist create --publicity task.md'
+  assert_fixture_allowed allowed-split-publicity-continuation-token \
+    "gh gist create --pub$continuation" \
+    'licity task.md'
   assert_fixture_allowed allowed-preview-short-token \
     'gh gist create -preview task.md'
   assert_fixture_allowed allowed-quoted-text \
@@ -415,6 +439,9 @@ run_public_mode_fixtures() {
     'gh gist create "--public-task.md"'
   assert_fixture_allowed allowed-quoted-assignment-like-command \
     '"TOKEN=x" gh gist create --public task.md'
+  assert_fixture_allowed allowed-split-quoted-assignment-like-command \
+    "\"TOKEN=x\"$continuation" \
+    ' gh gist create --public task.md'
   assert_fixture_allowed allowed-desc-public-value \
     "gh gist create --desc '--public' task.md"
   assert_fixture_allowed allowed-stop-option-public-positional \
@@ -493,6 +520,13 @@ if [ "$1" = gist ] && [ "$2" = view ]; then
 	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = list ] && [ "$3" = --secret ]; then
+	list_call_number=1
+	if [ -n "${GIST_LIST_RECORD:-}" ]; then
+		if [ -f "$GIST_LIST_RECORD" ]; then
+			list_call_number=$(($(wc -l < "$GIST_LIST_RECORD") + 1))
+		fi
+		printf '%s\n' list >> "$GIST_LIST_RECORD"
+	fi
 	for arg in "$@"; do
 		if [ "$arg" = --json ]; then
 			jq_arg=
@@ -521,8 +555,14 @@ if [ "$1" = gist ] && [ "$2" = list ] && [ "$3" = --secret ]; then
 				age=${GIST_LIST_AGE_DAYS:-8}
 				;;
 			esac
+			gist_id=fixtureGistId
+			case "${GIST_LIST_MODE:-ok}:$list_call_number" in
+			divergent:2)
+				gist_id=divergentGistId
+				;;
+			esac
 			printf '%s\t%s\t%s\t%s\t%s\n' \
-				fixtureGistId i9wa4 i9wa4 "$age" 'agent-task:<repo>:<task>'
+				"$gist_id" i9wa4 i9wa4 "$age" 'agent-task:<repo>:<task>'
 			exit 0
 		fi
 	done
@@ -792,10 +832,13 @@ EOF
   done
 
   extract_documented_snippet '# agent-task-gist-reviewed-preview' "$fixture_dir/preview.sh"
-  GIST_DELETE_RECORD="$fixture_dir/unused-preview-delete-record" \
+  GIST_LIST_RECORD="$fixture_dir/preview-list-record" \
+    GIST_DELETE_RECORD="$fixture_dir/unused-preview-delete-record" \
     PATH="$mock_bin:$PATH" \
     reviewed_preview="$fixture_dir/reviewed-preview.tsv" \
     sh "$fixture_dir/preview.sh" >"$fixture_dir/preview.out"
+  test "$(wc -l <"$fixture_dir/preview-list-record")" -eq 1 ||
+    fail "documented reviewed-preview producer listed candidates more than once"
   test -s "$fixture_dir/reviewed-preview.tsv" ||
     fail "documented reviewed-preview producer did not write a preview record"
   grep -Fq '# schema=agent-task-gist-reviewed-preview-v1' "$fixture_dir/reviewed-preview.tsv" ||
@@ -804,6 +847,29 @@ EOF
     fail "documented reviewed-preview producer did not persist the derived age row"
   test ! -e "$fixture_dir/unused-preview-delete-record" ||
     fail "documented reviewed-preview producer deleted a Gist"
+  awk '/^#/ { next } NF { print }' "$fixture_dir/reviewed-preview.tsv" >"$fixture_dir/reviewed-preview-data.tsv"
+  cmp -s "$fixture_dir/preview.out" "$fixture_dir/reviewed-preview-data.tsv" ||
+    fail "documented reviewed-preview display was not derived from the proof-bound data"
+
+  GIST_LIST_MODE=divergent \
+    GIST_LIST_RECORD="$fixture_dir/divergent-preview-list-record" \
+    GIST_DELETE_RECORD="$fixture_dir/divergent-preview-unused-delete-record" \
+    PATH="$mock_bin:$PATH" \
+    reviewed_preview="$fixture_dir/divergent-reviewed-preview.tsv" \
+    sh "$fixture_dir/preview.sh" >"$fixture_dir/divergent-preview.out"
+  test "$(wc -l <"$fixture_dir/divergent-preview-list-record")" -eq 1 ||
+    fail "documented reviewed-preview producer permitted divergent consecutive lists"
+  awk '/^#/ { next } NF { print }' "$fixture_dir/divergent-reviewed-preview.tsv" >"$fixture_dir/divergent-reviewed-preview-data.tsv"
+  cmp -s "$fixture_dir/divergent-preview.out" "$fixture_dir/divergent-reviewed-preview-data.tsv" ||
+    fail "documented divergent preview display was not proof-bound"
+  grep -Fq "$(printf 'fixtureGistId\ti9wa4\ti9wa4\t8\tagent-task:<repo>:<task>')" \
+    "$fixture_dir/divergent-reviewed-preview.tsv" ||
+    fail "documented divergent preview did not preserve the reviewed candidate row"
+  if grep -Fq divergentGistId "$fixture_dir/divergent-preview.out" "$fixture_dir/divergent-reviewed-preview.tsv"; then
+    fail "documented divergent preview used a second candidate list"
+  fi
+  test ! -e "$fixture_dir/divergent-preview-unused-delete-record" ||
+    fail "documented divergent reviewed-preview producer deleted a Gist"
 
   GIST_LIST_MODE=invalid-timestamp \
     GIST_DELETE_RECORD="$fixture_dir/invalid-preview-delete-record" \
@@ -871,6 +937,15 @@ fixtureGistId
 EOF
   test -f "$fixture_dir/delete-record-bash" ||
     fail "documented deletion confirmation is not Bash-compatible"
+  GIST_DELETE_RECORD="$fixture_dir/divergent-delete-record" \
+    reviewed_preview="$fixture_dir/divergent-reviewed-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" <<'EOF'
+fixtureGistId
+EOF
+  test "$(cat "$fixture_dir/divergent-delete-record")" = fixtureGistId ||
+    fail "documented deletion was not bound to the divergent reviewed dataset"
 
   GIST_LIST_AGE_DAYS=6 \
     PATH="$mock_bin:$PATH" \

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -16,12 +16,59 @@ fail() {
 
 contains_public_gist_command() {
   awk '
-	  function inspect(command) {
-	    if (command ~ /^[[:space:]]*((command[[:space:]]+)|(env([[:space:]]+(-[[:alnum:]_=-]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+))*[[:space:]]+))?gh[[:space:]]+gist[[:space:]]+(create|edit|list|delete)([[:space:]]|$)/ && command ~ /(^|[[:space:]])--public([[:space:]]|$)/) {
-	      print command
-	      found = 1
-	    }
-	  }
+    function is_assignment(token) {
+      return token ~ /^[A-Za-z_][A-Za-z0-9_]*=/
+    }
+    function first_command_token(token_count, tokens, token_index) {
+      token_index = 1
+      while (token_index <= token_count) {
+        if (tokens[token_index] == "env") {
+          token_index++
+          while (token_index <= token_count) {
+            if (tokens[token_index] == "-u" || tokens[token_index] == "--unset") {
+              token_index += 2
+            } else if (tokens[token_index] ~ /^-u./ || tokens[token_index] ~ /^--unset=/ || is_assignment(tokens[token_index])) {
+              token_index++
+            } else if (tokens[token_index] ~ /^-/) {
+              token_index++
+            } else {
+              break
+            }
+          }
+        } else if (tokens[token_index] == "command") {
+          token_index++
+          while (token_index <= token_count && tokens[token_index] ~ /^-/) {
+            token_index++
+          }
+        } else {
+          break
+        }
+      }
+      return token_index
+    }
+    function is_public_token(token) {
+      return token == "--public" || token ~ /^--public=/ || token == "-p"
+    }
+    function inspect(command, token_count, tokens, token_index, action_index, public_index) {
+      sub(/^[[:space:]]+/, "", command)
+      sub(/[[:space:]]+$/, "", command)
+      token_count = split(command, tokens, /[[:space:]]+/)
+      token_index = first_command_token(token_count, tokens)
+      action_index = token_index + 2
+      if (tokens[token_index] != "gh" || tokens[token_index + 1] != "gist") {
+        return
+      }
+      if (tokens[action_index] !~ /^(create|edit|list|delete)$/) {
+        return
+      }
+      for (public_index = action_index + 1; public_index <= token_count; public_index++) {
+        if (is_public_token(tokens[public_index])) {
+          print command
+          found = 1
+          return
+        }
+      }
+    }
     {
       line = $0
       sub(/[[:space:]]+$/, "", line)
@@ -99,8 +146,16 @@ run_public_mode_fixtures() {
     '  --public gist-id'
   assert_fixture_rejected env-prefixed-public-create \
     'env GITHUB_TOKEN=fixture gh gist create --public task.md'
+  assert_fixture_rejected env-unset-prefixed-public-create \
+    'env -u TOKEN gh gist create --public task.md'
   assert_fixture_rejected command-prefixed-public-list \
     'command gh gist list --public'
+  assert_fixture_rejected command-path-prefixed-public-create \
+    'command -p gh gist create --public task.md'
+  assert_fixture_rejected public-equals-create \
+    'gh gist create --public=true task.md'
+  assert_fixture_rejected short-public-create \
+    'gh gist create -p task.md'
   assert_fixture_allowed allowed-create \
     "gh gist create --desc 'agent-task:<repo>:<task>' task.md"
   assert_fixture_allowed allowed-multiline-create \
@@ -108,6 +163,12 @@ run_public_mode_fixtures() {
     "  --desc 'agent-task:<repo>:<task>' $continuation" \
     '  task.md'
   assert_fixture_allowed allowed-list 'gh gist list --secret --limit 100'
+  assert_fixture_allowed allowed-publicity-token \
+    'gh gist create --publicity task.md'
+  assert_fixture_allowed allowed-preview-short-token \
+    'gh gist create -preview task.md'
+  assert_fixture_allowed allowed-quoted-text \
+    'printf "%s\n" "gh gist create --public task.md"'
 }
 
 run_documented_snippet_fixtures() {
@@ -198,6 +259,10 @@ EOF
 
   cat >"$mock_bin/rg" <<'EOF'
 #!/bin/sh
+if [ "${GIST_SCAN_MODE:-ok}" = fail ]; then
+	printf '%s\n' '1:tmux-a2a'
+	exit 0
+fi
 exit 1
 EOF
   chmod 700 "$mock_bin/rg"
@@ -244,13 +309,17 @@ EOF
 
   assert_create_failure_blocks_handoff() {
     name=$1
+    expected_pending_id=$2
+    shift
     shift
     out_file="$fixture_dir/$name.out"
     err_file="$fixture_dir/$name.err"
     url_record="$fixture_dir/$name-url-record"
     delete_record="$fixture_dir/$name-delete-record"
+    pending_record="$fixture_dir/$name-pending-cleanup"
     if GIST_URL_HANDOFF_RECORD="$url_record" \
       GIST_DELETE_RECORD="$delete_record" \
+      pending_cleanup_record="$pending_record" \
       PATH="$mock_bin:$PATH" \
       task_file="$fixture_dir/task.md" \
       env "$@" sh "$fixture_dir/create-url-flow.sh" >"$out_file" 2>"$err_file"; then
@@ -261,29 +330,38 @@ EOF
     fi
     test ! -e "$url_record" ||
       fail "documented create/read-back failure created URL handoff record: $name"
+    test ! -e "$delete_record" ||
+      fail "documented create/read-back failure deleted before reviewed confirmation: $name"
+    if [ "$expected_pending_id" != none ]; then
+      test -s "$pending_record" ||
+        fail "documented create/read-back failure left no pending cleanup record: $name"
+      if grep -Fq 'https://gist.github.com/' "$pending_record"; then
+        fail "documented pending cleanup record leaked URL: $name"
+      fi
+      if [ "$expected_pending_id" != unknown ]; then
+        grep -Fq "gist_id=$expected_pending_id" "$pending_record" ||
+          fail "documented pending cleanup record did not include exact Gist ID: $name"
+      fi
+    fi
   }
 
-  assert_create_failure_blocks_handoff bad-account GIST_MOCK_ACCOUNT=other-user
-  assert_create_failure_blocks_handoff public-metadata GIST_MOCK_PUBLIC=true
-  test "$(cat "$fixture_dir/public-metadata-delete-record")" = fixtureGistId ||
-    fail "public metadata failure did not clean up the created Gist"
-  assert_create_failure_blocks_handoff wrong-description GIST_MOCK_DESCRIPTION=wrong
-  test "$(cat "$fixture_dir/wrong-description-delete-record")" = fixtureGistId ||
-    fail "wrong description failure did not clean up the created Gist"
-  assert_create_failure_blocks_handoff wrong-filename GIST_MOCK_FILENAME=wrong.md
-  test "$(cat "$fixture_dir/wrong-filename-delete-record")" = fixtureGistId ||
-    fail "wrong filename failure did not clean up the created Gist"
-  assert_create_failure_blocks_handoff multiple-filenames GIST_MOCK_FILE_COUNT=2
-  test "$(cat "$fixture_dir/multiple-filenames-delete-record")" = fixtureGistId ||
-    fail "multiple filename failure did not clean up the created Gist"
-  assert_create_failure_blocks_handoff stderr-url-leakage GIST_CREATE_MODE=stderr-url
-  assert_create_failure_blocks_handoff noisy-create-output GIST_CREATE_MODE=noisy
-  assert_create_failure_blocks_handoff multiline-create-output GIST_CREATE_MODE=multiline
-  assert_create_failure_blocks_handoff malformed-create-output GIST_CREATE_MODE=malformed
+  assert_create_failure_blocks_handoff bad-account none GIST_MOCK_ACCOUNT=other-user
+  assert_create_failure_blocks_handoff public-metadata fixtureGistId GIST_MOCK_PUBLIC=true
+  assert_create_failure_blocks_handoff wrong-description fixtureGistId GIST_MOCK_DESCRIPTION=wrong
+  assert_create_failure_blocks_handoff wrong-filename fixtureGistId GIST_MOCK_FILENAME=wrong.md
+  assert_create_failure_blocks_handoff multiple-filenames fixtureGistId GIST_MOCK_FILE_COUNT=2
+  assert_create_failure_blocks_handoff stderr-url-leakage unknown GIST_CREATE_MODE=stderr-url
+  assert_create_failure_blocks_handoff noisy-create-output unknown GIST_CREATE_MODE=noisy
+  assert_create_failure_blocks_handoff multiline-create-output unknown GIST_CREATE_MODE=multiline
+  assert_create_failure_blocks_handoff malformed-create-output unknown GIST_CREATE_MODE=malformed
 
   extract_documented_snippet '# agent-task-gist-delete-confirmation' "$fixture_dir/delete.sh"
   sed 's/<reviewed-gist-id>/fixtureGistId/g' "$fixture_dir/delete.sh" >"$fixture_dir/delete-fixture.sh"
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>' \
+    >"$fixture_dir/reviewed-preview.tsv"
   GIST_DELETE_RECORD="$fixture_dir/delete-record" \
+    reviewed_preview="$fixture_dir/reviewed-preview.tsv" \
     PATH="$mock_bin:$PATH" \
     sh "$fixture_dir/delete-fixture.sh" <<'EOF'
 fixtureGistId
@@ -291,12 +369,47 @@ EOF
   test -f "$fixture_dir/delete-record" ||
     fail "documented deletion confirmation did not invoke the exact approved ID"
   GIST_DELETE_RECORD="$fixture_dir/delete-record-bash" \
+    reviewed_preview="$fixture_dir/reviewed-preview.tsv" \
     PATH="$mock_bin:$PATH" \
     bash "$fixture_dir/delete-fixture.sh" <<'EOF'
 fixtureGistId
 EOF
   test -f "$fixture_dir/delete-record-bash" ||
     fail "documented deletion confirmation is not Bash-compatible"
+
+  assert_delete_rejected() {
+    name=$1
+    preview_owner=$2
+    preview_account=$3
+    preview_age_days=$4
+    preview_id=$5
+    typed_id=$6
+    account_value=$7
+    delete_record="$fixture_dir/$name-delete-record"
+    preview_file="$fixture_dir/$name-reviewed-preview.tsv"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$preview_id" "$preview_owner" "$preview_account" "$preview_age_days" 'agent-task:<repo>:<task>' \
+      >"$preview_file"
+    GIST_DELETE_RECORD="$delete_record" \
+      GIST_MOCK_ACCOUNT="$account_value" \
+      reviewed_preview="$preview_file" \
+      PATH="$mock_bin:$PATH" \
+      sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/$name.out" 2>"$fixture_dir/$name.err" <<EOF &&
+$typed_id
+EOF
+      fail "documented deletion authority gate accepted invalid case: $name"
+    test ! -e "$delete_record" ||
+      fail "documented deletion authority gate deleted invalid case: $name"
+  }
+
+  assert_delete_rejected wrong-owner other-owner i9wa4 8 fixtureGistId fixtureGistId i9wa4
+  assert_delete_rejected wrong-account i9wa4 other-account 8 fixtureGistId fixtureGistId i9wa4
+  assert_delete_rejected missing-current-account i9wa4 i9wa4 8 fixtureGistId fixtureGistId other-user
+  assert_delete_rejected too-new i9wa4 i9wa4 6 fixtureGistId fixtureGistId i9wa4
+  assert_delete_rejected missing-preview-membership i9wa4 i9wa4 8 otherGistId fixtureGistId i9wa4
+  assert_delete_rejected missing-confirmation i9wa4 i9wa4 8 fixtureGistId wrongGistId i9wa4
+  assert_fixture_allowed bare-list-preview \
+    "gh gist list --secret --filter '^agent-task:<repo>:' --limit 100"
 
   extract_documented_snippet '# agent-task-gist-raw-verification' "$fixture_dir/raw.sh"
   GIST_CLEANUP_RECORD="$fixture_dir/cleanup-record" \
@@ -318,6 +431,7 @@ EOF
   printf 'different memo\n' >"$fixture_dir/mismatch-task.md"
   GIST_CLEANUP_RECORD="$fixture_dir/mismatch-cleanup-record" \
     GIST_FIXTURE_SOURCE="$fixture_dir/mismatch-task.md" \
+    pending_cleanup_record="$fixture_dir/mismatch-pending-cleanup" \
     gist_id=fixtureGistId \
     task_file="$fixture_dir/task.md" \
     PATH="$mock_bin:$PATH" \
@@ -328,6 +442,26 @@ EOF
   mismatch_cleaned_directory=$(cat "$fixture_dir/mismatch-cleanup-record")
   test ! -e "$mismatch_cleaned_directory" ||
     fail "documented raw verification mismatch path left its temporary directory behind"
+  grep -Fq 'gist_id=fixtureGistId' "$fixture_dir/mismatch-pending-cleanup" ||
+    fail "documented raw verification mismatch path did not record the exact pending cleanup ID"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/mismatch-pending-cleanup"; then
+    fail "documented raw verification mismatch pending cleanup record leaked URL"
+  fi
+
+  GIST_CLEANUP_RECORD="$fixture_dir/scan-cleanup-record" \
+    GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
+    GIST_SCAN_MODE=fail \
+    pending_cleanup_record="$fixture_dir/scan-pending-cleanup" \
+    gist_id=fixtureGistId \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    env -u TMPDIR sh "$fixture_dir/raw.sh" >"$fixture_dir/raw-scan.out" 2>&1 &&
+    fail "documented raw verification accepted scanned private content"
+  grep -Fq 'gist_id=fixtureGistId' "$fixture_dir/scan-pending-cleanup" ||
+    fail "documented raw verification scan failure did not record the exact pending cleanup ID"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/scan-pending-cleanup"; then
+    fail "documented raw verification scan pending cleanup record leaked URL"
+  fi
 
   {
     printf 'set -e\n'
@@ -340,6 +474,7 @@ EOF
   GIST_CLEANUP_RECORD="$fixture_dir/full-mismatch-cleanup-record" \
     GIST_FIXTURE_SOURCE="$fixture_dir/mismatch-task.md" \
     GIST_URL_HANDOFF_RECORD="$fixture_dir/url-handoff-record" \
+    pending_cleanup_record="$fixture_dir/full-mismatch-pending-cleanup" \
     task_file="$fixture_dir/task.md" \
     PATH="$mock_bin:$PATH" \
     env -u TMPDIR sh "$fixture_dir/full-mismatch-flow.sh" >"$fixture_dir/full-mismatch-flow.out" 2>&1 &&
@@ -349,6 +484,13 @@ EOF
   fi
   test ! -e "$fixture_dir/url-handoff-record" ||
     fail "documented mismatch flow reached URL handoff"
+  grep -Fq 'gist_id=fixtureGistId' "$fixture_dir/full-mismatch-pending-cleanup" ||
+    fail "documented mismatch flow did not record exact pending cleanup ID"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/full-mismatch-pending-cleanup"; then
+    fail "documented mismatch flow pending cleanup record leaked URL"
+  fi
+  test ! -e "${GIST_DELETE_RECORD:-$fixture_dir/unused-delete-record}" ||
+    fail "documented pre-handoff flow deleted outside reviewed confirmation"
 }
 
 # shellcheck disable=SC2016 # The literal command text is the policy assertion.

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -78,6 +78,33 @@ tokenize_shell_words() {
           token="$token${command:i:1}"
         fi
         ;;
+      ';')
+        if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
+          TOKENS+=("$token")
+          TOKEN_QUOTED+=("$quoted")
+          token=
+          quoted=0
+        fi
+        TOKENS+=(';')
+        TOKEN_QUOTED+=(0)
+        ;;
+      '&' | '|')
+        if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
+          TOKENS+=("$token")
+          TOKEN_QUOTED+=("$quoted")
+          token=
+          quoted=0
+        fi
+        next=${command:$((i + 1)):1}
+        if [ "$next" = "$char" ]; then
+          TOKENS+=("$char$next")
+          TOKEN_QUOTED+=(0)
+          i=$((i + 1))
+        else
+          TOKENS+=("$char")
+          TOKEN_QUOTED+=(0)
+        fi
+        ;;
       *)
         token="$token$char"
         ;;
@@ -116,14 +143,22 @@ tokenize_shell_words() {
   fi
 }
 
-command_has_public_gist_flag() {
-  local command=$1
-  tokenize_shell_words "$command"
+is_assignment_word() {
+  [[ $1 =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]
+}
+
+segment_has_public_gist_flag() {
+  local start=$1
+  local end=$2
   local index=0
-  while [ "$index" -lt "${#TOKENS[@]}" ]; do
+  index=$start
+  while [ "$index" -lt "$end" ] && is_assignment_word "${TOKENS[$index]}" && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; do
+    index=$((index + 1))
+  done
+  while [ "$index" -lt "$end" ]; do
     if [ "${TOKENS[$index]}" = env ] && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; then
       index=$((index + 1))
-      while [ "$index" -lt "${#TOKENS[@]}" ]; do
+      while [ "$index" -lt "$end" ]; do
         case "${TOKENS[$index]}" in
         -u | --unset)
           index=$((index + 2))
@@ -141,7 +176,7 @@ command_has_public_gist_flag() {
       done
     elif [ "${TOKENS[$index]}" = command ] && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; then
       index=$((index + 1))
-      while [ "$index" -lt "${#TOKENS[@]}" ] && [[ ${TOKENS[$index]} == -* ]]; do
+      while [ "$index" -lt "$end" ] && [[ ${TOKENS[$index]} == -* ]]; do
         index=$((index + 1))
       done
     else
@@ -158,13 +193,32 @@ command_has_public_gist_flag() {
   esac
   [ "${TOKEN_QUOTED[$((index + 2))]:-1}" -eq 0 ] || return 1
   local flag_index=$((index + 3))
-  while [ "$flag_index" -lt "${#TOKENS[@]}" ]; do
-    if [ "${TOKEN_QUOTED[$flag_index]}" -eq 0 ]; then
-      case "${TOKENS[$flag_index]}" in
-      --public | --public=* | -p) return 0 ;;
+  while [ "$flag_index" -lt "$end" ]; do
+    case "${TOKENS[$flag_index]}" in
+    --public | --public=* | -p) return 0 ;;
+    esac
+    flag_index=$((flag_index + 1))
+  done
+  return 1
+}
+
+command_has_public_gist_flag() {
+  local command=$1
+  tokenize_shell_words "$command"
+  local start=0
+  local index=0
+  while [ "$index" -le "${#TOKENS[@]}" ]; do
+    if [ "$index" -eq "${#TOKENS[@]}" ]; then
+      segment_has_public_gist_flag "$start" "$index" && return 0
+    else
+      case "${TOKENS[$index]}" in
+      ';' | '&&' | '||' | '|')
+        segment_has_public_gist_flag "$start" "$index" && return 0
+        start=$((index + 1))
+        ;;
       esac
     fi
-    flag_index=$((flag_index + 1))
+    index=$((index + 1))
   done
   return 1
 }
@@ -230,6 +284,14 @@ run_public_mode_fixtures() {
     'gh gist create --public=true task.md'
   assert_fixture_rejected short-public-create \
     'gh gist create -p task.md'
+  assert_fixture_rejected quoted-public-argv-create \
+    "gh gist create '--public' task.md"
+  assert_fixture_rejected quote-spliced-public-create \
+    'gh gist create --pub"lic" task.md'
+  assert_fixture_rejected separated-public-create \
+    'printf x; gh gist create --public task.md'
+  assert_fixture_rejected assignment-prefixed-public-create \
+    'TOKEN=x gh gist create --public task.md'
   assert_fixture_allowed allowed-create \
     "gh gist create --desc 'agent-task:<repo>:<task>' task.md"
   assert_fixture_allowed allowed-multiline-create \
@@ -287,6 +349,12 @@ if [ "$1" = gist ] && [ "$2" = create ]; then
 	malformed)
 		printf '%s\n' 'not-a-gist-url'
 		;;
+	path-extra)
+		printf '%s\n' 'https://gist.github.com/fixtureGistId/extra'
+		;;
+	query-extra)
+		printf '%s\n' 'https://gist.github.com/fixtureGistId?extra'
+		;;
 	*)
 		exit 64
 		;;
@@ -313,8 +381,34 @@ fi
 if [ "$1" = gist ] && [ "$2" = list ] && [ "$3" = --secret ]; then
 	for arg in "$@"; do
 		if [ "$arg" = --json ]; then
+			jq_arg=
+			while [ "$#" -gt 0 ]; do
+				if [ "$1" = --jq ]; then
+					jq_arg=$2
+					break
+				fi
+				shift
+			done
+			case "$jq_arg" in
+			*fromdateiso8601*) ;;
+			*) exit 64 ;;
+			esac
+			case "$jq_arg" in
+			*'"i9wa4", 8'*) exit 64 ;;
+			esac
+			case "${GIST_LIST_MODE:-ok}" in
+			invalid-timestamp)
+				exit 64
+				;;
+			future)
+				age=-1
+				;;
+			*)
+				age=${GIST_LIST_AGE_DAYS:-8}
+				;;
+			esac
 			printf '%s\t%s\t%s\t%s\t%s\n' \
-				fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>'
+				fixtureGistId i9wa4 i9wa4 "$age" 'agent-task:<repo>:<task>'
 			exit 0
 		fi
 	done
@@ -350,6 +444,16 @@ fi
 exit 64
 EOF
   chmod 700 "$mock_bin/gh"
+
+  cat >"$mock_bin/date" <<'EOF'
+#!/bin/sh
+if [ "$1" = +%s ]; then
+	printf '%s\n' "${GIST_NOW_EPOCH:-1000}"
+	exit 0
+fi
+exec /bin/date "$@"
+EOF
+  chmod 700 "$mock_bin/date"
 
   cat >"$mock_bin/rm" <<'EOF'
 #!/bin/sh
@@ -465,8 +569,42 @@ EOF
   assert_create_failure_blocks_handoff noisy-create-output unknown GIST_CREATE_MODE=noisy
   assert_create_failure_blocks_handoff multiline-create-output unknown GIST_CREATE_MODE=multiline
   assert_create_failure_blocks_handoff malformed-create-output unknown GIST_CREATE_MODE=malformed
+  assert_create_failure_blocks_handoff malformed-create-path-extra unknown GIST_CREATE_MODE=path-extra
+  assert_create_failure_blocks_handoff malformed-create-query-extra unknown GIST_CREATE_MODE=query-extra
   assert_create_failure_blocks_handoff metadata-edit-failed fixtureGistId GIST_EDIT_MODE=fail
   assert_create_failure_blocks_handoff metadata-api-failed fixtureGistId GIST_API_MODE=fail
+
+  for signal_name in HUP INT TERM; do
+    signal_script="$fixture_dir/create-signal-$signal_name.sh"
+    awk -v signal_name="$signal_name" '
+      { print }
+      $0 == "post_create_lifecycle=1" {
+        printf "kill -s %s $$\n", signal_name
+      }
+    ' "$fixture_dir/create-url-flow.sh" >"$signal_script"
+    pending_record="$fixture_dir/create-signal-$signal_name-pending-cleanup"
+    delete_record="$fixture_dir/create-signal-$signal_name-delete-record"
+    url_record="$fixture_dir/create-signal-$signal_name-url-record"
+    GIST_URL_HANDOFF_RECORD="$url_record" \
+      GIST_DELETE_RECORD="$delete_record" \
+      pending_cleanup_record="$pending_record" \
+      PATH="$mock_bin:$PATH" \
+      task_file="$fixture_dir/task.md" \
+      sh "$signal_script" >"$fixture_dir/create-signal-$signal_name.out" 2>"$fixture_dir/create-signal-$signal_name.err" &&
+      fail "documented create/read-back signal reached URL handoff: $signal_name"
+    test -s "$pending_record" ||
+      fail "documented create/read-back signal left no pending cleanup record: $signal_name"
+    if grep -Fq 'gist_id=' "$pending_record"; then
+      fail "documented create/read-back signal recorded an unvalidated Gist ID: $signal_name"
+    fi
+    if grep -Fq 'https://gist.github.com/' "$pending_record" "$fixture_dir/create-signal-$signal_name.out" "$fixture_dir/create-signal-$signal_name.err"; then
+      fail "documented create/read-back signal leaked URL: $signal_name"
+    fi
+    test ! -e "$url_record" ||
+      fail "documented create/read-back signal created URL handoff record: $signal_name"
+    test ! -e "$delete_record" ||
+      fail "documented create/read-back signal deleted before reviewed confirmation: $signal_name"
+  done
 
   extract_documented_snippet '# agent-task-gist-reviewed-preview' "$fixture_dir/preview.sh"
   GIST_DELETE_RECORD="$fixture_dir/unused-preview-delete-record" \
@@ -477,8 +615,28 @@ EOF
     fail "documented reviewed-preview producer did not write a preview record"
   grep -Fq '# schema=agent-task-gist-reviewed-preview-v1' "$fixture_dir/reviewed-preview.tsv" ||
     fail "documented reviewed-preview producer did not write schema metadata"
+  grep -Fq "$(printf 'fixtureGistId\ti9wa4\ti9wa4\t8\tagent-task:<repo>:<task>')" "$fixture_dir/reviewed-preview.tsv" ||
+    fail "documented reviewed-preview producer did not persist the derived age row"
   test ! -e "$fixture_dir/unused-preview-delete-record" ||
     fail "documented reviewed-preview producer deleted a Gist"
+
+  GIST_LIST_MODE=invalid-timestamp \
+    GIST_DELETE_RECORD="$fixture_dir/invalid-preview-delete-record" \
+    PATH="$mock_bin:$PATH" \
+    reviewed_preview="$fixture_dir/invalid-reviewed-preview.tsv" \
+    sh "$fixture_dir/preview.sh" >"$fixture_dir/invalid-preview.out" 2>"$fixture_dir/invalid-preview.err" &&
+    fail "documented reviewed-preview producer accepted an invalid updatedAt timestamp"
+  test ! -e "$fixture_dir/invalid-preview-delete-record" ||
+    fail "documented reviewed-preview producer deleted after invalid timestamp"
+
+  GIST_LIST_MODE=future \
+    GIST_DELETE_RECORD="$fixture_dir/future-preview-delete-record" \
+    PATH="$mock_bin:$PATH" \
+    reviewed_preview="$fixture_dir/future-reviewed-preview.tsv" \
+    sh "$fixture_dir/preview.sh" >"$fixture_dir/future-preview.out" 2>"$fixture_dir/future-preview.err" &&
+    fail "documented reviewed-preview producer accepted a future updatedAt timestamp"
+  test ! -e "$fixture_dir/future-preview-delete-record" ||
+    fail "documented reviewed-preview producer deleted after future timestamp"
 
   write_reviewed_preview() {
     destination=$1
@@ -522,6 +680,21 @@ fixtureGistId
 EOF
   test -f "$fixture_dir/delete-record-bash" ||
     fail "documented deletion confirmation is not Bash-compatible"
+
+  GIST_LIST_AGE_DAYS=6 \
+    PATH="$mock_bin:$PATH" \
+    reviewed_preview="$fixture_dir/too-new-produced-preview.tsv" \
+    sh "$fixture_dir/preview.sh" >"$fixture_dir/too-new-produced-preview.out"
+  GIST_DELETE_RECORD="$fixture_dir/too-new-produced-delete-record" \
+    reviewed_preview="$fixture_dir/too-new-produced-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/too-new-produced.out" 2>"$fixture_dir/too-new-produced.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted producer-derived too-new age"
+  test ! -e "$fixture_dir/too-new-produced-delete-record" ||
+    fail "documented deletion deleted producer-derived too-new preview"
 
   assert_delete_rejected() {
     name=$1
@@ -608,6 +781,45 @@ EOF
     "gh gist list --secret --filter '^agent-task:<repo>:' --limit 100"
 
   extract_documented_snippet '# agent-task-gist-raw-verification' "$fixture_dir/raw.sh"
+  raw_signal_script="$fixture_dir/raw-signal.sh"
+  awk '
+    { print }
+    $0 == "raw_file=\"$raw_dir/task.md\"" {
+      print "kill -s TERM $$"
+    }
+  ' "$fixture_dir/raw.sh" >"$raw_signal_script"
+  {
+    printf 'set -e\n'
+    cat "$fixture_dir/create-read-back.sh"
+    cat "$raw_signal_script"
+    cat "$fixture_dir/url-handoff.sh"
+    # shellcheck disable=SC2016 # The generated script must write this literal expansion.
+    printf '%s\n' 'printf "%s\n" "$secret_gist_url" > "$GIST_URL_HANDOFF_RECORD"'
+  } >"$fixture_dir/full-raw-signal-flow.sh"
+  GIST_CLEANUP_RECORD="$fixture_dir/raw-signal-cleanup-record" \
+    GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
+    GIST_URL_HANDOFF_RECORD="$fixture_dir/raw-signal-url-record" \
+    GIST_DELETE_RECORD="$fixture_dir/raw-signal-delete-record" \
+    pending_cleanup_record="$fixture_dir/raw-signal-pending-cleanup" \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    env -u TMPDIR sh "$fixture_dir/full-raw-signal-flow.sh" >"$fixture_dir/full-raw-signal-flow.out" 2>&1 &&
+    fail "documented raw-stage signal reached URL handoff"
+  test -s "$fixture_dir/raw-signal-cleanup-record" ||
+    fail "documented raw-stage signal did not clean raw temp state"
+  raw_signal_cleaned_directory=$(cat "$fixture_dir/raw-signal-cleanup-record")
+  test ! -e "$raw_signal_cleaned_directory" ||
+    fail "documented raw-stage signal left raw temp state behind"
+  grep -Fq 'gist_id=fixtureGistId' "$fixture_dir/raw-signal-pending-cleanup" ||
+    fail "documented raw-stage signal did not preserve exact pending cleanup ID"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/raw-signal-pending-cleanup" "$fixture_dir/full-raw-signal-flow.out"; then
+    fail "documented raw-stage signal leaked URL"
+  fi
+  test ! -e "$fixture_dir/raw-signal-url-record" ||
+    fail "documented raw-stage signal created URL handoff record"
+  test ! -e "$fixture_dir/raw-signal-delete-record" ||
+    fail "documented raw-stage signal deleted before reviewed confirmation"
+
   GIST_CLEANUP_RECORD="$fixture_dir/cleanup-record" \
     GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
     gist_id=fixtureGistId \

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -112,12 +112,32 @@ run_documented_snippet_fixtures() {
 
   cat >"$mock_bin/gh" <<'EOF'
 #!/bin/sh
+if [ "$1" = auth ] && [ "$2" = status ]; then
+  printf '%s\n' 'Logged in to github.com account i9wa4'
+  exit 0
+fi
+if [ "$1" = gist ] && [ "$2" = create ]; then
+  printf '%s\n' 'https://gist.github.com/fixture-gist-id'
+  exit 0
+fi
+if [ "$1" = gist ] && [ "$2" = edit ] && [ "$3" = fixture-gist-id ]; then
+  exit 0
+fi
 if [ "$1" = gist ] && [ "$2" = delete ] && [ "$3" = fixture-gist-id ]; then
   : > "$GIST_DELETE_RECORD"
   exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = view ]; then
   cat "$GIST_FIXTURE_SOURCE"
+  exit 0
+fi
+if [ "$1" = api ] && [ "$2" = gists/fixture-gist-id ] && [ "$4" = '{public,description,files:(.files|keys)}' ]; then
+  printf '%s\n' '{"public":false,"description":"agent-task:<repo>:<task>","files":["task.md"]}'
+  exit 0
+fi
+if [ "$1" = api ] && [ "$2" = gists/fixture-gist-id ] && [ "$4" = '.html_url' ]; then
+  : > "$GIST_URL_HANDOFF_RECORD"
+  printf '%s\n' 'https://gist.github.com/fixture-gist-id'
   exit 0
 fi
 exit 64
@@ -137,6 +157,35 @@ exit 1
 EOF
   chmod 700 "$mock_bin/rg"
 
+  cat >"$mock_bin/shasum" <<'EOF'
+#!/bin/sh
+if [ "$1" != -a ] || [ "$2" != 256 ]; then
+  exit 64
+fi
+case "$(cat "$3")" in
+"fixture memo")
+  printf '%s  %s\n' '1c72c50d1320856521d1a956f0cae3c257091c72294a1c99a22b337417457127' "$3"
+  ;;
+"different memo")
+  printf '%s  %s\n' 'e9cf18bd5c7a707b7c5f624f45639792a38b2ed609c5fbfb6d2df921c68bf858' "$3"
+  ;;
+*)
+  exit 64
+  ;;
+esac
+EOF
+  chmod 700 "$mock_bin/shasum"
+
+  printf 'fixture memo\n' >"$fixture_dir/task.md"
+  extract_documented_snippet '# agent-task-gist-create-read-back' "$fixture_dir/create-read-back.sh"
+  GIST_URL_HANDOFF_RECORD="$fixture_dir/create-url-record" \
+    PATH="$mock_bin:$PATH" \
+    task_file="$fixture_dir/task.md" \
+    sh "$fixture_dir/create-read-back.sh" >"$fixture_dir/create-read-back.out"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/create-read-back.out"; then
+    fail "documented create/read-back flow prints the secret URL before verification"
+  fi
+
   extract_documented_snippet '# agent-task-gist-delete-confirmation' "$fixture_dir/delete.sh"
   sed 's/<reviewed-gist-id>/fixture-gist-id/g' "$fixture_dir/delete.sh" >"$fixture_dir/delete-fixture.sh"
   GIST_DELETE_RECORD="$fixture_dir/delete-record" \
@@ -154,7 +203,6 @@ EOF
   test -f "$fixture_dir/delete-record-bash" ||
     fail "documented deletion confirmation is not Bash-compatible"
 
-  printf 'fixture memo\n' >"$fixture_dir/task.md"
   extract_documented_snippet '# agent-task-gist-raw-verification' "$fixture_dir/raw.sh"
   GIST_CLEANUP_RECORD="$fixture_dir/cleanup-record" \
     GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
@@ -171,6 +219,42 @@ EOF
   esac
   test ! -e "$cleaned_directory" ||
     fail "documented raw verification left its temporary directory behind"
+
+  printf 'different memo\n' >"$fixture_dir/mismatch-task.md"
+  GIST_CLEANUP_RECORD="$fixture_dir/mismatch-cleanup-record" \
+    GIST_FIXTURE_SOURCE="$fixture_dir/mismatch-task.md" \
+    gist_id=fixture-gist-id \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    env -u TMPDIR sh "$fixture_dir/raw.sh" >"$fixture_dir/raw-mismatch.out" 2>&1 &&
+    fail "documented raw verification accepted mismatched content"
+  test -s "$fixture_dir/mismatch-cleanup-record" ||
+    fail "documented raw verification mismatch path did not clean up"
+  mismatch_cleaned_directory=$(cat "$fixture_dir/mismatch-cleanup-record")
+  test ! -e "$mismatch_cleaned_directory" ||
+    fail "documented raw verification mismatch path left its temporary directory behind"
+
+  extract_documented_snippet '# agent-task-gist-url-handoff' "$fixture_dir/url-handoff.sh"
+  {
+    printf 'set -e\n'
+    cat "$fixture_dir/create-read-back.sh"
+    cat "$fixture_dir/raw.sh"
+    cat "$fixture_dir/url-handoff.sh"
+    # shellcheck disable=SC2016 # The generated script must write this literal expansion.
+    printf '%s\n' 'printf "%s\n" "$secret_gist_url" > "$GIST_URL_HANDOFF_RECORD"'
+  } >"$fixture_dir/full-mismatch-flow.sh"
+  GIST_CLEANUP_RECORD="$fixture_dir/full-mismatch-cleanup-record" \
+    GIST_FIXTURE_SOURCE="$fixture_dir/mismatch-task.md" \
+    GIST_URL_HANDOFF_RECORD="$fixture_dir/url-handoff-record" \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    env -u TMPDIR sh "$fixture_dir/full-mismatch-flow.sh" >"$fixture_dir/full-mismatch-flow.out" 2>&1 &&
+    fail "documented full flow reached URL handoff after mismatched content"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/full-mismatch-flow.out"; then
+    fail "documented mismatch flow printed the secret URL"
+  fi
+  test ! -e "$fixture_dir/url-handoff-record" ||
+    fail "documented mismatch flow reached URL handoff"
 }
 
 # shellcheck disable=SC2016 # The literal command text is the policy assertion.
@@ -200,10 +284,10 @@ run_public_mode_fixtures
 run_documented_snippet_fixtures
 
 url_handoff_line=$(grep -n '^# agent-task-gist-url-handoff$' "$policy_file" | cut -d: -f1)
-html_url_line=$(grep -n 'html_url' "$policy_file" | cut -d: -f1)
+url_assignment_line=$(grep -n '^secret_gist_url=' "$policy_file" | cut -d: -f1)
 test -n "$url_handoff_line" || fail "missing post-verification URL handoff marker"
-test -n "$html_url_line" || fail "missing post-verification URL retrieval"
-test "$html_url_line" -gt "$url_handoff_line" ||
-  fail "secret URL is retrieved before the approved handoff stage"
+test -n "$url_assignment_line" || fail "missing post-verification URL handoff assignment"
+test "$url_assignment_line" -gt "$url_handoff_line" ||
+  fail "secret URL is assigned before the approved handoff stage"
 
 echo "agent-task Gist policy validation passed"

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -9,6 +9,170 @@ cd "$repo_root"
 policy_file="skills/dotfiles/references/resume-handoff.md"
 skill_file="skills/dotfiles/SKILL.md"
 
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+contains_public_gist_command() {
+  awk '
+    function inspect(command) {
+      if (command ~ /^[[:space:]]*gh[[:space:]]+gist[[:space:]]+(create|edit|list|delete)([[:space:]]|$)/ && command ~ /(^|[[:space:]])--public([[:space:]]|$)/) {
+        print command
+        found = 1
+      }
+    }
+    {
+      line = $0
+      sub(/[[:space:]]+$/, "", line)
+      if (continued) {
+        command = command " " line
+      } else {
+        command = line
+      }
+      if (line ~ /\\$/) {
+        sub(/\\$/, "", command)
+        continued = 1
+        next
+      }
+      inspect(command)
+      command = ""
+      continued = 0
+    }
+    END {
+      if (continued) {
+        inspect(command)
+      }
+      exit(found ? 0 : 1)
+    }
+  ' "$1"
+}
+
+extract_documented_snippet() {
+  marker=$1
+  destination=$2
+  awk -v marker="$marker" '
+    $0 == marker { capture = 1; next }
+    capture && /^```/ { exit }
+    capture { print }
+  ' "$policy_file" >"$destination"
+  test -s "$destination" || fail "missing documented snippet: $marker"
+}
+
+fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/agent-task-gist-policy.XXXXXX")
+cleanup_fixture_dir() {
+  rm -rf "$fixture_dir"
+}
+trap cleanup_fixture_dir EXIT HUP INT TERM
+
+assert_fixture_rejected() {
+  name=$1
+  shift
+  printf '%s\n' "$@" >"$fixture_dir/$name"
+  contains_public_gist_command "$fixture_dir/$name" >/dev/null ||
+    fail "public-mode fixture bypassed validator: $name"
+}
+
+assert_fixture_allowed() {
+  name=$1
+  shift
+  printf '%s\n' "$@" >"$fixture_dir/$name"
+  if contains_public_gist_command "$fixture_dir/$name" >/dev/null; then
+    fail "allowed fixture was rejected: $name"
+  fi
+}
+
+run_public_mode_fixtures() {
+  continuation=$(printf '%b' '\134')
+  assert_fixture_rejected multiline-create \
+    "gh gist create $continuation" \
+    '  --public task.md'
+  assert_fixture_rejected multiline-edit \
+    "gh gist edit gist-id $continuation" \
+    "  --filename task.md $continuation" \
+    '  --public task.md'
+  assert_fixture_rejected multiline-list \
+    "gh gist list $continuation" \
+    '  --public'
+  assert_fixture_rejected multiline-delete \
+    "gh gist delete $continuation" \
+    '  --public gist-id'
+  assert_fixture_allowed allowed-create \
+    "gh gist create --desc 'agent-task:<repo>:<task>' task.md"
+  assert_fixture_allowed allowed-multiline-create \
+    "gh gist create $continuation" \
+    "  --desc 'agent-task:<repo>:<task>' $continuation" \
+    '  task.md'
+  assert_fixture_allowed allowed-list 'gh gist list --secret --limit 100'
+}
+
+run_documented_snippet_fixtures() {
+  mock_bin="$fixture_dir/mock-bin"
+  mkdir "$mock_bin"
+
+  cat >"$mock_bin/gh" <<'EOF'
+#!/bin/sh
+if [ "$1" = gist ] && [ "$2" = delete ] && [ "$3" = fixture-gist-id ]; then
+  : > "$GIST_DELETE_RECORD"
+  exit 0
+fi
+if [ "$1" = gist ] && [ "$2" = view ]; then
+  cat "$GIST_FIXTURE_SOURCE"
+  exit 0
+fi
+exit 64
+EOF
+  chmod 700 "$mock_bin/gh"
+
+  cat >"$mock_bin/rm" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$2" > "$GIST_CLEANUP_RECORD"
+exec /bin/rm "$@"
+EOF
+  chmod 700 "$mock_bin/rm"
+
+  cat >"$mock_bin/rg" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+  chmod 700 "$mock_bin/rg"
+
+  extract_documented_snippet '# agent-task-gist-delete-confirmation' "$fixture_dir/delete.sh"
+  sed 's/<reviewed-gist-id>/fixture-gist-id/g' "$fixture_dir/delete.sh" >"$fixture_dir/delete-fixture.sh"
+  GIST_DELETE_RECORD="$fixture_dir/delete-record" \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" <<'EOF'
+fixture-gist-id
+EOF
+  test -f "$fixture_dir/delete-record" ||
+    fail "documented deletion confirmation did not invoke the exact approved ID"
+  GIST_DELETE_RECORD="$fixture_dir/delete-record-bash" \
+    PATH="$mock_bin:$PATH" \
+    bash "$fixture_dir/delete-fixture.sh" <<'EOF'
+fixture-gist-id
+EOF
+  test -f "$fixture_dir/delete-record-bash" ||
+    fail "documented deletion confirmation is not Bash-compatible"
+
+  printf 'fixture memo\n' >"$fixture_dir/task.md"
+  extract_documented_snippet '# agent-task-gist-raw-verification' "$fixture_dir/raw.sh"
+  GIST_CLEANUP_RECORD="$fixture_dir/cleanup-record" \
+    GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
+    gist_id=fixture-gist-id \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    env -u TMPDIR sh "$fixture_dir/raw.sh"
+  test -s "$fixture_dir/cleanup-record" ||
+    fail "documented raw verification did not clean up its temporary directory"
+  cleaned_directory=$(cat "$fixture_dir/cleanup-record")
+  case "$cleaned_directory" in
+  /tmp/agent-task-gist.*) ;;
+  *) fail "documented raw verification did not use the TMPDIR fallback: $cleaned_directory" ;;
+  esac
+  test ! -e "$cleaned_directory" ||
+    fail "documented raw verification left its temporary directory behind"
+}
+
 # shellcheck disable=SC2016 # The literal command text is the policy assertion.
 for required in \
   '1 task = 1 Gist = 1 Markdown file' \
@@ -21,20 +185,25 @@ for required in \
   'gh gist list --secret' \
   'per-Gist confirmation' \
   'Do not use `gh gist delete --yes`'; do
-  grep -Fq -- "$required" "$policy_file" || {
-    echo "missing required agent-task Gist policy text: $required" >&2
-    exit 1
-  }
+  grep -Fq -- "$required" "$policy_file" ||
+    fail "missing required agent-task Gist policy text: $required"
 done
 
-grep -Fq -- 'optional portable agent task-memo Gists' "$skill_file" || {
-  echo "dotfiles skill does not expose portable agent task-memo Gists" >&2
-  exit 1
-}
+grep -Fq -- 'optional portable agent task-memo Gists' "$skill_file" ||
+  fail "dotfiles skill does not expose portable agent task-memo Gists"
 
-if grep -En '^[[:space:]]*gh gist (create|edit|list|delete).*--public' "$policy_file"; then
-  echo "agent-task Gist policy offers a public-mode command path" >&2
-  exit 1
+if contains_public_gist_command "$policy_file"; then
+  fail "agent-task Gist policy offers a public-mode command path"
 fi
+
+run_public_mode_fixtures
+run_documented_snippet_fixtures
+
+url_handoff_line=$(grep -n '^# agent-task-gist-url-handoff$' "$policy_file" | cut -d: -f1)
+html_url_line=$(grep -n 'html_url' "$policy_file" | cut -d: -f1)
+test -n "$url_handoff_line" || fail "missing post-verification URL handoff marker"
+test -n "$html_url_line" || fail "missing post-verification URL retrieval"
+test "$html_url_line" -gt "$url_handoff_line" ||
+  fail "secret URL is retrieved before the approved handoff stage"
 
 echo "agent-task Gist policy validation passed"

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -16,12 +16,12 @@ fail() {
 
 contains_public_gist_command() {
   awk '
-    function inspect(command) {
-      if (command ~ /^[[:space:]]*gh[[:space:]]+gist[[:space:]]+(create|edit|list|delete)([[:space:]]|$)/ && command ~ /(^|[[:space:]])--public([[:space:]]|$)/) {
-        print command
-        found = 1
-      }
-    }
+	  function inspect(command) {
+	    if (command ~ /^[[:space:]]*((command[[:space:]]+)|(env([[:space:]]+(-[[:alnum:]_=-]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+))*[[:space:]]+))?gh[[:space:]]+gist[[:space:]]+(create|edit|list|delete)([[:space:]]|$)/ && command ~ /(^|[[:space:]])--public([[:space:]]|$)/) {
+	      print command
+	      found = 1
+	    }
+	  }
     {
       line = $0
       sub(/[[:space:]]+$/, "", line)
@@ -97,6 +97,10 @@ run_public_mode_fixtures() {
   assert_fixture_rejected multiline-delete \
     "gh gist delete $continuation" \
     '  --public gist-id'
+  assert_fixture_rejected env-prefixed-public-create \
+    'env GITHUB_TOKEN=fixture gh gist create --public task.md'
+  assert_fixture_rejected command-prefixed-public-list \
+    'command gh gist list --public'
   assert_fixture_allowed allowed-create \
     "gh gist create --desc 'agent-task:<repo>:<task>' task.md"
   assert_fixture_allowed allowed-multiline-create \
@@ -113,32 +117,71 @@ run_documented_snippet_fixtures() {
   cat >"$mock_bin/gh" <<'EOF'
 #!/bin/sh
 if [ "$1" = auth ] && [ "$2" = status ]; then
-  printf '%s\n' 'Logged in to github.com account i9wa4'
-  exit 0
+	printf '%s\n' 'Logged in to github.com account i9wa4'
+	exit 0
+fi
+if [ "$1" = api ] && [ "$2" = user ] && [ "$3" = --jq ] && [ "$4" = .login ]; then
+	printf '%s\n' "${GIST_MOCK_ACCOUNT:-i9wa4}"
+	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = create ]; then
-  printf '%s\n' 'https://gist.github.com/fixture-gist-id'
-  exit 0
+	case "${GIST_CREATE_MODE:-ok}" in
+	ok)
+		printf '%s\n' 'https://gist.github.com/fixtureGistId'
+		;;
+	stderr-url)
+		printf '%s\n' 'https://gist.github.com/fixtureGistId' >&2
+		printf '%s\n' 'https://gist.github.com/fixtureGistId'
+		;;
+	noisy)
+		printf '%s\n%s\n' 'created:' 'https://gist.github.com/fixtureGistId'
+		;;
+	multiline)
+		printf '%s\n%s\n' 'https://gist.github.com/fixtureGistId' 'https://gist.github.com/other'
+		;;
+	malformed)
+		printf '%s\n' 'not-a-gist-url'
+		;;
+	*)
+		exit 64
+		;;
+	esac
+	exit 0
 fi
-if [ "$1" = gist ] && [ "$2" = edit ] && [ "$3" = fixture-gist-id ]; then
-  exit 0
+if [ "$1" = gist ] && [ "$2" = edit ] && [ "$3" = fixtureGistId ]; then
+	exit 0
 fi
-if [ "$1" = gist ] && [ "$2" = delete ] && [ "$3" = fixture-gist-id ]; then
-  : > "$GIST_DELETE_RECORD"
-  exit 0
+if [ "$1" = gist ] && [ "$2" = delete ]; then
+	printf '%s\n' "$3" >> "$GIST_DELETE_RECORD"
+	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = view ]; then
-  cat "$GIST_FIXTURE_SOURCE"
-  exit 0
+	cat "$GIST_FIXTURE_SOURCE"
+	exit 0
 fi
-if [ "$1" = api ] && [ "$2" = gists/fixture-gist-id ] && [ "$4" = '{public,description,files:(.files|keys)}' ]; then
-  printf '%s\n' '{"public":false,"description":"agent-task:<repo>:<task>","files":["task.md"]}'
-  exit 0
-fi
-if [ "$1" = api ] && [ "$2" = gists/fixture-gist-id ] && [ "$4" = '.html_url' ]; then
-  : > "$GIST_URL_HANDOFF_RECORD"
-  printf '%s\n' 'https://gist.github.com/fixture-gist-id'
-  exit 0
+if [ "$1" = api ] && [ "$2" = gists/fixtureGistId ] && [ "$3" = --jq ]; then
+	case "$4" in
+	.public)
+		printf '%s\n' "${GIST_MOCK_PUBLIC:-false}"
+		;;
+	.description)
+		printf '%s\n' "${GIST_MOCK_DESCRIPTION:-agent-task:<repo>:<task>}"
+		;;
+	'.files | keys | length')
+		printf '%s\n' "${GIST_MOCK_FILE_COUNT:-1}"
+		;;
+	'.files | keys[0]')
+		printf '%s\n' "${GIST_MOCK_FILENAME:-task.md}"
+		;;
+	.html_url)
+		: > "$GIST_URL_HANDOFF_RECORD"
+		printf '%s\n' 'https://gist.github.com/fixtureGistId'
+		;;
+	*)
+		exit 64
+		;;
+	esac
+	exit 0
 fi
 exit 64
 EOF
@@ -146,7 +189,9 @@ EOF
 
   cat >"$mock_bin/rm" <<'EOF'
 #!/bin/sh
-printf '%s\n' "$2" > "$GIST_CLEANUP_RECORD"
+if [ -n "${GIST_CLEANUP_RECORD:-}" ]; then
+	printf '%s\n' "$2" > "$GIST_CLEANUP_RECORD"
+fi
 exec /bin/rm "$@"
 EOF
   chmod 700 "$mock_bin/rm"
@@ -178,27 +223,77 @@ EOF
 
   printf 'fixture memo\n' >"$fixture_dir/task.md"
   extract_documented_snippet '# agent-task-gist-create-read-back' "$fixture_dir/create-read-back.sh"
+  extract_documented_snippet '# agent-task-gist-url-handoff' "$fixture_dir/url-handoff.sh"
+  {
+    printf 'set -e\n'
+    cat "$fixture_dir/create-read-back.sh"
+    cat "$fixture_dir/url-handoff.sh"
+    # shellcheck disable=SC2016 # The generated script must write this literal expansion.
+    printf '%s\n' 'printf "%s\n" "$secret_gist_url" > "$GIST_URL_HANDOFF_RECORD"'
+  } >"$fixture_dir/create-url-flow.sh"
   GIST_URL_HANDOFF_RECORD="$fixture_dir/create-url-record" \
+    GIST_DELETE_RECORD="$fixture_dir/create-delete-record" \
     PATH="$mock_bin:$PATH" \
     task_file="$fixture_dir/task.md" \
     sh "$fixture_dir/create-read-back.sh" >"$fixture_dir/create-read-back.out"
   if grep -Fq 'https://gist.github.com/' "$fixture_dir/create-read-back.out"; then
     fail "documented create/read-back flow prints the secret URL before verification"
   fi
+  test ! -e "$fixture_dir/create-delete-record" ||
+    fail "documented create/read-back flow cleaned up after successful metadata verification"
+
+  assert_create_failure_blocks_handoff() {
+    name=$1
+    shift
+    out_file="$fixture_dir/$name.out"
+    err_file="$fixture_dir/$name.err"
+    url_record="$fixture_dir/$name-url-record"
+    delete_record="$fixture_dir/$name-delete-record"
+    if GIST_URL_HANDOFF_RECORD="$url_record" \
+      GIST_DELETE_RECORD="$delete_record" \
+      PATH="$mock_bin:$PATH" \
+      task_file="$fixture_dir/task.md" \
+      env "$@" sh "$fixture_dir/create-url-flow.sh" >"$out_file" 2>"$err_file"; then
+      fail "documented create/read-back failure reached URL handoff: $name"
+    fi
+    if grep -Fq 'https://gist.github.com/' "$out_file" "$err_file"; then
+      fail "documented create/read-back failure leaked URL to logs: $name"
+    fi
+    test ! -e "$url_record" ||
+      fail "documented create/read-back failure created URL handoff record: $name"
+  }
+
+  assert_create_failure_blocks_handoff bad-account GIST_MOCK_ACCOUNT=other-user
+  assert_create_failure_blocks_handoff public-metadata GIST_MOCK_PUBLIC=true
+  test "$(cat "$fixture_dir/public-metadata-delete-record")" = fixtureGistId ||
+    fail "public metadata failure did not clean up the created Gist"
+  assert_create_failure_blocks_handoff wrong-description GIST_MOCK_DESCRIPTION=wrong
+  test "$(cat "$fixture_dir/wrong-description-delete-record")" = fixtureGistId ||
+    fail "wrong description failure did not clean up the created Gist"
+  assert_create_failure_blocks_handoff wrong-filename GIST_MOCK_FILENAME=wrong.md
+  test "$(cat "$fixture_dir/wrong-filename-delete-record")" = fixtureGistId ||
+    fail "wrong filename failure did not clean up the created Gist"
+  assert_create_failure_blocks_handoff multiple-filenames GIST_MOCK_FILE_COUNT=2
+  test "$(cat "$fixture_dir/multiple-filenames-delete-record")" = fixtureGistId ||
+    fail "multiple filename failure did not clean up the created Gist"
+  assert_create_failure_blocks_handoff stderr-url-leakage GIST_CREATE_MODE=stderr-url
+  assert_create_failure_blocks_handoff noisy-create-output GIST_CREATE_MODE=noisy
+  assert_create_failure_blocks_handoff multiline-create-output GIST_CREATE_MODE=multiline
+  assert_create_failure_blocks_handoff malformed-create-output GIST_CREATE_MODE=malformed
 
   extract_documented_snippet '# agent-task-gist-delete-confirmation' "$fixture_dir/delete.sh"
-  sed 's/<reviewed-gist-id>/fixture-gist-id/g' "$fixture_dir/delete.sh" >"$fixture_dir/delete-fixture.sh"
+  sed 's/<reviewed-gist-id>/fixtureGistId/g' "$fixture_dir/delete.sh" >"$fixture_dir/delete-fixture.sh"
   GIST_DELETE_RECORD="$fixture_dir/delete-record" \
     PATH="$mock_bin:$PATH" \
     sh "$fixture_dir/delete-fixture.sh" <<'EOF'
-fixture-gist-id
+fixtureGistId
 EOF
   test -f "$fixture_dir/delete-record" ||
     fail "documented deletion confirmation did not invoke the exact approved ID"
   GIST_DELETE_RECORD="$fixture_dir/delete-record-bash" \
     PATH="$mock_bin:$PATH" \
     bash "$fixture_dir/delete-fixture.sh" <<'EOF'
-fixture-gist-id
+fixtureGistId
 EOF
   test -f "$fixture_dir/delete-record-bash" ||
     fail "documented deletion confirmation is not Bash-compatible"
@@ -206,7 +301,7 @@ EOF
   extract_documented_snippet '# agent-task-gist-raw-verification' "$fixture_dir/raw.sh"
   GIST_CLEANUP_RECORD="$fixture_dir/cleanup-record" \
     GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
-    gist_id=fixture-gist-id \
+    gist_id=fixtureGistId \
     task_file="$fixture_dir/task.md" \
     PATH="$mock_bin:$PATH" \
     env -u TMPDIR sh "$fixture_dir/raw.sh"
@@ -223,7 +318,7 @@ EOF
   printf 'different memo\n' >"$fixture_dir/mismatch-task.md"
   GIST_CLEANUP_RECORD="$fixture_dir/mismatch-cleanup-record" \
     GIST_FIXTURE_SOURCE="$fixture_dir/mismatch-task.md" \
-    gist_id=fixture-gist-id \
+    gist_id=fixtureGistId \
     task_file="$fixture_dir/task.md" \
     PATH="$mock_bin:$PATH" \
     env -u TMPDIR sh "$fixture_dir/raw.sh" >"$fixture_dir/raw-mismatch.out" 2>&1 &&
@@ -234,7 +329,6 @@ EOF
   test ! -e "$mismatch_cleaned_directory" ||
     fail "documented raw verification mismatch path left its temporary directory behind"
 
-  extract_documented_snippet '# agent-task-gist-url-handoff' "$fixture_dir/url-handoff.sh"
   {
     printf 'set -e\n'
     cat "$fixture_dir/create-read-back.sh"

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -45,12 +45,64 @@ tokenize_shell_words() {
   local command=$1
   TOKENS=()
   TOKEN_QUOTED=()
+  TOKEN_ASSIGNMENT_PREFIX=()
   local token=
   local quoted=0
+  local assignment_prefix=0
+  local assignment_equal_seen=0
+  local assignment_name_valid=1
+  local assignment_name_len=0
   local state=normal
   local i=0
   local char=
   local next=
+  flush_token() {
+    TOKENS+=("$token")
+    TOKEN_QUOTED+=("$quoted")
+    TOKEN_ASSIGNMENT_PREFIX+=("$assignment_prefix")
+    token=
+    quoted=0
+    assignment_prefix=0
+    assignment_equal_seen=0
+    assignment_name_valid=1
+    assignment_name_len=0
+  }
+  append_unquoted_char() {
+    local appended=$1
+    if [ "$assignment_equal_seen" -eq 0 ]; then
+      case "$appended" in
+      =)
+        if [ "$assignment_name_valid" -eq 1 ] && [ "$assignment_name_len" -gt 0 ]; then
+          assignment_prefix=1
+        fi
+        assignment_equal_seen=1
+        ;;
+      [A-Za-z_])
+        assignment_name_len=$((assignment_name_len + 1))
+        ;;
+      [0-9])
+        if [ "$assignment_name_len" -eq 0 ]; then
+          assignment_name_valid=0
+        fi
+        assignment_name_len=$((assignment_name_len + 1))
+        ;;
+      *)
+        assignment_name_valid=0
+        assignment_name_len=$((assignment_name_len + 1))
+        ;;
+      esac
+    fi
+    token="$token$appended"
+  }
+  append_quoted_char() {
+    local appended=$1
+    # Only an unquoted NAME= prefix is shell assignment syntax; quoted NAME=
+    # remains the command argv word.
+    if [ "$assignment_equal_seen" -eq 0 ]; then
+      assignment_name_valid=0
+    fi
+    token="$token$appended"
+  }
   while [ "$i" -lt "${#command}" ]; do
     char=${command:i:1}
     case "$state" in
@@ -58,55 +110,55 @@ tokenize_shell_words() {
       case "$char" in
       [[:space:]])
         if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
-          TOKENS+=("$token")
-          TOKEN_QUOTED+=("$quoted")
-          token=
-          quoted=0
+          flush_token
         fi
         ;;
       "'")
         state=single
         quoted=1
+        if [ "$assignment_equal_seen" -eq 0 ]; then
+          assignment_name_valid=0
+        fi
         ;;
       '"')
         state=double
         quoted=1
+        if [ "$assignment_equal_seen" -eq 0 ]; then
+          assignment_name_valid=0
+        fi
         ;;
       \\)
         i=$((i + 1))
         if [ "$i" -lt "${#command}" ]; then
-          token="$token${command:i:1}"
+          append_quoted_char "${command:i:1}"
         fi
         ;;
       ';')
         if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
-          TOKENS+=("$token")
-          TOKEN_QUOTED+=("$quoted")
-          token=
-          quoted=0
+          flush_token
         fi
         TOKENS+=(';')
         TOKEN_QUOTED+=(0)
+        TOKEN_ASSIGNMENT_PREFIX+=(0)
         ;;
       '&' | '|' | '(' | ')')
         if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
-          TOKENS+=("$token")
-          TOKEN_QUOTED+=("$quoted")
-          token=
-          quoted=0
+          flush_token
         fi
         next=${command:$((i + 1)):1}
         if [ "$char" != '(' ] && [ "$char" != ')' ] && [ "$next" = "$char" ]; then
           TOKENS+=("$char$next")
           TOKEN_QUOTED+=(0)
+          TOKEN_ASSIGNMENT_PREFIX+=(0)
           i=$((i + 1))
         else
           TOKENS+=("$char")
           TOKEN_QUOTED+=(0)
+          TOKEN_ASSIGNMENT_PREFIX+=(0)
         fi
         ;;
       *)
-        token="$token$char"
+        append_unquoted_char "$char"
         ;;
       esac
       ;;
@@ -114,7 +166,7 @@ tokenize_shell_words() {
       if [ "$char" = "'" ]; then
         state=normal
       else
-        token="$token$char"
+        append_quoted_char "$char"
       fi
       ;;
     double)
@@ -126,11 +178,11 @@ tokenize_shell_words() {
         i=$((i + 1))
         if [ "$i" -lt "${#command}" ]; then
           next=${command:i:1}
-          token="$token$next"
+          append_quoted_char "$next"
         fi
         ;;
       *)
-        token="$token$char"
+        append_quoted_char "$char"
         ;;
       esac
       ;;
@@ -138,13 +190,8 @@ tokenize_shell_words() {
     i=$((i + 1))
   done
   if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
-    TOKENS+=("$token")
-    TOKEN_QUOTED+=("$quoted")
+    flush_token
   fi
-}
-
-is_assignment_word() {
-  [[ $1 =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]
 }
 
 segment_has_public_gist_flag() {
@@ -152,7 +199,7 @@ segment_has_public_gist_flag() {
   local end=$2
   local index=0
   index=$start
-  while [ "$index" -lt "$end" ] && is_assignment_word "${TOKENS[$index]}"; do
+  while [ "$index" -lt "$end" ] && [ "${TOKEN_ASSIGNMENT_PREFIX[$index]}" -eq 1 ]; do
     index=$((index + 1))
   done
   while [ "$index" -lt "$end" ]; do
@@ -288,6 +335,12 @@ run_public_mode_fixtures() {
     'command g"h" gist create --public task.md'
   assert_command_rejected direct-ampersand-separated-public-create \
     'printf x & gh gist create --public task.md'
+  assert_command_rejected direct-assignment-quoted-value-public-create \
+    'TOKEN="x" gh gist create --public task.md'
+  assert_command_rejected direct-env-quoted-assignment-public-create \
+    'env "TOKEN=x" gh gist create --public task.md'
+  assert_command_allowed direct-quoted-assignment-like-command \
+    '"TOKEN=x" gh gist create --public task.md'
   assert_command_allowed direct-desc-public-value \
     "gh gist create --desc '--public' task.md"
   assert_command_allowed direct-stop-option-public-positional \
@@ -333,6 +386,8 @@ run_public_mode_fixtures() {
     'gh gist c"reate" --public task.md'
   assert_fixture_rejected quoted-assignment-prefixed-public-create \
     'TOKEN="x" gh gist create --public task.md'
+  assert_fixture_rejected env-quoted-assignment-public-create \
+    'env "TOKEN=x" gh gist create --public task.md'
   assert_fixture_rejected ampersand-separated-public-create \
     'printf x & gh gist create --public task.md'
   assert_fixture_rejected command-quote-spliced-public-create \
@@ -358,6 +413,8 @@ run_public_mode_fixtures() {
     "gh gist create --desc 'document the --public prohibition' task.md"
   assert_fixture_allowed allowed-quoted-filename-public-text \
     'gh gist create "--public-task.md"'
+  assert_fixture_allowed allowed-quoted-assignment-like-command \
+    '"TOKEN=x" gh gist create --public task.md'
   assert_fixture_allowed allowed-desc-public-value \
     "gh gist create --desc '--public' task.md"
   assert_fixture_allowed allowed-stop-option-public-positional \

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -184,7 +184,18 @@ tokenize_shell_words() {
         i=$((i + 1))
         if [ "$i" -lt "${#command}" ]; then
           next=${command:i:1}
-          append_quoted_char "$next"
+          case "$next" in
+          '"' | \\ | '$' | '`')
+            append_quoted_char "$next"
+            ;;
+          $'\n')
+            ;;
+          *)
+            # shellcheck disable=SC1003 # Literal backslash preserved in double quotes.
+            append_quoted_char '\'
+            append_quoted_char "$next"
+            ;;
+          esac
         fi
         ;;
       *)
@@ -333,8 +344,37 @@ assert_command_allowed() {
   fi
 }
 
+assert_token_equals() {
+  name=$1
+  command=$2
+  index=$3
+  expected=$4
+  tokenize_shell_words "$command"
+  test "${TOKENS[$index]:-}" = "$expected" ||
+    fail "tokenizer produced unexpected token for $name"
+}
+
 run_public_mode_fixtures() {
   continuation=$(printf '%b' '\134')
+  assert_token_equals direct-double-quote-preserved-nonspecial-backslash \
+    'gh gist create "--pub\lic" task.md' 3 '--pub\lic'
+  assert_token_equals direct-double-quote-escaped-backslash \
+    'gh gist create "--pub\\lic" task.md' 3 '--pub\lic'
+  assert_token_equals direct-double-quote-escaped-quote \
+    'gh gist create "--pub\"lic" task.md' 3 '--pub"lic'
+  # shellcheck disable=SC2016 # Literal dollar exercises double-quote escaping.
+  assert_token_equals direct-double-quote-escaped-dollar \
+    'gh gist create "--pub\$lic" task.md' 3 '--pub$lic'
+  assert_token_equals direct-double-quote-escaped-backtick \
+    'gh gist create "--pub\`lic" task.md' 3 '--pub`lic'
+  assert_token_equals direct-double-quote-backslash-newline-removal \
+    $'gh gist create "--pub\\\nlic" task.md' 3 '--public'
+  assert_command_allowed direct-double-quote-preserved-nonspecial-backslash-create \
+    'gh gist create "--pub\lic" task.md'
+  assert_command_allowed direct-double-quote-escaped-backslash-create \
+    'gh gist create "--pub\\lic" task.md'
+  assert_command_rejected direct-double-quote-backslash-newline-public-create \
+    $'gh gist create "--pub\\\nlic" task.md'
   assert_command_rejected direct-quote-spliced-gh-create \
     'g"h" gist create --public task.md'
   assert_command_rejected direct-command-quote-spliced-public-create \
@@ -383,6 +423,9 @@ run_public_mode_fixtures() {
   assert_fixture_rejected split-public-continuation-create \
     "gh gist create --pub$continuation" \
     'lic task.md'
+  assert_fixture_rejected split-public-double-quoted-continuation-create \
+    "gh gist create \"--pub$continuation" \
+    'lic" task.md'
   assert_fixture_rejected split-quote-spliced-gh-continuation-create \
     "g$continuation" \
     '"h" gist create --public task.md'
@@ -424,6 +467,10 @@ run_public_mode_fixtures() {
   assert_fixture_allowed allowed-list 'gh gist list --secret --limit 100'
   assert_fixture_allowed allowed-publicity-token \
     'gh gist create --publicity task.md'
+  assert_fixture_allowed allowed-double-quoted-preserved-backslash-public-token \
+    'gh gist create "--pub\lic" task.md'
+  assert_fixture_allowed allowed-double-quoted-escaped-backslash-public-token \
+    'gh gist create "--pub\\lic" task.md'
   assert_fixture_allowed allowed-split-publicity-continuation-token \
     "gh gist create --pub$continuation" \
     'licity task.md'

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -88,7 +88,7 @@ tokenize_shell_words() {
         TOKENS+=(';')
         TOKEN_QUOTED+=(0)
         ;;
-      '&' | '|')
+      '&' | '|' | '(' | ')')
         if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
           TOKENS+=("$token")
           TOKEN_QUOTED+=("$quoted")
@@ -96,7 +96,7 @@ tokenize_shell_words() {
           quoted=0
         fi
         next=${command:$((i + 1)):1}
-        if [ "$next" = "$char" ]; then
+        if [ "$char" != '(' ] && [ "$char" != ')' ] && [ "$next" = "$char" ]; then
           TOKENS+=("$char$next")
           TOKEN_QUOTED+=(0)
           i=$((i + 1))
@@ -152,11 +152,11 @@ segment_has_public_gist_flag() {
   local end=$2
   local index=0
   index=$start
-  while [ "$index" -lt "$end" ] && is_assignment_word "${TOKENS[$index]}" && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; do
+  while [ "$index" -lt "$end" ] && is_assignment_word "${TOKENS[$index]}"; do
     index=$((index + 1))
   done
   while [ "$index" -lt "$end" ]; do
-    if [ "${TOKENS[$index]}" = env ] && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; then
+    if [ "${TOKENS[$index]}" = env ]; then
       index=$((index + 1))
       while [ "$index" -lt "$end" ]; do
         case "${TOKENS[$index]}" in
@@ -174,7 +174,7 @@ segment_has_public_gist_flag() {
           ;;
         esac
       done
-    elif [ "${TOKENS[$index]}" = command ] && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; then
+    elif [ "${TOKENS[$index]}" = command ]; then
       index=$((index + 1))
       while [ "$index" -lt "$end" ] && [[ ${TOKENS[$index]} == -* ]]; do
         index=$((index + 1))
@@ -184,18 +184,26 @@ segment_has_public_gist_flag() {
     fi
   done
   [ "${TOKENS[$index]:-}" = gh ] || return 1
-  [ "${TOKEN_QUOTED[$index]:-1}" -eq 0 ] || return 1
   [ "${TOKENS[$((index + 1))]:-}" = gist ] || return 1
-  [ "${TOKEN_QUOTED[$((index + 1))]:-1}" -eq 0 ] || return 1
   case "${TOKENS[$((index + 2))]:-}" in
   create | edit | list | delete) ;;
   *) return 1 ;;
   esac
-  [ "${TOKEN_QUOTED[$((index + 2))]:-1}" -eq 0 ] || return 1
   local flag_index=$((index + 3))
   while [ "$flag_index" -lt "$end" ]; do
     case "${TOKENS[$flag_index]}" in
-    --public | --public=* | -p) return 0 ;;
+    --) return 1 ;;
+    --desc | --description | -d | --filename | --file | -f)
+      flag_index=$((flag_index + 2))
+      continue
+      ;;
+    --desc=* | --description=* | --filename=* | --file=*)
+      flag_index=$((flag_index + 1))
+      continue
+      ;;
+    --public | --public=* | -p)
+      return 0
+      ;;
     esac
     flag_index=$((flag_index + 1))
   done
@@ -212,7 +220,7 @@ command_has_public_gist_flag() {
       segment_has_public_gist_flag "$start" "$index" && return 0
     else
       case "${TOKENS[$index]}" in
-      ';' | '&&' | '||' | '|')
+      ';' | '&' | '&&' | '||' | '|' | '(' | ')')
         segment_has_public_gist_flag "$start" "$index" && return 0
         start=$((index + 1))
         ;;
@@ -257,8 +265,33 @@ assert_fixture_allowed() {
   fi
 }
 
+assert_command_rejected() {
+  name=$1
+  command=$2
+  command_has_public_gist_flag "$command" ||
+    fail "public-mode command bypassed argv parser: $name"
+}
+
+assert_command_allowed() {
+  name=$1
+  command=$2
+  if command_has_public_gist_flag "$command"; then
+    fail "allowed command was rejected by argv parser: $name"
+  fi
+}
+
 run_public_mode_fixtures() {
   continuation=$(printf '%b' '\134')
+  assert_command_rejected direct-quote-spliced-gh-create \
+    'g"h" gist create --public task.md'
+  assert_command_rejected direct-command-quote-spliced-public-create \
+    'command g"h" gist create --public task.md'
+  assert_command_rejected direct-ampersand-separated-public-create \
+    'printf x & gh gist create --public task.md'
+  assert_command_allowed direct-desc-public-value \
+    "gh gist create --desc '--public' task.md"
+  assert_command_allowed direct-stop-option-public-positional \
+    "gh gist create -- '--public'"
   assert_fixture_rejected multiline-create \
     "gh gist create $continuation" \
     '  --public task.md'
@@ -292,6 +325,20 @@ run_public_mode_fixtures() {
     'printf x; gh gist create --public task.md'
   assert_fixture_rejected assignment-prefixed-public-create \
     'TOKEN=x gh gist create --public task.md'
+  assert_fixture_rejected quote-spliced-gh-create \
+    'g"h" gist create --public task.md'
+  assert_fixture_rejected quote-spliced-gist-create \
+    'gh g"ist" create --public task.md'
+  assert_fixture_rejected quote-spliced-create-create \
+    'gh gist c"reate" --public task.md'
+  assert_fixture_rejected quoted-assignment-prefixed-public-create \
+    'TOKEN="x" gh gist create --public task.md'
+  assert_fixture_rejected ampersand-separated-public-create \
+    'printf x & gh gist create --public task.md'
+  assert_fixture_rejected command-quote-spliced-public-create \
+    'command g"h" gist create --public task.md'
+  assert_fixture_rejected grouped-public-create \
+    '( gh gist create --public task.md )'
   assert_fixture_allowed allowed-create \
     "gh gist create --desc 'agent-task:<repo>:<task>' task.md"
   assert_fixture_allowed allowed-multiline-create \
@@ -311,6 +358,10 @@ run_public_mode_fixtures() {
     "gh gist create --desc 'document the --public prohibition' task.md"
   assert_fixture_allowed allowed-quoted-filename-public-text \
     'gh gist create "--public-task.md"'
+  assert_fixture_allowed allowed-desc-public-value \
+    "gh gist create --desc '--public' task.md"
+  assert_fixture_allowed allowed-stop-option-public-positional \
+    "gh gist create -- '--public'"
 }
 
 run_documented_snippet_fixtures() {
@@ -328,6 +379,12 @@ if [ "$1" = api ] && [ "$2" = user ] && [ "$3" = --jq ] && [ "$4" = .login ]; th
 	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = create ]; then
+	if [ -n "${GIST_CREATE_RECORD:-}" ]; then
+		printf '%s\n' create >> "$GIST_CREATE_RECORD"
+	fi
+	if [ -n "${GIST_ORDER_RECORD:-}" ]; then
+		printf '%s\n' create >> "$GIST_ORDER_RECORD"
+	fi
 	case "${GIST_CREATE_MODE:-ok}" in
 	ok)
 		printf '%s\n' 'https://gist.github.com/fixtureGistId'
@@ -466,14 +523,34 @@ EOF
 
   cat >"$mock_bin/rg" <<'EOF'
 #!/bin/sh
-if [ "${GIST_SCAN_MODE:-ok}" = fail ]; then
+if [ -n "${GIST_SCAN_RECORD:-}" ]; then
+	printf '%s\n' "$*" >> "$GIST_SCAN_RECORD"
+fi
+if [ -n "${GIST_ORDER_RECORD:-}" ]; then
+	printf '%s\n' scan >> "$GIST_ORDER_RECORD"
+fi
+if [ "${GIST_SCAN_MODE:-ok}" = fail ] || [ "${GIST_SCAN_MODE:-ok}" = fail-local ]; then
 	printf '%s\n' '1:tmux-a2a'
 	exit 0
 fi
-if [ "${GIST_SCAN_MODE:-ok}" = error ]; then
+if [ "${GIST_SCAN_MODE:-ok}" = error-local ]; then
 	printf '%s\n' 'scanner error' >&2
 	exit 2
 fi
+for arg do
+	if [ "${GIST_SCAN_MODE:-ok}" = error ]; then
+		case "$arg" in
+		*/agent-task-gist.*)
+			printf '%s\n' 'scanner error' >&2
+			exit 2
+			;;
+		esac
+	fi
+	if [ -f "$arg" ] && grep -Fq 'tmux-a2a' "$arg"; then
+		printf '%s\n' '1:tmux-a2a'
+		exit 0
+	fi
+done
 exit 1
 EOF
   chmod 700 "$mock_bin/rg"
@@ -497,6 +574,7 @@ EOF
   chmod 700 "$mock_bin/shasum"
 
   printf 'fixture memo\n' >"$fixture_dir/task.md"
+  printf 'tmux-a2a marker\n' >"$fixture_dir/private-task.md"
   extract_documented_snippet '# agent-task-gist-create-read-back' "$fixture_dir/create-read-back.sh"
   extract_documented_snippet '# agent-task-gist-url-handoff' "$fixture_dir/url-handoff.sh"
   {
@@ -508,9 +586,18 @@ EOF
   } >"$fixture_dir/create-url-flow.sh"
   GIST_URL_HANDOFF_RECORD="$fixture_dir/create-url-record" \
     GIST_DELETE_RECORD="$fixture_dir/create-delete-record" \
+    GIST_CREATE_RECORD="$fixture_dir/create-record" \
+    GIST_SCAN_RECORD="$fixture_dir/local-scan-record" \
+    GIST_ORDER_RECORD="$fixture_dir/local-order-record" \
     PATH="$mock_bin:$PATH" \
     task_file="$fixture_dir/task.md" \
     sh "$fixture_dir/create-read-back.sh" >"$fixture_dir/create-read-back.out"
+  test "$(wc -l <"$fixture_dir/create-record")" -eq 1 ||
+    fail "documented clean local scan did not reach create exactly once"
+  test -s "$fixture_dir/local-scan-record" ||
+    fail "documented clean flow did not scan local task before create"
+  test "$(printf 'scan\ncreate\n')" = "$(cat "$fixture_dir/local-order-record")" ||
+    fail "documented clean flow did not scan before create"
   if grep -Fq 'https://gist.github.com/' "$fixture_dir/create-read-back.out"; then
     fail "documented create/read-back flow prints the secret URL before verification"
   fi
@@ -573,6 +660,47 @@ EOF
   assert_create_failure_blocks_handoff malformed-create-query-extra unknown GIST_CREATE_MODE=query-extra
   assert_create_failure_blocks_handoff metadata-edit-failed fixtureGistId GIST_EDIT_MODE=fail
   assert_create_failure_blocks_handoff metadata-api-failed fixtureGistId GIST_API_MODE=fail
+
+  assert_local_scan_blocks_create() {
+    name=$1
+    shift
+    out_file="$fixture_dir/$name.out"
+    err_file="$fixture_dir/$name.err"
+    create_record="$fixture_dir/$name-create-record"
+    scan_record="$fixture_dir/$name-scan-record"
+    order_record="$fixture_dir/$name-order-record"
+    pending_record="$fixture_dir/$name-pending-cleanup"
+    delete_record="$fixture_dir/$name-delete-record"
+    url_record="$fixture_dir/$name-url-record"
+    if GIST_CREATE_RECORD="$create_record" \
+      GIST_SCAN_RECORD="$scan_record" \
+      GIST_ORDER_RECORD="$order_record" \
+      GIST_URL_HANDOFF_RECORD="$url_record" \
+      GIST_DELETE_RECORD="$delete_record" \
+      pending_cleanup_record="$pending_record" \
+      PATH="$mock_bin:$PATH" \
+      env "$@" sh "$fixture_dir/create-url-flow.sh" >"$out_file" 2>"$err_file"; then
+      fail "documented local scan failure reached URL handoff: $name"
+    fi
+    test -s "$scan_record" ||
+      fail "documented local scan failure did not scan before create: $name"
+    test "$(cat "$order_record")" = scan ||
+      fail "documented local scan failure order was not scan-only: $name"
+    test ! -e "$create_record" ||
+      fail "documented local scan failure still created a Gist: $name"
+    test ! -e "$pending_record" ||
+      fail "documented local scan failure invented pending remote cleanup: $name"
+    test ! -e "$url_record" ||
+      fail "documented local scan failure created URL handoff record: $name"
+    test ! -e "$delete_record" ||
+      fail "documented local scan failure deleted before remote creation: $name"
+    if grep -Fq 'https://gist.github.com/' "$out_file" "$err_file"; then
+      fail "documented local scan failure leaked URL: $name"
+    fi
+  }
+
+  assert_local_scan_blocks_create local-scan-prohibited-marker task_file="$fixture_dir/private-task.md"
+  assert_local_scan_blocks_create local-scan-scanner-error task_file="$fixture_dir/task.md" GIST_SCAN_MODE=error-local
 
   for signal_name in HUP INT TERM; do
     signal_script="$fixture_dir/create-signal-$signal_name.sh"
@@ -646,17 +774,23 @@ EOF
     preview_account=$5
     preview_age_days=$6
     preview_description=$7
+    metadata_schema=${8:-agent-task-gist-reviewed-preview-v1}
+    metadata_account=${9:-i9wa4}
     preview_data="$destination.data"
+    preview_proof="$destination.proof"
     printf '%s\t%s\t%s\t%s\t%s\n' \
       "$preview_id" "$preview_owner" "$preview_account" "$preview_age_days" "$preview_description" \
       >"$preview_data"
-    preview_hash=$(PATH="$mock_bin:$PATH" shasum -a 256 "$preview_data" | awk '{print $1}')
     {
-      printf '# schema=agent-task-gist-reviewed-preview-v1\n'
-      printf '# account=i9wa4\n'
+      printf '# schema=%s\n' "$metadata_schema"
+      printf '# account=%s\n' "$metadata_account"
       printf '# generated_epoch=%s\n' "$generated_epoch"
-      printf '# data_sha256=%s\n' "$preview_hash"
       cat "$preview_data"
+    } >"$preview_proof"
+    preview_hash=$(PATH="$mock_bin:$PATH" shasum -a 256 "$preview_proof" | awk '{print $1}')
+    {
+      cat "$preview_proof"
+      printf '# proof_sha256=%s\n' "$preview_hash"
     } >"$destination"
   }
 
@@ -732,14 +866,57 @@ EOF
   assert_delete_rejected missing-confirmation i9wa4 i9wa4 8 fixtureGistId wrongGistId i9wa4
   assert_delete_rejected wrong-description i9wa4 i9wa4 8 fixtureGistId fixtureGistId i9wa4 wrong-description
   assert_delete_rejected stale-preview i9wa4 i9wa4 8 fixtureGistId fixtureGistId i9wa4 'agent-task:<repo>:<task>' 0 5000
+  assert_delete_rejected future-metadata-recomputed i9wa4 i9wa4 8 fixtureGistId fixtureGistId i9wa4 'agent-task:<repo>:<task>' 2000 1000
+  write_reviewed_preview "$fixture_dir/future-unchanged-reviewed-preview.tsv" 1000 \
+    fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>'
+  sed 's/# generated_epoch=1000/# generated_epoch=2000/' \
+    "$fixture_dir/future-unchanged-reviewed-preview.tsv" \
+    >"$fixture_dir/future-unchanged-reviewed-preview-mutated.tsv"
+  GIST_DELETE_RECORD="$fixture_dir/future-unchanged-delete-record" \
+    reviewed_preview="$fixture_dir/future-unchanged-reviewed-preview-mutated.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/future-unchanged.out" 2>"$fixture_dir/future-unchanged.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted future metadata with unchanged proof"
+  test ! -e "$fixture_dir/future-unchanged-delete-record" ||
+    fail "documented deletion deleted future metadata with unchanged proof"
+  write_reviewed_preview "$fixture_dir/wrong-schema-reviewed-preview.tsv" 1000 \
+    fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>' wrong-schema i9wa4
+  GIST_DELETE_RECORD="$fixture_dir/wrong-schema-delete-record" \
+    reviewed_preview="$fixture_dir/wrong-schema-reviewed-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/wrong-schema.out" 2>"$fixture_dir/wrong-schema.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted wrong proof-bound schema"
+  test ! -e "$fixture_dir/wrong-schema-delete-record" ||
+    fail "documented deletion deleted wrong proof-bound schema"
+  write_reviewed_preview "$fixture_dir/wrong-metadata-account-reviewed-preview.tsv" 1000 \
+    fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>' agent-task-gist-reviewed-preview-v1 other-account
+  GIST_DELETE_RECORD="$fixture_dir/wrong-metadata-account-delete-record" \
+    reviewed_preview="$fixture_dir/wrong-metadata-account-reviewed-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/wrong-metadata-account.out" 2>"$fixture_dir/wrong-metadata-account.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted wrong proof-bound account"
+  test ! -e "$fixture_dir/wrong-metadata-account-delete-record" ||
+    fail "documented deletion deleted wrong proof-bound account"
   printf '%s\t%s\n' fixtureGistId i9wa4 >"$fixture_dir/malformed-reviewed-preview.tsv.data"
-  malformed_hash=$(PATH="$mock_bin:$PATH" shasum -a 256 "$fixture_dir/malformed-reviewed-preview.tsv.data" | awk '{print $1}')
   {
     printf '# schema=agent-task-gist-reviewed-preview-v1\n'
     printf '# account=i9wa4\n'
     printf '# generated_epoch=1000\n'
-    printf '# data_sha256=%s\n' "$malformed_hash"
     cat "$fixture_dir/malformed-reviewed-preview.tsv.data"
+  } >"$fixture_dir/malformed-reviewed-preview.tsv.proof"
+  malformed_hash=$(PATH="$mock_bin:$PATH" shasum -a 256 "$fixture_dir/malformed-reviewed-preview.tsv.proof" | awk '{print $1}')
+  {
+    cat "$fixture_dir/malformed-reviewed-preview.tsv.proof"
+    printf '# proof_sha256=%s\n' "$malformed_hash"
   } >"$fixture_dir/malformed-reviewed-preview.tsv"
   GIST_DELETE_RECORD="$fixture_dir/malformed-delete-record" \
     reviewed_preview="$fixture_dir/malformed-reviewed-preview.tsv" \

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -18,21 +18,26 @@ contains_public_gist_command() {
   local file=$1
   local command=
   local line=
+  local raw_line=
+  local continues=0
   local continuation=0
   while IFS= read -r line || [ -n "$line" ]; do
+    raw_line=$line
+    continues=0
+    case "$raw_line" in
+    *\\) continues=1 ;;
+    esac
     line=${line%"${line##*[![:space:]]}"}
     if [ "$continuation" -eq 1 ]; then
       command="$command$line"
     else
       command=$line
     fi
-    case "$line" in
-    *\\)
+    if [ "$continues" -eq 1 ]; then
       command=${command%\\}
       continuation=1
       continue
-      ;;
-    esac
+    fi
     if command_has_public_gist_flag "$command"; then
       printf '%s\n' "$command"
       return 0
@@ -381,6 +386,12 @@ run_public_mode_fixtures() {
     'command g"h" gist create --public task.md'
   assert_command_rejected direct-ampersand-separated-public-create \
     'printf x & gh gist create --public task.md'
+  assert_command_rejected direct-pipe-separated-public-create \
+    'printf x | gh gist create --public task.md'
+  assert_command_rejected direct-and-if-public-create \
+    'true && gh gist create --public task.md'
+  assert_command_rejected direct-or-if-public-create \
+    'false || gh gist create --public task.md'
   assert_command_rejected direct-assignment-quoted-value-public-create \
     'TOKEN="x" gh gist create --public task.md'
   assert_command_rejected direct-env-quoted-assignment-public-create \
@@ -423,6 +434,9 @@ run_public_mode_fixtures() {
   assert_fixture_rejected split-public-continuation-create \
     "gh gist create --pub$continuation" \
     'lic task.md'
+  assert_fixture_allowed allowed-backslash-space-no-continuation-create \
+    "gh gist create --pub$continuation  " \
+    'lic task.md'
   assert_fixture_rejected split-public-double-quoted-continuation-create \
     "gh gist create \"--pub$continuation" \
     'lic" task.md'
@@ -440,6 +454,12 @@ run_public_mode_fixtures() {
     'x" gh gist create --public task.md'
   assert_fixture_rejected separated-public-create \
     'printf x; gh gist create --public task.md'
+  assert_fixture_rejected pipe-separated-public-create \
+    'printf x | gh gist create --public task.md'
+  assert_fixture_rejected and-if-public-create \
+    'true && gh gist create --public task.md'
+  assert_fixture_rejected or-if-public-create \
+    'false || gh gist create --public task.md'
   assert_fixture_rejected assignment-prefixed-public-create \
     'TOKEN=x gh gist create --public task.md'
   assert_fixture_rejected quote-spliced-gh-create \

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -15,84 +15,158 @@ fail() {
 }
 
 contains_public_gist_command() {
-  awk '
-    function is_assignment(token) {
-      return token ~ /^[A-Za-z_][A-Za-z0-9_]*=/
-    }
-    function first_command_token(token_count, tokens, token_index) {
-      token_index = 1
-      while (token_index <= token_count) {
-        if (tokens[token_index] == "env") {
-          token_index++
-          while (token_index <= token_count) {
-            if (tokens[token_index] == "-u" || tokens[token_index] == "--unset") {
-              token_index += 2
-            } else if (tokens[token_index] ~ /^-u./ || tokens[token_index] ~ /^--unset=/ || is_assignment(tokens[token_index])) {
-              token_index++
-            } else if (tokens[token_index] ~ /^-/) {
-              token_index++
-            } else {
-              break
-            }
-          }
-        } else if (tokens[token_index] == "command") {
-          token_index++
-          while (token_index <= token_count && tokens[token_index] ~ /^-/) {
-            token_index++
-          }
-        } else {
+  local file=$1
+  local command=
+  local line=
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%"${line##*[![:space:]]}"}
+    if [ -n "$command" ]; then
+      command="$command ${line%\\}"
+    else
+      command=${line%\\}
+    fi
+    case "$line" in
+    *\\) continue ;;
+    esac
+    if command_has_public_gist_flag "$command"; then
+      printf '%s\n' "$command"
+      return 0
+    fi
+    command=
+  done <"$file"
+  if [ -n "$command" ] && command_has_public_gist_flag "$command"; then
+    printf '%s\n' "$command"
+    return 0
+  fi
+  return 1
+}
+
+tokenize_shell_words() {
+  local command=$1
+  TOKENS=()
+  TOKEN_QUOTED=()
+  local token=
+  local quoted=0
+  local state=normal
+  local i=0
+  local char=
+  local next=
+  while [ "$i" -lt "${#command}" ]; do
+    char=${command:i:1}
+    case "$state" in
+    normal)
+      case "$char" in
+      [[:space:]])
+        if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
+          TOKENS+=("$token")
+          TOKEN_QUOTED+=("$quoted")
+          token=
+          quoted=0
+        fi
+        ;;
+      "'")
+        state=single
+        quoted=1
+        ;;
+      '"')
+        state=double
+        quoted=1
+        ;;
+      \\)
+        i=$((i + 1))
+        if [ "$i" -lt "${#command}" ]; then
+          token="$token${command:i:1}"
+        fi
+        ;;
+      *)
+        token="$token$char"
+        ;;
+      esac
+      ;;
+    single)
+      if [ "$char" = "'" ]; then
+        state=normal
+      else
+        token="$token$char"
+      fi
+      ;;
+    double)
+      case "$char" in
+      '"')
+        state=normal
+        ;;
+      \\)
+        i=$((i + 1))
+        if [ "$i" -lt "${#command}" ]; then
+          next=${command:i:1}
+          token="$token$next"
+        fi
+        ;;
+      *)
+        token="$token$char"
+        ;;
+      esac
+      ;;
+    esac
+    i=$((i + 1))
+  done
+  if [ -n "$token" ] || [ "$quoted" -eq 1 ]; then
+    TOKENS+=("$token")
+    TOKEN_QUOTED+=("$quoted")
+  fi
+}
+
+command_has_public_gist_flag() {
+  local command=$1
+  tokenize_shell_words "$command"
+  local index=0
+  while [ "$index" -lt "${#TOKENS[@]}" ]; do
+    if [ "${TOKENS[$index]}" = env ] && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; then
+      index=$((index + 1))
+      while [ "$index" -lt "${#TOKENS[@]}" ]; do
+        case "${TOKENS[$index]}" in
+        -u | --unset)
+          index=$((index + 2))
+          ;;
+        -u* | --unset=* | [A-Za-z_]*=*)
+          index=$((index + 1))
+          ;;
+        -*)
+          index=$((index + 1))
+          ;;
+        *)
           break
-        }
-      }
-      return token_index
-    }
-    function is_public_token(token) {
-      return token == "--public" || token ~ /^--public=/ || token == "-p"
-    }
-    function inspect(command, token_count, tokens, token_index, action_index, public_index) {
-      sub(/^[[:space:]]+/, "", command)
-      sub(/[[:space:]]+$/, "", command)
-      token_count = split(command, tokens, /[[:space:]]+/)
-      token_index = first_command_token(token_count, tokens)
-      action_index = token_index + 2
-      if (tokens[token_index] != "gh" || tokens[token_index + 1] != "gist") {
-        return
-      }
-      if (tokens[action_index] !~ /^(create|edit|list|delete)$/) {
-        return
-      }
-      for (public_index = action_index + 1; public_index <= token_count; public_index++) {
-        if (is_public_token(tokens[public_index])) {
-          print command
-          found = 1
-          return
-        }
-      }
-    }
-    {
-      line = $0
-      sub(/[[:space:]]+$/, "", line)
-      if (continued) {
-        command = command " " line
-      } else {
-        command = line
-      }
-      if (line ~ /\\$/) {
-        sub(/\\$/, "", command)
-        continued = 1
-        next
-      }
-      inspect(command)
-      command = ""
-      continued = 0
-    }
-    END {
-      if (continued) {
-        inspect(command)
-      }
-      exit(found ? 0 : 1)
-    }
-  ' "$1"
+          ;;
+        esac
+      done
+    elif [ "${TOKENS[$index]}" = command ] && [ "${TOKEN_QUOTED[$index]}" -eq 0 ]; then
+      index=$((index + 1))
+      while [ "$index" -lt "${#TOKENS[@]}" ] && [[ ${TOKENS[$index]} == -* ]]; do
+        index=$((index + 1))
+      done
+    else
+      break
+    fi
+  done
+  [ "${TOKENS[$index]:-}" = gh ] || return 1
+  [ "${TOKEN_QUOTED[$index]:-1}" -eq 0 ] || return 1
+  [ "${TOKENS[$((index + 1))]:-}" = gist ] || return 1
+  [ "${TOKEN_QUOTED[$((index + 1))]:-1}" -eq 0 ] || return 1
+  case "${TOKENS[$((index + 2))]:-}" in
+  create | edit | list | delete) ;;
+  *) return 1 ;;
+  esac
+  [ "${TOKEN_QUOTED[$((index + 2))]:-1}" -eq 0 ] || return 1
+  local flag_index=$((index + 3))
+  while [ "$flag_index" -lt "${#TOKENS[@]}" ]; do
+    if [ "${TOKEN_QUOTED[$flag_index]}" -eq 0 ]; then
+      case "${TOKENS[$flag_index]}" in
+      --public | --public=* | -p) return 0 ;;
+      esac
+    fi
+    flag_index=$((flag_index + 1))
+  done
+  return 1
 }
 
 extract_documented_snippet() {
@@ -169,6 +243,12 @@ run_public_mode_fixtures() {
     'gh gist create -preview task.md'
   assert_fixture_allowed allowed-quoted-text \
     'printf "%s\n" "gh gist create --public task.md"'
+  assert_fixture_allowed allowed-quoted-description-public-text \
+    'gh gist create --desc "document the --public prohibition" task.md'
+  assert_fixture_allowed allowed-single-quoted-description-public-text \
+    "gh gist create --desc 'document the --public prohibition' task.md"
+  assert_fixture_allowed allowed-quoted-filename-public-text \
+    'gh gist create "--public-task.md"'
 }
 
 run_documented_snippet_fixtures() {
@@ -190,6 +270,10 @@ if [ "$1" = gist ] && [ "$2" = create ]; then
 	ok)
 		printf '%s\n' 'https://gist.github.com/fixtureGistId'
 		;;
+	nonzero-side-effect)
+		printf '%s\n' 'https://gist.github.com/fixtureGistId'
+		exit 64
+		;;
 	stderr-url)
 		printf '%s\n' 'https://gist.github.com/fixtureGistId' >&2
 		printf '%s\n' 'https://gist.github.com/fixtureGistId'
@@ -210,6 +294,9 @@ if [ "$1" = gist ] && [ "$2" = create ]; then
 	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = edit ] && [ "$3" = fixtureGistId ]; then
+	if [ "${GIST_EDIT_MODE:-ok}" = fail ]; then
+		exit 64
+	fi
 	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = delete ]; then
@@ -217,10 +304,26 @@ if [ "$1" = gist ] && [ "$2" = delete ]; then
 	exit 0
 fi
 if [ "$1" = gist ] && [ "$2" = view ]; then
+	if [ "${GIST_VIEW_MODE:-ok}" = fail ]; then
+		exit 64
+	fi
 	cat "$GIST_FIXTURE_SOURCE"
 	exit 0
 fi
+if [ "$1" = gist ] && [ "$2" = list ] && [ "$3" = --secret ]; then
+	for arg in "$@"; do
+		if [ "$arg" = --json ]; then
+			printf '%s\t%s\t%s\t%s\t%s\n' \
+				fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>'
+			exit 0
+		fi
+	done
+	exit 0
+fi
 if [ "$1" = api ] && [ "$2" = gists/fixtureGistId ] && [ "$3" = --jq ]; then
+	if [ "${GIST_API_MODE:-ok}" = fail ]; then
+		exit 64
+	fi
 	case "$4" in
 	.public)
 		printf '%s\n' "${GIST_MOCK_PUBLIC:-false}"
@@ -263,6 +366,10 @@ if [ "${GIST_SCAN_MODE:-ok}" = fail ]; then
 	printf '%s\n' '1:tmux-a2a'
 	exit 0
 fi
+if [ "${GIST_SCAN_MODE:-ok}" = error ]; then
+	printf '%s\n' 'scanner error' >&2
+	exit 2
+fi
 exit 1
 EOF
   chmod 700 "$mock_bin/rg"
@@ -272,17 +379,16 @@ EOF
 if [ "$1" != -a ] || [ "$2" != 256 ]; then
   exit 64
 fi
-case "$(cat "$3")" in
-"fixture memo")
-  printf '%s  %s\n' '1c72c50d1320856521d1a956f0cae3c257091c72294a1c99a22b337417457127' "$3"
-  ;;
-"different memo")
-  printf '%s  %s\n' 'e9cf18bd5c7a707b7c5f624f45639792a38b2ed609c5fbfb6d2df921c68bf858' "$3"
-  ;;
-*)
-  exit 64
-  ;;
+case "${GIST_HASH_MODE:-ok}:$3" in
+fail-local:*task.md)
+	exit 64
+	;;
+fail-raw:*/agent-task-gist.*)
+	exit 64
+	;;
 esac
+sum=$(cksum < "$3" | awk '{print $1}')
+printf '%064d  %s\n' "$sum" "$3"
 EOF
   chmod 700 "$mock_bin/shasum"
 
@@ -338,7 +444,11 @@ EOF
       if grep -Fq 'https://gist.github.com/' "$pending_record"; then
         fail "documented pending cleanup record leaked URL: $name"
       fi
-      if [ "$expected_pending_id" != unknown ]; then
+      if [ "$expected_pending_id" = unknown ]; then
+        if grep -Fq 'gist_id=' "$pending_record"; then
+          fail "documented unknown pending cleanup record included a Gist ID: $name"
+        fi
+      else
         grep -Fq "gist_id=$expected_pending_id" "$pending_record" ||
           fail "documented pending cleanup record did not include exact Gist ID: $name"
       fi
@@ -350,18 +460,53 @@ EOF
   assert_create_failure_blocks_handoff wrong-description fixtureGistId GIST_MOCK_DESCRIPTION=wrong
   assert_create_failure_blocks_handoff wrong-filename fixtureGistId GIST_MOCK_FILENAME=wrong.md
   assert_create_failure_blocks_handoff multiple-filenames fixtureGistId GIST_MOCK_FILE_COUNT=2
+  assert_create_failure_blocks_handoff create-nonzero-side-effect unknown GIST_CREATE_MODE=nonzero-side-effect
   assert_create_failure_blocks_handoff stderr-url-leakage unknown GIST_CREATE_MODE=stderr-url
   assert_create_failure_blocks_handoff noisy-create-output unknown GIST_CREATE_MODE=noisy
   assert_create_failure_blocks_handoff multiline-create-output unknown GIST_CREATE_MODE=multiline
   assert_create_failure_blocks_handoff malformed-create-output unknown GIST_CREATE_MODE=malformed
+  assert_create_failure_blocks_handoff metadata-edit-failed fixtureGistId GIST_EDIT_MODE=fail
+  assert_create_failure_blocks_handoff metadata-api-failed fixtureGistId GIST_API_MODE=fail
+
+  extract_documented_snippet '# agent-task-gist-reviewed-preview' "$fixture_dir/preview.sh"
+  GIST_DELETE_RECORD="$fixture_dir/unused-preview-delete-record" \
+    PATH="$mock_bin:$PATH" \
+    reviewed_preview="$fixture_dir/reviewed-preview.tsv" \
+    sh "$fixture_dir/preview.sh" >"$fixture_dir/preview.out"
+  test -s "$fixture_dir/reviewed-preview.tsv" ||
+    fail "documented reviewed-preview producer did not write a preview record"
+  grep -Fq '# schema=agent-task-gist-reviewed-preview-v1' "$fixture_dir/reviewed-preview.tsv" ||
+    fail "documented reviewed-preview producer did not write schema metadata"
+  test ! -e "$fixture_dir/unused-preview-delete-record" ||
+    fail "documented reviewed-preview producer deleted a Gist"
+
+  write_reviewed_preview() {
+    destination=$1
+    generated_epoch=$2
+    preview_id=$3
+    preview_owner=$4
+    preview_account=$5
+    preview_age_days=$6
+    preview_description=$7
+    preview_data="$destination.data"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$preview_id" "$preview_owner" "$preview_account" "$preview_age_days" "$preview_description" \
+      >"$preview_data"
+    preview_hash=$(PATH="$mock_bin:$PATH" shasum -a 256 "$preview_data" | awk '{print $1}')
+    {
+      printf '# schema=agent-task-gist-reviewed-preview-v1\n'
+      printf '# account=i9wa4\n'
+      printf '# generated_epoch=%s\n' "$generated_epoch"
+      printf '# data_sha256=%s\n' "$preview_hash"
+      cat "$preview_data"
+    } >"$destination"
+  }
 
   extract_documented_snippet '# agent-task-gist-delete-confirmation' "$fixture_dir/delete.sh"
   sed 's/<reviewed-gist-id>/fixtureGistId/g' "$fixture_dir/delete.sh" >"$fixture_dir/delete-fixture.sh"
-  printf '%s\t%s\t%s\t%s\t%s\n' \
-    fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>' \
-    >"$fixture_dir/reviewed-preview.tsv"
   GIST_DELETE_RECORD="$fixture_dir/delete-record" \
     reviewed_preview="$fixture_dir/reviewed-preview.tsv" \
+    now_epoch=1000 \
     PATH="$mock_bin:$PATH" \
     sh "$fixture_dir/delete-fixture.sh" <<'EOF'
 fixtureGistId
@@ -370,6 +515,7 @@ EOF
     fail "documented deletion confirmation did not invoke the exact approved ID"
   GIST_DELETE_RECORD="$fixture_dir/delete-record-bash" \
     reviewed_preview="$fixture_dir/reviewed-preview.tsv" \
+    now_epoch=1000 \
     PATH="$mock_bin:$PATH" \
     bash "$fixture_dir/delete-fixture.sh" <<'EOF'
 fixtureGistId
@@ -385,14 +531,17 @@ EOF
     preview_id=$5
     typed_id=$6
     account_value=$7
+    preview_description=${8:-agent-task:<repo>:<task>}
+    generated_epoch=${9:-1000}
+    current_epoch=${10:-1000}
     delete_record="$fixture_dir/$name-delete-record"
     preview_file="$fixture_dir/$name-reviewed-preview.tsv"
-    printf '%s\t%s\t%s\t%s\t%s\n' \
-      "$preview_id" "$preview_owner" "$preview_account" "$preview_age_days" 'agent-task:<repo>:<task>' \
-      >"$preview_file"
+    write_reviewed_preview "$preview_file" "$generated_epoch" \
+      "$preview_id" "$preview_owner" "$preview_account" "$preview_age_days" "$preview_description"
     GIST_DELETE_RECORD="$delete_record" \
       GIST_MOCK_ACCOUNT="$account_value" \
       reviewed_preview="$preview_file" \
+      now_epoch="$current_epoch" \
       PATH="$mock_bin:$PATH" \
       sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/$name.out" 2>"$fixture_dir/$name.err" <<EOF &&
 $typed_id
@@ -408,6 +557,53 @@ EOF
   assert_delete_rejected too-new i9wa4 i9wa4 6 fixtureGistId fixtureGistId i9wa4
   assert_delete_rejected missing-preview-membership i9wa4 i9wa4 8 otherGistId fixtureGistId i9wa4
   assert_delete_rejected missing-confirmation i9wa4 i9wa4 8 fixtureGistId wrongGistId i9wa4
+  assert_delete_rejected wrong-description i9wa4 i9wa4 8 fixtureGistId fixtureGistId i9wa4 wrong-description
+  assert_delete_rejected stale-preview i9wa4 i9wa4 8 fixtureGistId fixtureGistId i9wa4 'agent-task:<repo>:<task>' 0 5000
+  printf '%s\t%s\n' fixtureGistId i9wa4 >"$fixture_dir/malformed-reviewed-preview.tsv.data"
+  malformed_hash=$(PATH="$mock_bin:$PATH" shasum -a 256 "$fixture_dir/malformed-reviewed-preview.tsv.data" | awk '{print $1}')
+  {
+    printf '# schema=agent-task-gist-reviewed-preview-v1\n'
+    printf '# account=i9wa4\n'
+    printf '# generated_epoch=1000\n'
+    printf '# data_sha256=%s\n' "$malformed_hash"
+    cat "$fixture_dir/malformed-reviewed-preview.tsv.data"
+  } >"$fixture_dir/malformed-reviewed-preview.tsv"
+  GIST_DELETE_RECORD="$fixture_dir/malformed-delete-record" \
+    reviewed_preview="$fixture_dir/malformed-reviewed-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/malformed.out" 2>"$fixture_dir/malformed.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted malformed preview"
+  test ! -e "$fixture_dir/malformed-delete-record" ||
+    fail "documented deletion deleted from malformed preview"
+  printf '%s\t%s\t%s\t%s\t%s\n' fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>' \
+    >"$fixture_dir/fabricated-reviewed-preview.tsv"
+  GIST_DELETE_RECORD="$fixture_dir/fabricated-delete-record" \
+    reviewed_preview="$fixture_dir/fabricated-reviewed-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/fabricated.out" 2>"$fixture_dir/fabricated.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted fabricated preview without provenance metadata"
+  test ! -e "$fixture_dir/fabricated-delete-record" ||
+    fail "documented deletion deleted from fabricated preview"
+  write_reviewed_preview "$fixture_dir/unproven-reviewed-preview.tsv" 1000 \
+    fixtureGistId i9wa4 i9wa4 8 'agent-task:<repo>:<task>'
+  printf '%s\t%s\t%s\t%s\t%s\n' tamper i9wa4 i9wa4 8 'agent-task:<repo>:<task>' \
+    >>"$fixture_dir/unproven-reviewed-preview.tsv"
+  GIST_DELETE_RECORD="$fixture_dir/unproven-delete-record" \
+    reviewed_preview="$fixture_dir/unproven-reviewed-preview.tsv" \
+    now_epoch=1000 \
+    PATH="$mock_bin:$PATH" \
+    sh "$fixture_dir/delete-fixture.sh" >"$fixture_dir/unproven.out" 2>"$fixture_dir/unproven.err" <<'EOF' &&
+fixtureGistId
+EOF
+    fail "documented deletion accepted digest-mismatched preview"
+  test ! -e "$fixture_dir/unproven-delete-record" ||
+    fail "documented deletion deleted from digest-mismatched preview"
   assert_fixture_allowed bare-list-preview \
     "gh gist list --secret --filter '^agent-task:<repo>:' --limit 100"
 
@@ -463,6 +659,52 @@ EOF
     fail "documented raw verification scan pending cleanup record leaked URL"
   fi
 
+  assert_raw_failure_pending() {
+    name=$1
+    shift
+    pending_record="$fixture_dir/$name-pending-cleanup"
+    delete_record="$fixture_dir/$name-delete-record"
+    GIST_CLEANUP_RECORD="$fixture_dir/$name-cleanup-record" \
+      GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
+      GIST_DELETE_RECORD="$delete_record" \
+      pending_cleanup_record="$pending_record" \
+      gist_id=fixtureGistId \
+      task_file="$fixture_dir/task.md" \
+      PATH="$mock_bin:$PATH" \
+      env "$@" sh "$fixture_dir/raw.sh" >"$fixture_dir/$name.out" 2>"$fixture_dir/$name.err" &&
+      fail "documented raw verification accepted failure path: $name"
+    test -s "$pending_record" ||
+      fail "documented raw verification did not write pending cleanup for: $name"
+    grep -Fq 'gist_id=fixtureGistId' "$pending_record" ||
+      fail "documented raw verification did not record exact ID for: $name"
+    if grep -Fq 'https://gist.github.com/' "$pending_record" "$fixture_dir/$name.out" "$fixture_dir/$name.err"; then
+      fail "documented raw verification leaked URL for: $name"
+    fi
+    test ! -e "$delete_record" ||
+      fail "documented raw verification deleted outside reviewed confirmation: $name"
+  }
+
+  assert_raw_failure_pending raw-fetch-failure GIST_VIEW_MODE=fail
+  assert_raw_failure_pending raw-local-hash-failure GIST_HASH_MODE=fail-local
+  assert_raw_failure_pending raw-remote-hash-failure GIST_HASH_MODE=fail-raw
+  pending_record="$fixture_dir/raw-temp-failure-pending-cleanup"
+  delete_record="$fixture_dir/raw-temp-failure-delete-record"
+  GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
+    GIST_DELETE_RECORD="$delete_record" \
+    pending_cleanup_record="$pending_record" \
+    gist_id=fixtureGistId \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    TMPDIR="$fixture_dir/missing-tmpdir" \
+    sh "$fixture_dir/raw.sh" >"$fixture_dir/raw-temp-failure.out" 2>"$fixture_dir/raw-temp-failure.err" &&
+    fail "documented raw verification accepted temp directory failure"
+  test -s "$pending_record" ||
+    fail "documented raw temp failure did not write pending cleanup"
+  grep -Fq 'gist_id=fixtureGistId' "$pending_record" ||
+    fail "documented raw temp failure did not record exact ID"
+  test ! -e "$delete_record" ||
+    fail "documented raw temp failure deleted outside reviewed confirmation"
+
   {
     printf 'set -e\n'
     cat "$fixture_dir/create-read-back.sh"
@@ -491,6 +733,34 @@ EOF
   fi
   test ! -e "${GIST_DELETE_RECORD:-$fixture_dir/unused-delete-record}" ||
     fail "documented pre-handoff flow deleted outside reviewed confirmation"
+
+  {
+    printf 'set -e\n'
+    cat "$fixture_dir/create-read-back.sh"
+    cat "$fixture_dir/raw.sh"
+    cat "$fixture_dir/url-handoff.sh"
+    # shellcheck disable=SC2016 # The generated script must write this literal expansion.
+    printf '%s\n' 'printf "%s\n" "$secret_gist_url" > "$GIST_URL_HANDOFF_RECORD"'
+  } >"$fixture_dir/full-scan-error-flow.sh"
+  GIST_CLEANUP_RECORD="$fixture_dir/full-scan-error-cleanup-record" \
+    GIST_FIXTURE_SOURCE="$fixture_dir/task.md" \
+    GIST_SCAN_MODE=error \
+    GIST_URL_HANDOFF_RECORD="$fixture_dir/scan-error-url-handoff-record" \
+    GIST_DELETE_RECORD="$fixture_dir/scan-error-delete-record" \
+    pending_cleanup_record="$fixture_dir/full-scan-error-pending-cleanup" \
+    task_file="$fixture_dir/task.md" \
+    PATH="$mock_bin:$PATH" \
+    env -u TMPDIR sh "$fixture_dir/full-scan-error-flow.sh" >"$fixture_dir/full-scan-error-flow.out" 2>&1 &&
+    fail "documented full flow reached URL handoff after scanner error"
+  test ! -e "$fixture_dir/scan-error-url-handoff-record" ||
+    fail "documented scanner error flow reached URL handoff"
+  grep -Fq 'gist_id=fixtureGistId' "$fixture_dir/full-scan-error-pending-cleanup" ||
+    fail "documented scanner error flow did not record exact pending cleanup ID"
+  if grep -Fq 'https://gist.github.com/' "$fixture_dir/full-scan-error-pending-cleanup" "$fixture_dir/full-scan-error-flow.out"; then
+    fail "documented scanner error flow leaked URL"
+  fi
+  test ! -e "$fixture_dir/scan-error-delete-record" ||
+    fail "documented scanner error flow deleted outside reviewed confirmation"
 }
 
 # shellcheck disable=SC2016 # The literal command text is the policy assertion.

--- a/scripts/validation/validate-agent-task-gist-policy.sh
+++ b/scripts/validation/validate-agent-task-gist-policy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+policy_file="skills/dotfiles/references/resume-handoff.md"
+skill_file="skills/dotfiles/SKILL.md"
+
+# shellcheck disable=SC2016 # The literal command text is the policy assertion.
+for required in \
+  '1 task = 1 Gist = 1 Markdown file' \
+  'agent-task:<repo>:<task>' \
+  'secret/unlisted' \
+  'not access-controlled private storage' \
+  'gh auth status' \
+  'public=false' \
+  'shasum -a 256' \
+  'gh gist list --secret' \
+  'per-Gist confirmation' \
+  'Do not use `gh gist delete --yes`'; do
+  grep -Fq -- "$required" "$policy_file" || {
+    echo "missing required agent-task Gist policy text: $required" >&2
+    exit 1
+  }
+done
+
+grep -Fq -- 'optional portable agent task-memo Gists' "$skill_file" || {
+  echo "dotfiles skill does not expose portable agent task-memo Gists" >&2
+  exit 1
+}
+
+if grep -En '^[[:space:]]*gh gist (create|edit|list|delete).*--public' "$policy_file"; then
+  echo "agent-task Gist policy offers a public-mode command path" >&2
+  exit 1
+fi
+
+echo "agent-task Gist policy validation passed"

--- a/skills/dotfiles/SKILL.md
+++ b/skills/dotfiles/SKILL.md
@@ -4,7 +4,12 @@ license: MIT
 metadata:
   version: "1.0.0"
 description: |
-  USE FOR: This dotfiles environment and its agent harness: machine setup (Ubuntu, WSL2, macOS, home-manager, nix-darwin), daily Nix operations and upgrade/recovery, missing CLI tools / command not found, operating concepts, clipboard (Vim, Neovim, tmux), Claude Code and Codex CLI config, hooks, MCP, skill installation, postman routing, orchestrator runbooks, tmux workspaces, issue/PR worktrees, pane operations, prompt/review contracts, resume handoff; Agent Skills authoring: add/edit/validate skills, Waza, publishing. DO NOT USE FOR: Nix package authoring (programming).
+  USE FOR: This dotfiles environment and agent harness: machine setup, Nix
+  operations/recovery, missing tools, operating concepts, clipboard,
+  Claude/Codex config, hooks, MCP, skills, Postman routing/runbooks,
+  tmux/worktrees/panes, prompt/review/resume-handoff contracts, and optional
+  portable agent task-memo Gists; Agent Skills authoring/validation/Waza.
+  DO NOT USE FOR: Nix package authoring (programming).
 ---
 
 # Dotfiles Environment
@@ -39,5 +44,7 @@ Agent harness (hubs link their siblings):
   Git lock diagnostics, panes, boot, VDE
 - [Prompts](references/prompt-contracts.md) — prompt
   blocks, review contracts, boundaries, resume handoff
+- [Resume Handoff](references/resume-handoff.md) — local task handoffs and
+  optional portable agent task-memo Gists
 - [Skills Management](references/skills-management.md) — skill authoring,
   Waza, release, publishing

--- a/skills/dotfiles/evals/tasks/positive-trigger-3.yaml
+++ b/skills/dotfiles/evals/tasks/positive-trigger-3.yaml
@@ -1,0 +1,15 @@
+id: positive-trigger-003
+name: Positive Trigger 3
+description: Curated trigger for portable agent task-memo Gist policy.
+tags:
+  - positive-trigger
+inputs:
+  prompt: "Update the dotfiles agent harness policy for optional portable agent task-memo Gists alongside local resume handoff artifacts."
+expected:
+  should_trigger: true
+graders:
+  - type: trigger
+    name: positive-trigger
+    config:
+      skill_path: skills/dotfiles/SKILL.md
+      mode: positive

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -63,10 +63,13 @@ not permission to perform one. Each creation command intentionally omits
 `--public`.
 
 ```sh
+# agent-task-gist-create-read-back
 gh auth status
-gh gist create --desc 'agent-task:<repo>:<task>' task.md
-gh gist edit <gist-id> --filename task.md task.md
-gh api gists/<gist-id> --jq '{public,description,files:(.files|keys)}'
+create_output=$(gh gist create --desc 'agent-task:<repo>:<task>' task.md)
+gist_id=${create_output##*/}
+test -n "$gist_id"
+gh gist edit "$gist_id" --filename task.md task.md
+gh api "gists/$gist_id" --jq '{public,description,files:(.files|keys)}'
 ```
 
 Verify API output reports `public=false`, the expected description, and the
@@ -85,7 +88,12 @@ cleanup_raw_dir() {
 trap cleanup_raw_dir EXIT HUP INT TERM
 raw_file="$raw_dir/task.md"
 gh gist view "$gist_id" --raw > "$raw_file"
-shasum -a 256 "$task_file" "$raw_file"
+local_hash=$(shasum -a 256 "$task_file" | awk '{print $1}')
+raw_hash=$(shasum -a 256 "$raw_file" | awk '{print $1}')
+printf '%s  %s\n%s  %s\n' "$local_hash" "$task_file" "$raw_hash" "$raw_file"
+if [ "$local_hash" != "$raw_hash" ]; then
+  exit 1
+fi
 if rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$raw_file"; then
   exit 1
 fi
@@ -100,7 +108,7 @@ handoff channel.
 
 ```sh
 # agent-task-gist-url-handoff
-secret_gist_url=$(gh api "gists/$gist_id" --jq '.html_url')
+secret_gist_url=$create_output
 test -n "$secret_gist_url"
 ```
 

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -3,12 +3,14 @@
 Use these patterns for long-running agent tasks, follow-up turns on the same
 thread, or result summaries that another agent may need to resume later.
 
-This repo already saves lightweight handoff context through:
+The current harness does not save automatic Codex stop/session-start snapshots.
+Those hooks were removed on 2026-04-29 because their saved state was not a
+load-bearing handoff mechanism. Keep local `mkmd` artifacts, repository state,
+and Postman traffic as the normal handoff record.
 
-- `nix/home-manager/agents/scripts/codex-stop-save.sh`
-- `nix/home-manager/agents/scripts/codex-sessionstart-reload.sh`
-
-Write results so those saved summaries stay readable and useful on reload.
+When a task must survive the workspace, machine, or agent session, an optional
+secret GitHub Gist may carry a compact portable copy. This extends local
+handoff; it never replaces the local artifact.
 
 ## 1. Handoff Rules
 
@@ -20,7 +22,94 @@ Write results so those saved summaries stay readable and useful on reload.
 - Prefer delta prompts for resume turns. Do not restate the full original task
   unless the direction changed materially.
 
-## 2. Recommended Result Fields
+## 2. Optional Portable Agent Task-Memo Gists
+
+Use a Gist only when the task memo must survive beyond the local workspace,
+machine, or agent session. Stay local when a normal `mkmd` artifact and the
+repository/issue state are sufficient.
+
+- Use `1 task = 1 Gist = 1 Markdown file`.
+- Keep the local task/handoff file as the canonical working copy.
+- Use description identity `agent-task:<repo>:<task>`; the Gist ID and
+  description identify the memo, while the filename may stay simple.
+- Memo contents are compact and resume-oriented: current task, status,
+  blockers, next action, verification, and relevant issue/PR/thread IDs.
+- Gists are ephemeral task memory, not the knowledge base. At completion,
+  promote durable knowledge into repository docs/issues, then delete the Gist
+  by default.
+
+### 2.1. Secret, authorization, and URL boundaries
+
+Agent task-memo Gists are always secret/unlisted. Public Gists are prohibited:
+never use `--public`, and do not offer a public-mode flag in an agent-facing
+helper. Secret means unlisted, not access-controlled private storage; anyone
+with the URL can read it.
+
+Never store credentials, tokens, secrets, personal data, or other sensitive
+material in a task memo. Before any create, edit, or delete operation, obtain
+the current human approval required for that external mutation and confirm the
+authenticated account with `gh auth status`. Do not mutate a Gist merely
+because a task is in progress.
+
+Do not copy a secret-Gist URL to a public issue, PR, commit, review, or log.
+It may be included in the approved private handoff channel only after the
+verification below succeeds. A separate current approval is required before
+any broader sharing.
+
+### 2.2. Approved mutation and read-back procedure
+
+The following commands are examples for an already approved mutation; they are
+not permission to perform one. Each creation command intentionally omits
+`--public`.
+
+```sh
+gh auth status
+gh gist create --desc 'agent-task:<repo>:<task>' task.md
+gh gist edit <gist-id> --filename task.md task.md
+gh api gists/<gist-id> --jq '{html_url,public,description,files:(.files|keys)}'
+```
+
+Verify API output reports `public=false`, the expected description, and the
+expected single filename. Fetch Raw content, compare it with the local source,
+and scan before sharing the URL:
+
+```sh
+gh gist view <gist-id> --raw > "$TMPDIR/agent-task-gist.md"
+shasum -a 256 task.md "$TMPDIR/agent-task-gist.md"
+rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$TMPDIR/agent-task-gist.md"
+```
+
+The hashes must match and the scan must find no private handoff or secret
+material. If any check fails, keep the local artifact canonical and report the
+failure through the approved private handoff channel.
+
+### 2.3. Resume, finish, and safe cleanup
+
+On resume, locate only secret task-memo candidates by their description and
+read the identified Gist before acting:
+
+```sh
+gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
+```
+
+For cleanup, first preview candidates. Filter by the expected repository,
+owner/account, and an explicit age threshold before choosing any item. Deletion
+is an external mutation: require current human approval and an explicit
+per-Gist confirmation; never bulk-delete from a bare list.
+
+```sh
+gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
+read -r 'DELETE_GIST_ID?Delete this approved agent-task Gist ID: '
+test -n "$DELETE_GIST_ID"
+gh gist delete "$DELETE_GIST_ID"
+```
+
+Do not use `gh gist delete --yes` in an agent-facing cleanup path. Keep a
+preview record and delete only the reviewed Gist after checking its description,
+owner/account, and age. On task completion, delete the approved memo or
+promote durable knowledge before deletion.
+
+## 3. Recommended Result Fields
 
 - current task
 - status
@@ -29,7 +118,7 @@ Write results so those saved summaries stay readable and useful on reload.
 - verification
 - resume command, when a thread ID is known
 
-## 3. Example Result Shape
+## 4. Example Result Shape
 
 ```text
 current task: tighten the review output contract for worker-side review runs
@@ -40,7 +129,7 @@ verification: git diff --check clean; prompt references present under skills/dot
 resume command: resume the saved thread context when supported
 ```
 
-## 4. Example Resume Delta Prompt
+## 5. Example Resume Delta Prompt
 
 ```xml
 <task>
@@ -64,7 +153,7 @@ output from this run.
 </grounding_rules>
 ```
 
-## 5. What Not To Carry Over From The Plugin
+## 6. What Not To Carry Over From The Plugin
 
 - Do not assume plugin-owned broker state
 - Do not assume slash commands or plugin environment variables

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -300,9 +300,11 @@ set -e
 expected_account='i9wa4'
 expected_description_prefix='agent-task:<repo>:'
 reviewed_preview=${reviewed_preview:-agent-task-gist-reviewed-preview.tsv}
+candidate_data=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-candidates.XXXXXX") || exit 1
 preview_data=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-preview.XXXXXX") || exit 1
 preview_proof=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-proof.XXXXXX") || exit 1
 cleanup_preview_data() {
+  rm -f "$candidate_data"
   rm -f "$preview_data"
   rm -f "$preview_proof"
 }
@@ -314,11 +316,12 @@ generated_epoch=$(date +%s)
 case "$generated_epoch" in
 "" | *[!0-9]*) exit 1 ;;
 esac
-gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100 \
   --json id,description,owner,updatedAt \
   --jq ".[] | [.id, .owner.login, \"$account\", (((($generated_epoch) - (.updatedAt | fromdateiso8601)) / 86400) | floor), .description] | @tsv" \
-  > "$preview_data"
+  > "$candidate_data"
+cp "$candidate_data" "$preview_data"
+cat "$candidate_data"
 if ! awk -F '	' -v prefix="$expected_description_prefix" '
   NF != 5 { exit 1 }
   $4 !~ /^[0-9]+$/ { exit 1 }

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -75,6 +75,7 @@ account=$(gh api user --jq .login)
 test "$account" = "$expected_account"
 gist_id=
 create_log=
+post_create_lifecycle=0
 write_pending_cleanup() {
   reason=$1
   {
@@ -92,14 +93,25 @@ fail_with_pending_cleanup() {
   write_pending_cleanup "$1"
   exit 1
 }
+cleanup_after_signal() {
+  cleanup_create_log
+  if [ "$post_create_lifecycle" = 1 ]; then
+    write_pending_cleanup interrupted
+  fi
+  exit 1
+}
 cleanup_create_log() {
   if [ -n "$create_log" ]; then
     rm -f "$create_log"
   fi
 }
-trap cleanup_create_log EXIT HUP INT TERM
+trap cleanup_create_log EXIT
+trap cleanup_after_signal HUP INT TERM
 create_log=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-create.XXXXXX") || exit 1
-create_output=$(gh gist create --desc "$expected_description" "$task_file" 2>"$create_log") || exit 1
+post_create_lifecycle=1
+if ! create_output=$(gh gist create --desc "$expected_description" "$task_file" 2>"$create_log"); then
+  fail_with_pending_cleanup create-command-failed
+fi
 if [ -s "$create_log" ]; then
   fail_with_pending_cleanup create-stderr
 fi
@@ -113,27 +125,39 @@ case "$create_output" in
 *'
 '*) fail_with_pending_cleanup create-output-unvalidated ;;
 esac
-gist_url=$create_output
-gist_id=${gist_url#https://gist.github.com/}
-test "$gist_id" != "$gist_url"
+gist_id=${create_output#https://gist.github.com/}
+test "$gist_id" != "$create_output"
 test "$gist_id" = "${gist_id##*/}"
 case "$gist_id" in
 "" | *[!A-Za-z0-9]*) fail_with_pending_cleanup create-output-unvalidated ;;
 esac
-test "$gist_url" = "https://gist.github.com/$gist_id"
+test "$create_output" = "https://gist.github.com/$gist_id"
+create_output=
 if ! gh gist edit "$gist_id" --filename "$expected_filename" "$task_file" >/dev/null; then
   fail_with_pending_cleanup metadata-edit-failed
 fi
-if [ "$(gh api "gists/$gist_id" --jq .public)" != false ]; then
+if ! gist_public=$(gh api "gists/$gist_id" --jq .public); then
+  fail_with_pending_cleanup metadata-public-read
+fi
+if [ "$gist_public" != false ]; then
   fail_with_pending_cleanup metadata-public
 fi
-if [ "$(gh api "gists/$gist_id" --jq .description)" != "$expected_description" ]; then
+if ! gist_description=$(gh api "gists/$gist_id" --jq .description); then
+  fail_with_pending_cleanup metadata-description-read
+fi
+if [ "$gist_description" != "$expected_description" ]; then
   fail_with_pending_cleanup metadata-description
 fi
-if [ "$(gh api "gists/$gist_id" --jq '.files | keys | length')" != 1 ]; then
+if ! gist_file_count=$(gh api "gists/$gist_id" --jq '.files | keys | length'); then
+  fail_with_pending_cleanup metadata-file-count-read
+fi
+if [ "$gist_file_count" != 1 ]; then
   fail_with_pending_cleanup metadata-file-count
 fi
-if [ "$(gh api "gists/$gist_id" --jq '.files | keys[0]')" != "$expected_filename" ]; then
+if ! gist_filename=$(gh api "gists/$gist_id" --jq '.files | keys[0]'); then
+  fail_with_pending_cleanup metadata-filename-read
+fi
+if [ "$gist_filename" != "$expected_filename" ]; then
   fail_with_pending_cleanup metadata-filename
 fi
 ```
@@ -170,35 +194,60 @@ if ! type fail_with_pending_cleanup >/dev/null 2>&1; then
 fi
 tmp_base=${TMPDIR:-/tmp}
 umask 077
-raw_dir=$(mktemp -d "$tmp_base/agent-task-gist.XXXXXX") || exit 1
+raw_dir=$(mktemp -d "$tmp_base/agent-task-gist.XXXXXX") ||
+  fail_with_pending_cleanup raw-temp
 cleanup_raw_dir() {
   rm -rf "$raw_dir"
 }
 trap cleanup_raw_dir EXIT HUP INT TERM
 raw_file="$raw_dir/task.md"
-gh gist view "$gist_id" --raw > "$raw_file"
-local_hash=$(shasum -a 256 "$task_file" | awk '{print $1}')
-raw_hash=$(shasum -a 256 "$raw_file" | awk '{print $1}')
+if ! gh gist view "$gist_id" --raw > "$raw_file"; then
+  fail_with_pending_cleanup raw-fetch
+fi
+if ! local_hash_line=$(shasum -a 256 "$task_file"); then
+  fail_with_pending_cleanup raw-local-hash
+fi
+local_hash=$(printf '%s\n' "$local_hash_line" | awk '{print $1}')
+if [ -z "$local_hash" ]; then
+  fail_with_pending_cleanup raw-local-hash
+fi
+if ! raw_hash_line=$(shasum -a 256 "$raw_file"); then
+  fail_with_pending_cleanup raw-remote-hash
+fi
+raw_hash=$(printf '%s\n' "$raw_hash_line" | awk '{print $1}')
+if [ -z "$raw_hash" ]; then
+  fail_with_pending_cleanup raw-remote-hash
+fi
 printf '%s  %s\n%s  %s\n' "$local_hash" "$task_file" "$raw_hash" "$raw_file"
 if [ "$local_hash" != "$raw_hash" ]; then
   fail_with_pending_cleanup raw-digest-mismatch
 fi
-if rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$raw_file"; then
+set +e
+rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$raw_file" >/dev/null
+scan_status=$?
+set -e
+if [ "$scan_status" -eq 0 ]; then
   fail_with_pending_cleanup content-scan
+fi
+if [ "$scan_status" -ne 1 ]; then
+  fail_with_pending_cleanup scanner-error
 fi
 ```
 
 The hashes must match and the scan must find no private handoff or secret
 material. If any check fails, keep the local artifact canonical and report the
-failure through the approved private handoff channel. Only after every API,
-identity, filename, hash, and content check above succeeds may the secret URL
-be retrieved. Do not print it: send it only through that approved private
-handoff channel.
+failure through the approved private handoff channel. The create command's
+returned URL is private, unapproved transient state until it is normalized to
+the exact Gist ID and all checks pass; it must not be logged, handed off, or
+stored in cleanup records. Only after every API, identity, filename, hash, and
+content check above succeeds may the secret URL be derived from the validated
+ID. Do not print it: send it only through that approved private handoff
+channel.
 
 ```sh
 # agent-task-gist-url-handoff
 set -e
-secret_gist_url=$gist_url
+secret_gist_url="https://gist.github.com/$gist_id"
 test -n "$secret_gist_url"
 ```
 
@@ -217,19 +266,74 @@ is an external mutation: require current human approval and an explicit
 per-Gist confirmation; never bulk-delete from a bare list.
 
 ```sh
+# agent-task-gist-reviewed-preview
+set -e
+expected_account='i9wa4'
+expected_description_prefix='agent-task:<repo>:'
+reviewed_preview=${reviewed_preview:-agent-task-gist-reviewed-preview.tsv}
+preview_data=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-preview.XXXXXX") || exit 1
+cleanup_preview_data() {
+  rm -f "$preview_data"
+}
+trap cleanup_preview_data EXIT HUP INT TERM
+gh auth status >/dev/null
+account=$(gh api user --jq .login)
+test "$account" = "$expected_account"
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
+gh gist list --secret --filter '^agent-task:<repo>:' --limit 100 \
+  --json id,description,owner,updatedAt \
+  --jq '.[] | [.id, .owner.login, "i9wa4", 8, .description] | @tsv' \
+  > "$preview_data"
+if grep -Fv "$expected_description_prefix" "$preview_data" >/dev/null; then
+  exit 1
+fi
+preview_hash=$(shasum -a 256 "$preview_data" | awk '{print $1}')
+{
+  printf '# schema=agent-task-gist-reviewed-preview-v1\n'
+  printf '# account=%s\n' "$account"
+  printf '# generated_epoch=%s\n' "$(date +%s)"
+  printf '# data_sha256=%s\n' "$preview_hash"
+  cat "$preview_data"
+} > "$reviewed_preview"
+```
+
+The preview file is the reviewed authority artifact for deletion. Keep the
+metadata lines and data rows intact; the deletion step rejects missing,
+malformed, stale, or digest-mismatched preview files.
+
+```sh
 # agent-task-gist-delete-confirmation
 set -e
 expected_account='i9wa4'
 expected_owner='i9wa4'
 expected_description='agent-task:<repo>:<task>'
 min_age_days=7
+max_preview_age_seconds=3600
 reviewed_preview=${reviewed_preview:-agent-task-gist-reviewed-preview.tsv}
 approved_gist_id='<reviewed-gist-id>'
 gh auth status >/dev/null
 account=$(gh api user --jq .login)
 test "$account" = "$expected_account"
-preview_row=$(awk -F '	' -v id="$approved_gist_id" '$1 == id { print; found = 1 } END { exit(found ? 0 : 1) }' "$reviewed_preview")
+test "$(awk -F = '$1 == "# schema" { print $2 }' "$reviewed_preview")" = agent-task-gist-reviewed-preview-v1
+test "$(awk -F = '$1 == "# account" { print $2 }' "$reviewed_preview")" = "$expected_account"
+preview_generated_epoch=$(awk -F = '$1 == "# generated_epoch" { print $2 }' "$reviewed_preview")
+case "$preview_generated_epoch" in
+"" | *[!0-9]*) exit 1 ;;
+esac
+now_epoch=${now_epoch:-$(date +%s)}
+test $((now_epoch - preview_generated_epoch)) -le "$max_preview_age_seconds"
+expected_preview_hash=$(awk -F = '$1 == "# data_sha256" { print $2 }' "$reviewed_preview")
+case "$expected_preview_hash" in
+"" | *[!A-Fa-f0-9]*) exit 1 ;;
+esac
+preview_data=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-preview.XXXXXX") || exit 1
+cleanup_preview_data() {
+  rm -f "$preview_data"
+}
+trap cleanup_preview_data EXIT HUP INT TERM
+awk '/^#/ { next } NF { print }' "$reviewed_preview" > "$preview_data"
+test "$(shasum -a 256 "$preview_data" | awk '{print $1}')" = "$expected_preview_hash"
+preview_row=$(awk -F '	' -v id="$approved_gist_id" '$1 == id { print; found = 1 } END { exit(found ? 0 : 1) }' "$preview_data")
 IFS="$(printf '\t')" read -r preview_id preview_owner preview_account preview_age_days preview_description <<EOF
 $preview_row
 EOF

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -66,22 +66,43 @@ not permission to perform one. Each creation command intentionally omits
 gh auth status
 gh gist create --desc 'agent-task:<repo>:<task>' task.md
 gh gist edit <gist-id> --filename task.md task.md
-gh api gists/<gist-id> --jq '{html_url,public,description,files:(.files|keys)}'
+gh api gists/<gist-id> --jq '{public,description,files:(.files|keys)}'
 ```
 
 Verify API output reports `public=false`, the expected description, and the
-expected single filename. Fetch Raw content, compare it with the local source,
-and scan before sharing the URL:
+expected single filename. Fetch Raw content into a private unique temporary
+directory, compare it with the local source, and scan before retrieving or
+sharing the URL:
 
 ```sh
-gh gist view <gist-id> --raw > "$TMPDIR/agent-task-gist.md"
-shasum -a 256 task.md "$TMPDIR/agent-task-gist.md"
-rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$TMPDIR/agent-task-gist.md"
+# agent-task-gist-raw-verification
+tmp_base=${TMPDIR:-/tmp}
+umask 077
+raw_dir=$(mktemp -d "$tmp_base/agent-task-gist.XXXXXX") || exit 1
+cleanup_raw_dir() {
+  rm -rf "$raw_dir"
+}
+trap cleanup_raw_dir EXIT HUP INT TERM
+raw_file="$raw_dir/task.md"
+gh gist view "$gist_id" --raw > "$raw_file"
+shasum -a 256 "$task_file" "$raw_file"
+if rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$raw_file"; then
+  exit 1
+fi
 ```
 
 The hashes must match and the scan must find no private handoff or secret
 material. If any check fails, keep the local artifact canonical and report the
-failure through the approved private handoff channel.
+failure through the approved private handoff channel. Only after every API,
+identity, filename, hash, and content check above succeeds may the secret URL
+be retrieved. Do not print it: send it only through that approved private
+handoff channel.
+
+```sh
+# agent-task-gist-url-handoff
+secret_gist_url=$(gh api "gists/$gist_id" --jq '.html_url')
+test -n "$secret_gist_url"
+```
 
 ### 2.3. Resume, finish, and safe cleanup
 
@@ -99,15 +120,20 @@ per-Gist confirmation; never bulk-delete from a bare list.
 
 ```sh
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
-read -r 'DELETE_GIST_ID?Delete this approved agent-task Gist ID: '
+# agent-task-gist-delete-confirmation
+approved_gist_id='<reviewed-gist-id>'
+printf '%s' 'Delete this approved agent-task Gist ID: '
+IFS= read -r DELETE_GIST_ID
 test -n "$DELETE_GIST_ID"
+test "$DELETE_GIST_ID" = "$approved_gist_id"
 gh gist delete "$DELETE_GIST_ID"
 ```
 
 Do not use `gh gist delete --yes` in an agent-facing cleanup path. Keep a
 preview record and delete only the reviewed Gist after checking its description,
-owner/account, and age. On task completion, delete the approved memo or
-promote durable knowledge before deletion.
+owner/account, and age. `approved_gist_id` must be the exact reviewed ID and
+current human approval must still cover that one deletion. On task completion,
+delete the approved memo or promote durable knowledge before deletion.
 
 ## 3. Recommended Result Fields
 

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -126,12 +126,23 @@ case "$create_output" in
 '*) fail_with_pending_cleanup create-output-unvalidated ;;
 esac
 gist_id=${create_output#https://gist.github.com/}
-test "$gist_id" != "$create_output"
-test "$gist_id" = "${gist_id##*/}"
+if [ "$gist_id" = "$create_output" ]; then
+  fail_with_pending_cleanup create-output-unvalidated
+fi
+if [ "$gist_id" != "${gist_id##*/}" ]; then
+  gist_id=
+  fail_with_pending_cleanup create-output-unvalidated
+fi
 case "$gist_id" in
-"" | *[!A-Za-z0-9]*) fail_with_pending_cleanup create-output-unvalidated ;;
+"" | *[!A-Za-z0-9]*)
+  gist_id=
+  fail_with_pending_cleanup create-output-unvalidated
+  ;;
 esac
-test "$create_output" = "https://gist.github.com/$gist_id"
+if [ "$create_output" != "https://gist.github.com/$gist_id" ]; then
+  gist_id=
+  fail_with_pending_cleanup create-output-unvalidated
+fi
 create_output=
 if ! gh gist edit "$gist_id" --filename "$expected_filename" "$task_file" >/dev/null; then
   fail_with_pending_cleanup metadata-edit-failed
@@ -199,7 +210,15 @@ raw_dir=$(mktemp -d "$tmp_base/agent-task-gist.XXXXXX") ||
 cleanup_raw_dir() {
   rm -rf "$raw_dir"
 }
-trap cleanup_raw_dir EXIT HUP INT TERM
+cleanup_raw_after_signal() {
+  cleanup_raw_dir
+  if type cleanup_after_signal >/dev/null 2>&1; then
+    cleanup_after_signal
+  fi
+  fail_with_pending_cleanup interrupted
+}
+trap cleanup_raw_dir EXIT
+trap cleanup_raw_after_signal HUP INT TERM
 raw_file="$raw_dir/task.md"
 if ! gh gist view "$gist_id" --raw > "$raw_file"; then
   fail_with_pending_cleanup raw-fetch
@@ -279,19 +298,27 @@ trap cleanup_preview_data EXIT HUP INT TERM
 gh auth status >/dev/null
 account=$(gh api user --jq .login)
 test "$account" = "$expected_account"
+generated_epoch=$(date +%s)
+case "$generated_epoch" in
+"" | *[!0-9]*) exit 1 ;;
+esac
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100 \
   --json id,description,owner,updatedAt \
-  --jq '.[] | [.id, .owner.login, "i9wa4", 8, .description] | @tsv' \
+  --jq ".[] | [.id, .owner.login, \"$account\", (((($generated_epoch) - (.updatedAt | fromdateiso8601)) / 86400) | floor), .description] | @tsv" \
   > "$preview_data"
-if grep -Fv "$expected_description_prefix" "$preview_data" >/dev/null; then
+if ! awk -F '	' -v prefix="$expected_description_prefix" '
+  NF != 5 { exit 1 }
+  $4 !~ /^[0-9]+$/ { exit 1 }
+  $5 !~ "^" prefix { exit 1 }
+' "$preview_data"; then
   exit 1
 fi
 preview_hash=$(shasum -a 256 "$preview_data" | awk '{print $1}')
 {
   printf '# schema=agent-task-gist-reviewed-preview-v1\n'
   printf '# account=%s\n' "$account"
-  printf '# generated_epoch=%s\n' "$(date +%s)"
+  printf '# generated_epoch=%s\n' "$generated_epoch"
   printf '# data_sha256=%s\n' "$preview_hash"
   cat "$preview_data"
 } > "$reviewed_preview"

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -64,12 +64,49 @@ not permission to perform one. Each creation command intentionally omits
 
 ```sh
 # agent-task-gist-create-read-back
-gh auth status
-create_output=$(gh gist create --desc 'agent-task:<repo>:<task>' task.md)
-gist_id=${create_output##*/}
-test -n "$gist_id"
-gh gist edit "$gist_id" --filename task.md task.md
-gh api "gists/$gist_id" --jq '{public,description,files:(.files|keys)}'
+set -e
+expected_account='i9wa4'
+expected_description='agent-task:<repo>:<task>'
+expected_filename='task.md'
+task_file=${task_file:-task.md}
+gh auth status >/dev/null
+account=$(gh api user --jq .login)
+test "$account" = "$expected_account"
+gist_id=
+create_log=
+agent_task_gist_metadata_verified=0
+cleanup_unverified_gist() {
+  if [ -n "$create_log" ]; then
+    rm -f "$create_log"
+  fi
+  if [ -n "$gist_id" ] && [ "$agent_task_gist_metadata_verified" != 1 ]; then
+    gh gist delete "$gist_id"
+  fi
+}
+trap cleanup_unverified_gist EXIT HUP INT TERM
+create_log=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-create.XXXXXX") || exit 1
+create_output=$(gh gist create --desc "$expected_description" "$task_file" 2>"$create_log") || exit 1
+test ! -s "$create_log"
+rm -f "$create_log"
+create_log=
+case "$create_output" in
+https://gist.github.com/*) ;;
+*) exit 1 ;;
+esac
+gist_url=$create_output
+gist_id=${gist_url#https://gist.github.com/}
+test "$gist_id" != "$gist_url"
+test "$gist_id" = "${gist_id##*/}"
+case "$gist_id" in
+"" | *[!A-Za-z0-9]*) exit 1 ;;
+esac
+test "$gist_url" = "https://gist.github.com/$gist_id"
+gh gist edit "$gist_id" --filename "$expected_filename" "$task_file" >/dev/null
+test "$(gh api "gists/$gist_id" --jq .public)" = false
+test "$(gh api "gists/$gist_id" --jq .description)" = "$expected_description"
+test "$(gh api "gists/$gist_id" --jq '.files | keys | length')" = 1
+test "$(gh api "gists/$gist_id" --jq '.files | keys[0]')" = "$expected_filename"
+agent_task_gist_metadata_verified=1
 ```
 
 Verify API output reports `public=false`, the expected description, and the
@@ -79,6 +116,7 @@ sharing the URL:
 
 ```sh
 # agent-task-gist-raw-verification
+set -e
 tmp_base=${TMPDIR:-/tmp}
 umask 077
 raw_dir=$(mktemp -d "$tmp_base/agent-task-gist.XXXXXX") || exit 1
@@ -108,7 +146,8 @@ handoff channel.
 
 ```sh
 # agent-task-gist-url-handoff
-secret_gist_url=$create_output
+set -e
+secret_gist_url=$gist_url
 test -n "$secret_gist_url"
 ```
 
@@ -129,6 +168,7 @@ per-Gist confirmation; never bulk-delete from a bare list.
 ```sh
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
 # agent-task-gist-delete-confirmation
+set -e
 approved_gist_id='<reviewed-gist-id>'
 printf '%s' 'Delete this approved agent-task Gist ID: '
 IFS= read -r DELETE_GIST_ID

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -69,44 +69,73 @@ expected_account='i9wa4'
 expected_description='agent-task:<repo>:<task>'
 expected_filename='task.md'
 task_file=${task_file:-task.md}
+pending_cleanup_record=${pending_cleanup_record:-agent-task-gist-pending-cleanup.txt}
 gh auth status >/dev/null
 account=$(gh api user --jq .login)
 test "$account" = "$expected_account"
 gist_id=
 create_log=
-agent_task_gist_metadata_verified=0
-cleanup_unverified_gist() {
+write_pending_cleanup() {
+  reason=$1
+  {
+    printf 'status=pending-cleanup\n'
+    printf 'reason=%s\n' "$reason"
+    printf 'account=%s\n' "${account:-unknown}"
+    printf 'description=%s\n' "$expected_description"
+    printf 'filename=%s\n' "$expected_filename"
+    if [ -n "$gist_id" ]; then
+      printf 'gist_id=%s\n' "$gist_id"
+    fi
+  } > "$pending_cleanup_record"
+}
+fail_with_pending_cleanup() {
+  write_pending_cleanup "$1"
+  exit 1
+}
+cleanup_create_log() {
   if [ -n "$create_log" ]; then
     rm -f "$create_log"
   fi
-  if [ -n "$gist_id" ] && [ "$agent_task_gist_metadata_verified" != 1 ]; then
-    gh gist delete "$gist_id"
-  fi
 }
-trap cleanup_unverified_gist EXIT HUP INT TERM
+trap cleanup_create_log EXIT HUP INT TERM
 create_log=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-create.XXXXXX") || exit 1
 create_output=$(gh gist create --desc "$expected_description" "$task_file" 2>"$create_log") || exit 1
-test ! -s "$create_log"
+if [ -s "$create_log" ]; then
+  fail_with_pending_cleanup create-stderr
+fi
 rm -f "$create_log"
 create_log=
 case "$create_output" in
 https://gist.github.com/*) ;;
-*) exit 1 ;;
+*) fail_with_pending_cleanup create-output-unvalidated ;;
+esac
+case "$create_output" in
+*'
+'*) fail_with_pending_cleanup create-output-unvalidated ;;
 esac
 gist_url=$create_output
 gist_id=${gist_url#https://gist.github.com/}
 test "$gist_id" != "$gist_url"
 test "$gist_id" = "${gist_id##*/}"
 case "$gist_id" in
-"" | *[!A-Za-z0-9]*) exit 1 ;;
+"" | *[!A-Za-z0-9]*) fail_with_pending_cleanup create-output-unvalidated ;;
 esac
 test "$gist_url" = "https://gist.github.com/$gist_id"
-gh gist edit "$gist_id" --filename "$expected_filename" "$task_file" >/dev/null
-test "$(gh api "gists/$gist_id" --jq .public)" = false
-test "$(gh api "gists/$gist_id" --jq .description)" = "$expected_description"
-test "$(gh api "gists/$gist_id" --jq '.files | keys | length')" = 1
-test "$(gh api "gists/$gist_id" --jq '.files | keys[0]')" = "$expected_filename"
-agent_task_gist_metadata_verified=1
+if ! gh gist edit "$gist_id" --filename "$expected_filename" "$task_file" >/dev/null; then
+  fail_with_pending_cleanup metadata-edit-failed
+fi
+if [ "$(gh api "gists/$gist_id" --jq .public)" != false ]; then
+  fail_with_pending_cleanup metadata-public
+fi
+if [ "$(gh api "gists/$gist_id" --jq .description)" != "$expected_description" ]; then
+  fail_with_pending_cleanup metadata-description
+fi
+if [ "$(gh api "gists/$gist_id" --jq '.files | keys | length')" != 1 ]; then
+  fail_with_pending_cleanup metadata-file-count
+fi
+if [ "$(gh api "gists/$gist_id" --jq '.files | keys[0]')" != "$expected_filename" ]; then
+  fail_with_pending_cleanup metadata-filename
+fi
 ```
 
 Verify API output reports `public=false`, the expected description, and the
@@ -117,6 +146,28 @@ sharing the URL:
 ```sh
 # agent-task-gist-raw-verification
 set -e
+if ! type write_pending_cleanup >/dev/null 2>&1; then
+  pending_cleanup_record=${pending_cleanup_record:-agent-task-gist-pending-cleanup.txt}
+  write_pending_cleanup() {
+    reason=$1
+    {
+      printf 'status=pending-cleanup\n'
+      printf 'reason=%s\n' "$reason"
+      printf 'account=%s\n' "${account:-unknown}"
+      printf 'description=%s\n' "${expected_description:-unknown}"
+      printf 'filename=%s\n' "${expected_filename:-unknown}"
+      if [ -n "${gist_id:-}" ]; then
+        printf 'gist_id=%s\n' "$gist_id"
+      fi
+    } > "$pending_cleanup_record"
+  }
+fi
+if ! type fail_with_pending_cleanup >/dev/null 2>&1; then
+  fail_with_pending_cleanup() {
+    write_pending_cleanup "$1"
+    exit 1
+  }
+fi
 tmp_base=${TMPDIR:-/tmp}
 umask 077
 raw_dir=$(mktemp -d "$tmp_base/agent-task-gist.XXXXXX") || exit 1
@@ -130,10 +181,10 @@ local_hash=$(shasum -a 256 "$task_file" | awk '{print $1}')
 raw_hash=$(shasum -a 256 "$raw_file" | awk '{print $1}')
 printf '%s  %s\n%s  %s\n' "$local_hash" "$task_file" "$raw_hash" "$raw_file"
 if [ "$local_hash" != "$raw_hash" ]; then
-  exit 1
+  fail_with_pending_cleanup raw-digest-mismatch
 fi
 if rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$raw_file"; then
-  exit 1
+  fail_with_pending_cleanup content-scan
 fi
 ```
 
@@ -169,7 +220,27 @@ per-Gist confirmation; never bulk-delete from a bare list.
 gh gist list --secret --filter '^agent-task:<repo>:' --limit 100
 # agent-task-gist-delete-confirmation
 set -e
+expected_account='i9wa4'
+expected_owner='i9wa4'
+expected_description='agent-task:<repo>:<task>'
+min_age_days=7
+reviewed_preview=${reviewed_preview:-agent-task-gist-reviewed-preview.tsv}
 approved_gist_id='<reviewed-gist-id>'
+gh auth status >/dev/null
+account=$(gh api user --jq .login)
+test "$account" = "$expected_account"
+preview_row=$(awk -F '	' -v id="$approved_gist_id" '$1 == id { print; found = 1 } END { exit(found ? 0 : 1) }' "$reviewed_preview")
+IFS="$(printf '\t')" read -r preview_id preview_owner preview_account preview_age_days preview_description <<EOF
+$preview_row
+EOF
+test "$preview_id" = "$approved_gist_id"
+test "$preview_owner" = "$expected_owner"
+test "$preview_account" = "$expected_account"
+test "$preview_description" = "$expected_description"
+case "$preview_age_days" in
+"" | *[!0-9]*) exit 1 ;;
+esac
+test "$preview_age_days" -ge "$min_age_days"
 printf '%s' 'Delete this approved agent-task Gist ID: '
 IFS= read -r DELETE_GIST_ID
 test -n "$DELETE_GIST_ID"

--- a/skills/dotfiles/references/resume-handoff.md
+++ b/skills/dotfiles/references/resume-handoff.md
@@ -73,6 +73,16 @@ pending_cleanup_record=${pending_cleanup_record:-agent-task-gist-pending-cleanup
 gh auth status >/dev/null
 account=$(gh api user --jq .login)
 test "$account" = "$expected_account"
+set +e
+rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$task_file" >/dev/null
+local_scan_status=$?
+set -e
+if [ "$local_scan_status" -eq 0 ]; then
+  exit 1
+fi
+if [ "$local_scan_status" -ne 1 ]; then
+  exit 1
+fi
 gist_id=
 create_log=
 post_create_lifecycle=0
@@ -291,8 +301,10 @@ expected_account='i9wa4'
 expected_description_prefix='agent-task:<repo>:'
 reviewed_preview=${reviewed_preview:-agent-task-gist-reviewed-preview.tsv}
 preview_data=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-preview.XXXXXX") || exit 1
+preview_proof=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-proof.XXXXXX") || exit 1
 cleanup_preview_data() {
   rm -f "$preview_data"
+  rm -f "$preview_proof"
 }
 trap cleanup_preview_data EXIT HUP INT TERM
 gh auth status >/dev/null
@@ -314,13 +326,16 @@ if ! awk -F '	' -v prefix="$expected_description_prefix" '
 ' "$preview_data"; then
   exit 1
 fi
-preview_hash=$(shasum -a 256 "$preview_data" | awk '{print $1}')
 {
   printf '# schema=agent-task-gist-reviewed-preview-v1\n'
   printf '# account=%s\n' "$account"
   printf '# generated_epoch=%s\n' "$generated_epoch"
-  printf '# data_sha256=%s\n' "$preview_hash"
   cat "$preview_data"
+} > "$preview_proof"
+preview_hash=$(shasum -a 256 "$preview_proof" | awk '{print $1}')
+{
+  cat "$preview_proof"
+  printf '# proof_sha256=%s\n' "$preview_hash"
 } > "$reviewed_preview"
 ```
 
@@ -348,18 +363,30 @@ case "$preview_generated_epoch" in
 "" | *[!0-9]*) exit 1 ;;
 esac
 now_epoch=${now_epoch:-$(date +%s)}
+case "$now_epoch" in
+"" | *[!0-9]*) exit 1 ;;
+esac
+test "$preview_generated_epoch" -le "$now_epoch"
 test $((now_epoch - preview_generated_epoch)) -le "$max_preview_age_seconds"
-expected_preview_hash=$(awk -F = '$1 == "# data_sha256" { print $2 }' "$reviewed_preview")
+expected_preview_hash=$(awk -F = '$1 == "# proof_sha256" { print $2 }' "$reviewed_preview")
 case "$expected_preview_hash" in
 "" | *[!A-Fa-f0-9]*) exit 1 ;;
 esac
 preview_data=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-preview.XXXXXX") || exit 1
+preview_proof=$(mktemp "${TMPDIR:-/tmp}/agent-task-gist-reviewed-proof.XXXXXX") || exit 1
 cleanup_preview_data() {
   rm -f "$preview_data"
+  rm -f "$preview_proof"
 }
 trap cleanup_preview_data EXIT HUP INT TERM
 awk '/^#/ { next } NF { print }' "$reviewed_preview" > "$preview_data"
-test "$(shasum -a 256 "$preview_data" | awk '{print $1}')" = "$expected_preview_hash"
+{
+  printf '# schema=%s\n' "$(awk -F = '$1 == "# schema" { print $2 }' "$reviewed_preview")"
+  printf '# account=%s\n' "$(awk -F = '$1 == "# account" { print $2 }' "$reviewed_preview")"
+  printf '# generated_epoch=%s\n' "$preview_generated_epoch"
+  cat "$preview_data"
+} > "$preview_proof"
+test "$(shasum -a 256 "$preview_proof" | awk '{print $1}')" = "$expected_preview_hash"
 preview_row=$(awk -F '	' -v id="$approved_gist_id" '$1 == id { print; found = 1 } END { exit(found ? 0 : 1) }' "$preview_data")
 IFS="$(printf '\t')" read -r preview_id preview_owner preview_account preview_age_days preview_description <<EOF
 $preview_row


### PR DESCRIPTION
## Summary
- Add discoverable guidance for optional portable agent-task memo Gists while keeping local task artifacts canonical.
- Prohibit public Gist mode and document approval, account, visibility, read-back, hash, URL-sharing, lifecycle, and cleanup safeguards.
- Update the validator and hook coverage so policy regressions are caught by focused checks and the repo check.

## Verification
- `bash scripts/validation/validate-agent-task-gist-policy.sh`
- `env -u TMPDIR bash scripts/validation/validate-agent-task-gist-policy.sh`
- `bash -n scripts/validation/validate-agent-task-gist-policy.sh`
- `nix run nixpkgs#shellcheck -- scripts/validation/validate-agent-task-gist-policy.sh`
- `bash scripts/validation/validate-skill-trigger-evals.sh skills/dotfiles`
- `git diff --check`
- `nix fmt`
- `nix run .#check`

Closes #309