### PR TITLE
fix(deps): ignore tmux-a2a-postman in Dependabot nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,10 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+      # First-party input: cooldown would hide a fresh release and make
+      # Dependabot propose the previous tag as the "latest eligible" version,
+      # i.e. a downgrade of the manual pin in flake.nix.
+      exclude:
+        - "tmux-a2a-postman"
     commit-message:
       prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,13 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-      # First-party input: cooldown would hide a fresh release and make
-      # Dependabot propose the previous tag as the "latest eligible" version,
-      # i.e. a downgrade of the manual pin in flake.nix.
-      exclude:
-        - "tmux-a2a-postman"
+    # First-party input: the flake.nix pin is bumped by hand within hours of
+    # each release, so Dependabot can only race that bump. Every PR it has ever
+    # opened for it was a downgrade (#278, #285, #320, #321) or a redundant
+    # catch-up (#286). Any filter that drops the pinned version from the
+    # candidate set turns a "version update" into a downgrade, so take the
+    # dependency out of Dependabot's hands entirely rather than tuning filters.
+    ignore:
+      - dependency-name: "tmux-a2a-postman"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
Closes #323

## Summary

Take the first-party `tmux-a2a-postman` flake input out of Dependabot's hands
so it can no longer open downgrade PRs for it.

## Background

`.github/dependabot.yml` sets `cooldown.default-days: 7` on the `nix` block.
Cooldown removes a too-recent release from the candidate set rather than
delaying the PR, so Dependabot still resolves a "latest eligible" version from
what remains. When the pin is raised by hand ahead of that window, the newest
eligible tag is older than the pin and Dependabot proposes a downgrade.

The timing confirms the mechanism. Dependabot's nix run fires daily at ~21:05
UTC, and the direction flips exactly when the window closes:

| Date (UTC) | Event | v0.9.0 cooldown (ends 07-15 13:48) |
| --- | --- | --- |
| 07-08 13:48 | v0.9.0 released | - |
| 07-08 15:27 | pin raised by hand | inside |
| 07-08 21:05 | #278 downgrade v0.9.0 -> v0.8.5 | inside |
| 07-13 23:11 | pin raised again | inside |
| 07-14 21:04 | #285 downgrade again | inside |
| 07-15 21:05 | #286 bump forward v0.8.5 -> v0.9.0 | expired |

## Changes

- Add an `ignore` rule for `tmux-a2a-postman` in the `nix` update block.

## Technical Details

`cooldown.exclude` was the first approach and is what the first commit on this
branch does. It removes the confirmed trigger but not the shape of the failure:
any filter that drops the pinned version from the candidate set can produce a
downgrade, and closing a redundant forward PR filters a version the same way
cooldown does.

A pinned version needs a single owner. Excluding it from cooldown keeps the pin
under shared management and only tunes the filter. Ignoring it ends the sharing,
which is what makes a downgrade PR structurally impossible rather than merely
unlikely.

Across 12 releases Dependabot has never produced a useful update for this
input: every PR was a downgrade (#278, #285, #320, #321) or a redundant
catch-up (#286). The pin is raised by hand within hours of each release, so the
lost "you forgot to bump" reminder costs nothing in practice.

The `github-actions` cooldown is untouched. The other first-party input,
`markdown-formatter`, tracks a default branch with no tag, so cooldown can only
hold its locked rev back and never reverse it. It needs no rule.

## Verification

- `pre-commit run --files .github/dependabot.yml` passes, including
  `check-yaml`.

## Related URLs

- https://docs.github.com/code-security/reference/supply-chain-security/dependabot-options-reference#ignore