### PR TITLE
fix(artifacts): use skill root for gist verifier

### DIFF
--- a/skills/artifacts/references/gist-delivery.md
+++ b/skills/artifacts/references/gist-delivery.md
@@ -39,17 +39,20 @@ copy; do not overwrite unrelated material.
 Verify with the executable operator path before handing off the URL:
 
 ```sh
+export ARTIFACTS_SKILL_ROOT=/absolute/path/to/artifacts-skill
 export MKMD_ARTIFACT=/absolute/path/to/local-artifact.md
 export GIST_ID=<gist-id>
 export GIST_OWNER=<owner>
 export GIST_DESCRIPTION='<human-facing artifact description>'
 export GIST_FILENAME="$(basename "$MKMD_ARTIFACT")"
 export GIST_EXPECTED_FILES="$GIST_FILENAME"
-skills/artifacts/scripts/verify-gist-delivery
+"${ARTIFACTS_SKILL_ROOT}/scripts/verify-gist-delivery"
 ```
 
 Required result:
 
+- `ARTIFACTS_SKILL_ROOT` is set to the local artifacts skill directory, so the
+  verifier is reachable from any target repository or current working directory;
 - the verifier exits nonzero unless the API reports `public=false`;
 - URL, description, expected filename, and exact file set match expectation;
 - page and raw transports return success; failed transport is a blocker;
@@ -88,7 +91,8 @@ skills/artifacts/scripts/validate-gist-delivery-contract.sh
 
 The validator uses local fixtures only. It executes the published verifier path
 with mocked `gh`, `curl`, and `rg` commands. It checks unique temporary
-directories, fail-closed transport, visibility and metadata assertions, byte
-and hash equality, explicit `rg` status handling, replacement collision
+directories, unrelated-cwd operator reachability through `ARTIFACTS_SKILL_ROOT`,
+absent-root failure, fail-closed transport, visibility and metadata assertions,
+byte and hash equality, explicit `rg` status handling, replacement collision
 failure behavior, and machine-local path detection without creating or changing
 any Gist.

--- a/skills/artifacts/scripts/validate-gist-delivery-contract.sh
+++ b/skills/artifacts/scripts/validate-gist-delivery-contract.sh
@@ -33,6 +33,7 @@ assert_failure() {
   fi
 }
 
+# shellcheck disable=SC2030,SC2031
 run_verifier_fixture() {
   (
     export PATH="$mock_bin:$PATH"
@@ -48,7 +49,38 @@ run_verifier_fixture() {
   )
 }
 
-require_doc 'skills/artifacts/scripts/verify-gist-delivery'
+# shellcheck disable=SC2030,SC2031
+run_operator_fixture() {
+  (
+    cd "$operator_cwd"
+    export PATH="$mock_bin:$PATH"
+    export MKMD_ARTIFACT="$source_file"
+    export GIST_ID="abc123"
+    export GIST_OWNER="example-owner"
+    export GIST_DESCRIPTION="Expected handoff"
+    export GIST_FILENAME="source.md"
+    export GIST_EXPECTED_FILES="source.md"
+    export ARTIFACTS_GIST_SOURCE="$source_file"
+    export ARTIFACTS_GIST_REAL_RG="$real_rg"
+    if test "${ARTIFACTS_OPERATOR_EXPORT_ROOT:-1}" = 1; then
+      export ARTIFACTS_SKILL_ROOT="$repo_root/skills/artifacts"
+    else
+      unset ARTIFACTS_SKILL_ROOT
+    fi
+    "${ARTIFACTS_SKILL_ROOT}/scripts/verify-gist-delivery"
+  )
+}
+
+run_old_relative_operator_fixture() {
+  (
+    cd "$operator_cwd"
+    skills/artifacts/scripts/verify-gist-delivery
+  )
+}
+
+require_doc 'ARTIFACTS_SKILL_ROOT'
+# shellcheck disable=SC2016
+require_doc '${ARTIFACTS_SKILL_ROOT}/scripts/verify-gist-delivery'
 require_doc 'public=false'
 require_doc 'GIST_DESCRIPTION'
 require_doc 'GIST_EXPECTED_FILES'
@@ -71,6 +103,8 @@ test -d "$first_tmp" || fail "first temporary directory was not created"
 test -d "$second_tmp" || fail "second temporary directory was not created"
 test "$first_tmp" != "$second_tmp" || fail "temporary directory names are not unique"
 rm -rf "$first_tmp" "$second_tmp"
+operator_cwd=$(mktemp -d "${TMPDIR:-/tmp}/artifacts-gist-unrelated-cwd.XXXXXX")
+test -d "$operator_cwd" || fail "operator cwd was not created"
 
 mock_bin="$fixture_dir/bin"
 mkdir "$mock_bin"
@@ -142,6 +176,11 @@ source_file="$fixture_dir/source.md"
 printf '%s\n' 'clean handoff body' >"$source_file"
 
 ARTIFACTS_GIST_RG_MODE=clean assert_success clean-copy run_verifier_fixture
+ARTIFACTS_GIST_RG_MODE=clean assert_success injected-root-operator run_operator_fixture
+ARTIFACTS_GIST_RG_MODE=clean assert_failure old-relative-operator run_old_relative_operator_fixture
+ARTIFACTS_OPERATOR_EXPORT_ROOT=0 \
+  ARTIFACTS_GIST_RG_MODE=clean \
+  assert_failure missing-artifacts-skill-root run_operator_fixture
 
 ARTIFACTS_GIST_CURL_MODE=changed \
   ARTIFACTS_GIST_RG_MODE=clean \


### PR DESCRIPTION
## Summary

- Require ARTIFACTS_SKILL_ROOT for the gist verifier operator command.
- Invoke the verifier through the artifacts skill root instead of a target-repository-relative path.
- Add contract coverage for unrelated-cwd execution, missing-root failure, and injected-root success.

## Verification

- bash -n skills/artifacts/scripts/validate-gist-delivery-contract.sh
- skills/artifacts/scripts/validate-gist-delivery-contract.sh
- nix run nixpkgs#shellcheck -- skills/artifacts/scripts/validate-gist-delivery-contract.sh
- explicit old relative counterexample from an unrelated cwd returned status 127
- bash scripts/validation/validate-skill-private-content.sh skills/artifacts/references/gist-delivery.md skills/artifacts/scripts/validate-gist-delivery-contract.sh
- bash scripts/validation/validate-skill-trigger-evals.sh skills/artifacts
- nix run nixpkgs#rumdl -- check skills/artifacts/references/gist-delivery.md
- bash scripts/validation/validate-skill-frontmatter.sh skills/artifacts/SKILL.md
- bash scripts/validation/validate-skill-description-length.sh skills/artifacts/SKILL.md
- git diff --check
- nix flake check

Closes #317
