### PR TITLE
docs(agents): centralize postman language policy

### DIFF
--- a/config/tmux-a2a-postman/postman.md
+++ b/config/tmux-a2a-postman/postman.md
@@ -77,9 +77,22 @@ Hard gates:
 
 ### 2.2. Persona And Language
 
-- Think in English and respond in English.
-- For Japanese input, respond in English with a Japanese translation first:
-  `Translation: [translation here]`.
+Language policy belongs here for Postman-driven sessions. Skills and artifact
+workflows must follow this active runtime policy or an explicit requested
+output language; they must not establish independent Japanese/English defaults.
+
+- Think in English unless a task explicitly requires another reasoning
+  language.
+- `messenger` communicates with the human user in Japanese by default.
+- Human-facing documents and artifacts are written in Japanese by default.
+- All other agent communication and machine/agent-facing working material is
+  written in English by default, including plans, task artifacts, reviews,
+  research notes, handoffs, logs, and internal node-to-node messages.
+- An explicitly requested output language overrides these defaults for that
+  output.
+- Audience and explicit user intent decide the output language. Artifact type
+  alone does not: a Gist is not inherently Japanese, and a plan is not
+  inherently English when the user explicitly requests a Japanese deliverable.
 
 ## 3. `critic`
 

--- a/skills/plan-design/SKILL.md
+++ b/skills/plan-design/SKILL.md
@@ -7,7 +7,7 @@ description: |
   USE FOR: Implementation plans and durable task tracking: reduce ambiguity,
   compare options, parallel investigation, multi-source synthesis, review
   gates, task artifacts, evidence logs, handoff/resume, DONE/BLOCKED
-  verification, and human-facing artifacts requiring a Japanese Secret-Gist
+  verification, and human-facing artifacts requiring a Secret-Gist
   handoff. DO NOT USE FOR: machine-only outputs, internal logs, code/config
   artifacts, unrelated tasks, broad rewrites outside the request, or generated
   runtime outputs.
@@ -18,6 +18,10 @@ description: |
 Owns implementation-plan authoring and durable task tracking for plan-ready
 tasks: ambiguity reduction, option framing, multi-source synthesis, review
 gates, task artifacts, evidence logs, and handoff/resume.
+
+Follow the output language designated by the active runtime/session policy or
+explicit request. Do not establish an independent language policy in this
+skill.
 
 ## 1. Workflow
 

--- a/skills/plan-design/evals/tasks/positive-trigger-3.yaml
+++ b/skills/plan-design/evals/tasks/positive-trigger-3.yaml
@@ -4,7 +4,7 @@ description: Curated trigger-accuracy prompt for human-facing artifact handoffs.
 tags:
   - positive-trigger
 inputs:
-  prompt: "Prepare a Japanese human-facing completion artifact from an mkmd source, verify a Secret Gist without exposing private data, and hand it off through Postman."
+  prompt: "Use plan-design to prepare a human-facing Secret-Gist handoff from an mkmd task artifact, follow the active runtime language policy, verify the Gist safely, and report DONE/BLOCKED evidence through Postman."
 expected:
   should_trigger: true
 graders:

--- a/skills/plan-design/evals/tasks/positive-trigger-3.yaml
+++ b/skills/plan-design/evals/tasks/positive-trigger-3.yaml
@@ -4,7 +4,7 @@ description: Curated trigger-accuracy prompt for human-facing artifact handoffs.
 tags:
   - positive-trigger
 inputs:
-  prompt: "Use plan-design to prepare a human-facing Secret-Gist handoff from an mkmd task artifact, follow the active runtime language policy, verify the Gist safely, and report DONE/BLOCKED evidence through Postman."
+  prompt: "Prepare a human-facing Secret-Gist handoff from an mkmd task artifact, follow the active runtime language policy, verify the Gist safely, and report DONE/BLOCKED evidence through Postman."
 expected:
   should_trigger: true
 graders:

