### PR TITLE
fix(artifacts): make gist delivery contract check Nix-sandbox safe (#325)

### DIFF
--- a/skills/artifacts/scripts/validate-gist-delivery-contract.sh
+++ b/skills/artifacts/scripts/validate-gist-delivery-contract.sh
@@ -45,7 +45,7 @@ run_verifier_fixture() {
     export GIST_EXPECTED_FILES="source.md"
     export ARTIFACTS_GIST_SOURCE="$source_file"
     export ARTIFACTS_GIST_REAL_RG="$real_rg"
-    "$verifier"
+    bash "$verifier"
   )
 }
 
@@ -67,7 +67,7 @@ run_operator_fixture() {
     else
       unset ARTIFACTS_SKILL_ROOT
     fi
-    "${ARTIFACTS_SKILL_ROOT}/scripts/verify-gist-delivery"
+    bash "${ARTIFACTS_SKILL_ROOT}/scripts/verify-gist-delivery"
   )
 }
 


### PR DESCRIPTION
## Summary

- make the Gist-delivery verifier executable in the Nix sandbox
- preserve the documented operator execution path

## Verification

- nix run .#check

Closes #325