### PR TITLE
feat(tailscale): manage tailscaled as a root service on switch

### DIFF
--- a/config/vde/layout.yml
+++ b/config/vde/layout.yml
@@ -7,16 +7,10 @@ presets:
       type: horizontal
       ratio: [1, 1]
       panes:
-        - type: vertical
-          ratio: [1, 1]
-          panes:
-            - name: postman
-              command: tmux-a2a-postman start  # tmux-a2a-postman control-plane state is review_first
-              delay: 500
-              focus: true
-            - name: tailscale
-              command: sudo $(which tailscaled)
-              delay: 500
+        - name: postman
+          command: tmux-a2a-postman start  # tmux-a2a-postman control-plane state is review_first
+          delay: 500
+          focus: true
         - name: vde-monitor
           command: sh -c 'rm -rf -- "$HOME/.vde-monitor/panes" && exec vde-monitor --tailscale'  # startup prunes only disposable pane logs; durable vde-monitor state stays preserved
           delay: 500

--- a/nix/flake-parts/modules/apps.nix
+++ b/nix/flake-parts/modules/apps.nix
@@ -25,6 +25,48 @@
       tmuxA2aPostmanUpdateScript = ./../../../scripts/nix/flake-input-update-tmux-a2a-postman.sh;
       wazaUpdateScript = ./../../../scripts/nix/package-update-waza.sh;
       actrunUpdateScript = ./../../../scripts/nix/package-update-actrun.sh;
+
+      # Neither standalone home-manager (Ubuntu) nor a plain nix-darwin
+      # environment.systemPackages entry (macOS) can declare a root-level
+      # service on their own, so both service definitions are generated here
+      # and (re)installed on every `switch` -- one shared pattern instead of
+      # leaning on nix-darwin's services.tailscale module for macOS only.
+      tailscaledUnit = pkgs.writeText "tailscaled.service" ''
+        [Unit]
+        Description=Tailscale node agent
+        Documentation=https://tailscale.com/kb/
+        Wants=network-pre.target
+        After=network-pre.target NetworkManager.service systemd-resolved.service
+        StartLimitIntervalSec=0
+
+        [Service]
+        ExecStart=${pkgs.tailscale}/bin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock
+        ExecStopPost=${pkgs.tailscale}/bin/tailscaled --cleanup
+        Restart=on-failure
+        RuntimeDirectory=tailscale
+        RuntimeDirectoryMode=0755
+        StateDirectory=tailscale
+        StateDirectoryMode=0700
+        CacheDirectory=tailscale
+        CacheDirectoryMode=0750
+        Type=notify
+
+        [Install]
+        WantedBy=multi-user.target
+      '';
+
+      # macOS equivalent of tailscaledUnit above, as a LaunchDaemon plist.
+      # cf. nix-darwin's modules/services/tailscale.nix (launchd.daemons.tailscaled),
+      # reimplemented directly here to keep the nix-darwin-specific surface at zero.
+      # lib.generators.toPlist renders the XML; only this attrset needs editing.
+      tailscaledPlist = pkgs.writeText "com.tailscale.tailscaled.plist" (
+        lib.generators.toPlist { escape = true; } {
+          Label = "com.tailscale.tailscaled";
+          ProgramArguments = [ "${pkgs.tailscale}/bin/tailscaled" ];
+          RunAtLoad = true;
+          KeepAlive = true;
+        }
+      );
     in
     {
       apps = {
@@ -43,6 +85,13 @@
 
                   sudo -H darwin-rebuild switch --impure --flake ".#$profile"
                   sudo -H ${pkgs.nix}/bin/nix-env --profile /nix/var/nix/profiles/system --delete-generations 1d
+
+                  # tailscaled LaunchDaemon: idempotent (re)install, safe to
+                  # run on every switch. Regenerates the plist so it always
+                  # points at the current nixpkgs tailscale store path.
+                  sudo install -m644 ${tailscaledPlist} /Library/LaunchDaemons/com.tailscale.tailscaled.plist
+                  sudo launchctl unload /Library/LaunchDaemons/com.tailscale.tailscaled.plist 2>/dev/null || true
+                  sudo launchctl load -w /Library/LaunchDaemons/com.tailscale.tailscaled.plist
                 ''
               else
                 ''
@@ -51,6 +100,13 @@
                     home-manager -- switch -b backup --flake '.#ubuntu' --impure
                   nix run --access-tokens "github.com=$access_token" \
                     home-manager -- expire-generations '-1 days'
+
+                  # tailscaled systemd unit: idempotent (re)install, safe to
+                  # run on every switch. Regenerates the unit so it always
+                  # points at the current nixpkgs tailscale store path.
+                  sudo install -m644 ${tailscaledUnit} /etc/systemd/system/tailscaled.service
+                  sudo systemctl daemon-reload
+                  sudo systemctl enable --now tailscaled
                 ''
             }
           ''}/bin/switch";