--- a/skills/plan-design/references/durable-task-tracking.md
+++ b/skills/plan-design/references/durable-task-tracking.md
@@ -155,7 +155,7 @@ Local absolute artifact paths are fine in internal chat, mailbox traffic, and
 local task artifacts. Public GitHub surfaces such as commits, issues, PRs, and
 reviews should use repo-relative paths or stable URLs.
 
-## 9. Human-Facing Japanese Secret-Gist Workflow
+## 9. Human-Facing Secret-Gist Workflow
 
 Use this subsection whenever an artifact is intended for human viewing. Do not
 use it for machine-only build outputs, internal logs or mailbox receipts, code,
@@ -163,8 +163,11 @@ configuration, Nix sources, temporary scratch files, or other non-human output.
 
 ### 9.1. Source and language
 
-- Write the human-facing final Markdown body in Japanese. Preserve commands,
-  paths, URLs, identifiers, and versions in their exact notation when needed.
+- Follow the output language designated by the active runtime/session policy or
+  explicit request. Do not establish an independent language policy in this
+  workflow.
+- Preserve commands, paths, URLs, identifiers, and versions in their exact
+  notation when needed.
 - Create the local canonical source with `mkmd`; include title, purpose, scope,
   verification evidence, and remaining work.
 - Before upload, remove secrets, tokens, private data, internal mail or review
@@ -180,7 +183,7 @@ human approval. After approval, confirm the intended account with
 ```sh
 gh auth status
 gh gist create --filename "$(basename "$MKMD_ARTIFACT")" \
-  --desc '日本語の人間向け成果物' "$MKMD_ARTIFACT"
+  --desc '<human-facing artifact description>' "$MKMD_ARTIFACT"
 ```
 
 Keep the `mkmd` basename, including its unique suffix, as the Gist filename;
@@ -196,7 +199,9 @@ the URL in human-facing text until every check passes.
 ```sh
 gh api gists/<gist-id> --jq '{html_url,public,description,files:(.files|keys)}'
 curl -L --silent --show-error --head https://gist.github.com/<owner>/<gist-id>
-curl -L --silent https://gist.githubusercontent.com/<owner>/<gist-id>/raw/<filename> > "$TMPDIR/gist-raw.md"
+curl -L --silent \
+  https://gist.githubusercontent.com/<owner>/<gist-id>/raw/<filename> \
+  > "$TMPDIR/gist-raw.md"
 shasum -a 256 "$MKMD_ARTIFACT" "$TMPDIR/gist-raw.md"
 rg -n '/\.local/|tmux-a2a|pop_receipt|BEGIN (RSA|OPENSSH|PRIVATE)' "$TMPDIR/gist-raw.md"
 ```
@@ -208,10 +213,11 @@ unchanged when outside the request; on a filename collision, create a new
 
 ### 9.3. Handoff and fallback
 
-Postman or requester-facing Japanese handoff text must include the complete
-clickable Gist URL, visibility, filename, source identifier, verification
-commands and results, changed scope, and remaining blockers. Do not copy a
-Secret-Gist URL into public issues, PRs, or logs without separate approval.
+Postman or requester-facing handoff text must follow the active output language
+policy and include the complete clickable Gist URL, visibility, filename,
+source identifier, verification commands and results, changed scope, and
+remaining blockers. Do not copy a Secret-Gist URL into public issues, PRs, or
+logs without separate approval.
 
 If creation or verification fails, keep the local `mkmd` source as the
 canonical artifact and report the failure reason and next action. Never fall


### PR DESCRIPTION
## Summary

- make `config/tmux-a2a-postman/postman.md` the language-policy source of truth for Postman-driven sessions
- remove hard-coded Japanese Secret-Gist wording from `skills/plan-design`
- update the plan-design trigger eval to follow the active runtime language policy

## Validation

- `bash scripts/validation/validate-skill-frontmatter.sh skills/plan-design`
- `bash scripts/validation/validate-skill-trigger-evals.sh skills/plan-design`
- `waza --no-update-check check skills/plan-design --format json`
- `nix run nixpkgs#rumdl -- check config/tmux-a2a-postman/postman.md skills/plan-design/SKILL.md skills/plan-design/references/durable-task-tracking.md`
- `git diff --check`
- `nix flake check`

Closes #312.
