### PR TITLE
chore(ci): extend workflow timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- Increase the `ci` job timeout from 5 minutes to 15 minutes.

## Background
Recent runs complete the explicit checks but exceed the previous 5-minute job budget after the Nix closure grew, causing cancellations before the workflow can finish cleanly.

## Verification
- `actionlint .github/workflows/ci.yaml`
- `git diff --check`