--- a/nix/flake-parts/modules/ubuntu.nix
+++ b/nix/flake-parts/modules/ubuntu.nix
@@ -66,7 +66,12 @@ in
             };
             # Linux-specific home-manager settings
             home = {
-              packages = [ ];
+              # tailscale: CLI + tailscaled binary. The systemd unit that runs
+              # tailscaled as root is generated and installed by the `switch`
+              # app (nix/flake-parts/modules/apps.nix) on every run, since
+              # standalone home-manager cannot manage root-level systemd
+              # units directly.
+              packages = [ pkgs.tailscale ];
               # Timezone data (not needed on macOS)
               sessionVariables.TZDIR = "${pkgs.tzdata}/share/zoneinfo";
               # Start ssh-agent if not running

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -80,7 +80,6 @@ in
     packages = [
       # System
       pkgs.gnumake
-      pkgs.tailscale
       pkgs.wget
       # nixpkgs
       (pkgs.python3.withPackages (ps: [ ps.pynvim ]))

--- a/nix/nix-darwin/default.nix
+++ b/nix/nix-darwin/default.nix
@@ -86,7 +86,13 @@
 
   # System packages (CLI tools that need to be system-wide)
   # NOTE: GUI apps moved to Homebrew casks to avoid nix store bloat from generations
+  # tailscale: CLI + tailscaled binary. The LaunchDaemon that runs tailscaled
+  # as root is generated and (re)installed by the `switch` app
+  # (nix/flake-parts/modules/apps.nix) on every run, mirroring the systemd
+  # unit handling on Ubuntu, so both platforms share one pattern instead of
+  # this file depending on nix-darwin's services.tailscale module.
   environment.systemPackages = [
+    pkgs.tailscale
   ];
 
   # WORKAROUND: nix-darwin a1fa429 still passes the removed --toc-depth flag to


### PR DESCRIPTION
## Summary

Make `tailscaled` a properly managed root service on both macOS and Ubuntu, applied automatically every time `nix run '.#switch'` runs.

## Background

Neither standalone home-manager (Ubuntu, no root-service management) nor a plain `environment.systemPackages` entry (macOS) declares a root-level service on its own. Previously `tailscaled` had to be started manually in the foreground (`config/vde/layout.yml`'s `main` preset ran `sudo $(which tailscaled)` in a dedicated pane), which died on logout/Ctrl+C and forced re-authentication each time.

## Changes

- `nix/flake-parts/modules/apps.nix`: generate a systemd unit (Linux) and a launchd plist (Darwin, via `lib.generators.toPlist`) from the current nixpkgs `tailscale` store path, and (re)install + reload them idempotently on every `switch` run. One shared pattern for both platforms instead of leaning on nix-darwin's `services.tailscale` module for macOS only.
- `nix/home-manager/default.nix`: drop the shared `pkgs.tailscale` entry (now declared per-platform, where each switch path also needs it).
- `nix/nix-darwin/default.nix`: add `pkgs.tailscale` to `systemPackages` (CLI only; service lifecycle is handled by the generated plist).
- `nix/flake-parts/modules/ubuntu.nix`: add `pkgs.tailscale` to `home.packages` (CLI + `tailscaled` binary for the generated unit).
- `config/vde/layout.yml`: drop the now-redundant/harmful manual `sudo $(which tailscaled)` pane from the `main` preset.

## Verification

- `nix flake check --all-systems` passes.
- Generated launchd plist validated with `plutil -lint` (OK), and its `ProgramArguments` resolves to the current `pkgs.tailscale` store path.
- Not yet applied on a real Ubuntu machine (macOS `switch` requires interactive `sudo`, deferred to the user).