### PR TITLE
fix(harness): make grep/rg auto-allow hook durable via Nix

### DIFF
--- a/nix/home-manager/agents/claude/default.nix
+++ b/nix/home-manager/agents/claude/default.nix
@@ -101,6 +101,15 @@ let
           ];
         }
         {
+          matcher = "Bash";
+          hooks = [
+            {
+              type = "command";
+              command = "$CLAUDE_CONFIG_DIR/scripts/claude-pretooluse-allow-safe-grep.sh";
+            }
+          ];
+        }
+        {
           matcher = "Write|Edit|NotebookEdit";
           hooks = [
             {

--- a/nix/home-manager/agents/scripts/claude-pretooluse-allow-safe-grep.sh
+++ b/nix/home-manager/agents/scripts/claude-pretooluse-allow-safe-grep.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash matcher): auto-allow safe, single, read-only
+# grep/rg/ripgrep commands (optionally prefixed by "cd <dir> && ") so they
+# skip the interactive permission prompt. Reviewed and approved by `approver`
+# across 15 adversarial test scenarios; do not weaken any check below without
+# an equivalent re-review -- each one closes a specific chaining/substitution/
+# redirection/background-operator/newline bypass gap.
+
+c=$(jq -r '.tool_input.command // empty')
+[ -z "$c" ] && exit 0
+
+# shellcheck disable=SC2016 # literal substring match, not variable expansion
+case "$c" in
+*';'* | *'|'* | *'`'* | *'$('* | *'<('* | *'>('* | *'<'* | *'>'* | *$'\n'* | *$'\r'*)
+  exit 0
+  ;;
+esac
+
+tmp="${c//&&/}"
+case "$tmp" in
+*'&'*) exit 0 ;;
+esac
+
+amp_count=$(printf '%s' "$c" | grep -o '&&' | wc -l | tr -d ' ')
+rest="$c"
+if [ "$amp_count" = "1" ]; then
+  case "$c" in
+  cd\ *' && '*) rest="${c#*' && '}" ;;
+  *) exit 0 ;;
+  esac
+elif [ "$amp_count" != "0" ]; then
+  exit 0
+fi
+
+case "$rest" in
+grep\ * | grep | rg\ * | rg | ripgrep\ * | ripgrep) : ;;
+*) exit 0 ;;
+esac
+
+lc=$(printf '%s' "$c" | tr '[:upper:]' '[:lower:]')
+case "$lc" in
+*key* | *token* | *secret* | *.env* | *.ssh* | *credential* | *password*) exit 0 ;;
+esac
+
+case "$rest" in
+*'rm '* | *'sudo '* | *'curl '* | *'wget '*) exit 0 ;;
+esac
+
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Auto-allowed: single read-only grep/rg command, no chaining/substitution/redirection, no sensitive-path or risky-construct indicators."}}'
+exit 0


### PR DESCRIPTION
## Summary

Moves the approver-approved grep/rg `PreToolUse` auto-allow hook from a
direct, non-durable edit of `~/.claude/settings.json` into the Nix source
that generates it, so it survives the next `darwin-rebuild switch`.

## Background

`~/.claude/settings.json` is generated from `claudeSettings` in
`nix/home-manager/agents/claude/default.nix` and unconditionally overwritten
by `home.activation`. A prior direct edit to add this hook would be silently
wiped on the next rebuild.

## Changes

- `nix/home-manager/agents/scripts/claude-pretooluse-allow-safe-grep.sh`: new
  script, a straight reformat (inline string -> script file) of the already
  approver-reviewed, 15-scenario-tested command. Logic/ordering unchanged.
- `nix/home-manager/agents/claude/default.nix`: wire the script into
  `claudeSettings.hooks.PreToolUse` as a second `Bash` matcher entry, placed
  after the existing deny-bash entry so its denials still win.

## Status: superseded by #346

Issue #346 ("Implement default-deny/allowlist-only Bash command model", in
progress) folds this same grep/rg logic into a new consolidated
default-deny/allowlist mechanism rather than keeping it as a standalone
script -- per its own scope, preserving the behavior byte-for-byte. This PR
is being opened so the branch/commit history is captured on GitHub per
issue-worktree convention; whether it merges as-is or is closed in favor of
#346 is a call for the repo owner/orchestrator, not made here.

## Verification

- `nix-instantiate --parse nix/home-manager/agents/claude/default.nix`: valid.
- `nix flake check`: all green (pre-commit, treefmt; no rebuild/privilege
  escalation attempted).
- Re-ran the same 15-scenario pipe-test matrix directly against the new
  script file; behavior identical to the previously live inline hook.
- Diffed the script's logic against the inline command (statement-level,
  whitespace/comments normalized): identical.

Not done here (by design): activating this via the elevated
`darwin-rebuild switch` command -- elevated commands are denied for every
agent role; a human runs that themselves.

Closes #342