### PR TITLE
fix(agents): mask heredoc body content before Bash risky-construct scan

### DIFF
--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -427,12 +427,22 @@ mask_heredoc_bodies() {
   local pending="" pending_first=1
   local -a line_delims=()
   local -a fallback_queue=()
-  local fq_word fq_strip fq_compare
+  local fq_word fq_strip fq_quoted fq_compare
   local line_delims_raw line_delim_entry
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [ "${#fallback_queue[@]}" -gt 0 ]; then
-      IFS=$'\t' read -r fq_word fq_strip <<<"${fallback_queue[0]}"
+      # Read all three fields the record carries (word/strip_tabs/quoted).
+      # Reading only two here previously let $fq_strip silently absorb
+      # "strip_tabs<TAB>quoted" as one leftover string (read's last named
+      # variable gets everything remaining) -- a value that can never
+      # equal the literal "1" the check below compares against, so the
+      # leading-tab-stripping for a `<<-` operator's queued delimiter
+      # never activated (guardian finding C5). quoted_flag is unused here
+      # since the fallback never masks regardless of quoting; it must
+      # still be consumed so it does not get folded into fq_strip.
+      # shellcheck disable=SC2034 # fq_quoted deliberately unused: consumed only to keep fq_strip isolated to its own field
+      IFS=$'\t' read -r fq_word fq_strip fq_quoted <<<"${fallback_queue[0]}"
       fq_compare="$line"
       if [ "$fq_strip" = "1" ]; then
         while [ "${fq_compare:0:1}" = $'\t' ]; do

--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -240,9 +240,19 @@ fragment_has_risky_construct() {
 # Detect a heredoc/here-string operator (`<<`, `<<-`) in a single line,
 # outside quotes, that starts a multi-line body -- as opposed to a `<<<`
 # here-string, which is single-line and has no following body. On success,
-# print "<delimiter>\t<strip_tabs_flag>" and return 0; otherwise return 1.
-# Only the first such operator in the line is detected; multiple heredocs on
-# one line is a real but rare bash shape and is out of scope here.
+# print "<delimiter>\t<strip_tabs_flag>\t<quoted_flag>" and return 0;
+# otherwise return 1. Only the first such operator in the line is detected;
+# multiple heredocs on one line is a real but rare bash shape and is out of
+# scope here.
+#
+# <quoted_flag> matters more than it looks: real bash only treats a heredoc
+# BODY as inert literal text when the delimiter word is quoted (single- or
+# double-quoted) or has an escaped character (e.g. `<<\WORD`). An UNQUOTED
+# delimiter (`<<WORD`) means the body undergoes real parameter expansion,
+# command substitution, and backslash processing before the receiving
+# command ever sees it -- a bare `$(...)` or backtick in such a body is live
+# shell syntax, not data. The caller must only mask the body when this flag
+# is 1; an unquoted delimiter must be left fully visible to the scanners.
 # shellcheck disable=SC2329 # invoked indirectly via mask_heredoc_bodies
 detect_heredoc_operator() {
   local line="$1"
@@ -250,7 +260,7 @@ detect_heredoc_operator() {
   local index
   local single_quoted=0 double_quoted=0 escaped=0
   local len=${#line}
-  local run j rest strip_tabs word
+  local run j rest strip_tabs word opener quoted
 
   for ((index = 0; index < len; index++)); do
     char="${line:index:1}"
@@ -297,20 +307,47 @@ detect_heredoc_operator() {
       while [ "${rest:0:1}" = " " ] || [ "${rest:0:1}" = $'\t' ]; do
         rest="${rest:1}"
       done
-      case "${rest:0:1}" in
+
+      opener="${rest:0:1}"
+      word=""
+      # shellcheck disable=SC1003 # the '\' case pattern below matches a single backslash char, not an escape mistake; shfmt's canonical style prefers this quoting over "\\"
+      case "$opener" in
       "'" | '"')
         rest="${rest:1}"
+        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+          word+="${rest:0:1}"
+          rest="${rest:1}"
+        done
+        # Only genuinely quoted -- i.e. the SAME quote character closes the
+        # word -- disables expansion. An unmatched opener (malformed, or not
+        # actually a quote at all) must not be trusted as quoted.
+        if [ -n "$word" ] && [ "${rest:0:1}" = "$opener" ]; then
+          quoted=1
+        else
+          quoted=0
+        fi
+        ;;
+      '\')
+        rest="${rest:1}"
+        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+          word+="${rest:0:1}"
+          rest="${rest:1}"
+        done
+        quoted=1
+        ;;
+      *)
+        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+          word+="${rest:0:1}"
+          rest="${rest:1}"
+        done
+        quoted=0
         ;;
       esac
-      word=""
-      while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
-        word+="${rest:0:1}"
-        rest="${rest:1}"
-      done
+
       if [ -z "$word" ]; then
         return 1
       fi
-      printf '%s\t%s' "$word" "$strip_tabs"
+      printf '%s\t%s\t%s' "$word" "$strip_tabs" "$quoted"
       return 0
     fi
   done
@@ -331,6 +368,27 @@ detect_heredoc_operator() {
 # bare newline as meaningful, so body lines are simply dropped rather than
 # replaced with placeholders -- the surrounding structure (operator line,
 # delimiter line, and anything after) is preserved unchanged.
+#
+# Fail safe, not fail open, on a malformed/unclosed heredoc (issue #355
+# follow-up finding): body lines are buffered rather than dropped
+# immediately. If the closing delimiter is found, the buffer is discarded
+# -- that was a genuine heredoc body and masking it is the whole point. If
+# input ends while still inside the heredoc (no matching delimiter line
+# ever appears), the buffered lines are NOT genuinely known to be inert
+# data -- an unclosed heredoc opener is exactly the shape that could smuggle
+# a risky metacharacter (backtick, `$(`, bare `<`/`>`) past
+# `fragment_has_risky_construct` by hiding it inside what looks like a
+# heredoc body. So on that ambiguous outcome, the buffered lines are
+# appended back to the scanned text instead of being silently discarded:
+# masking must never make the scanned text safer-looking than reality by
+# omission.
+#
+# Only masks when `detect_heredoc_operator` reports a QUOTED delimiter.
+# An unquoted delimiter (`<<WORD`, no quotes or escape) means real bash
+# expands `$(...)`/backticks/`$VAR` inside the body as live syntax before
+# the receiving command ever sees it -- that body is exactly as dangerous
+# as any other command text and must stay fully visible to the scanners,
+# never masked.
 mask_heredoc_bodies() {
   local command_text="$1"
   local line
@@ -339,7 +397,8 @@ mask_heredoc_bodies() {
   local in_heredoc=0
   local strip_tabs=0
   local delimiter=""
-  local detected compare
+  local detected compare delim_word strip_flag quoted_flag
+  local pending="" pending_first=1
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [ "$in_heredoc" -eq 1 ]; then
@@ -351,12 +410,20 @@ mask_heredoc_bodies() {
       fi
       if [ "$compare" = "$delimiter" ]; then
         in_heredoc=0
+        pending=""
+        pending_first=1
         if [ "$first" -eq 1 ]; then
           out="$line"
           first=0
         else out+=$'\n'"$line"; fi
+      else
+        # Buffer rather than drop: appended back below only if the
+        # heredoc turns out never to close.
+        if [ "$pending_first" -eq 1 ]; then
+          pending="$line"
+          pending_first=0
+        else pending+=$'\n'"$line"; fi
       fi
-      # else: this is a body line -- swallow it, do not append.
       continue
     fi
 
@@ -366,11 +433,27 @@ mask_heredoc_bodies() {
     else out+=$'\n'"$line"; fi
 
     if detected="$(detect_heredoc_operator "$line")"; then
-      in_heredoc=1
-      delimiter="${detected%%$'\t'*}"
-      strip_tabs="${detected##*$'\t'}"
+      IFS=$'\t' read -r delim_word strip_flag quoted_flag <<<"$detected"
+      if [ "$quoted_flag" = "1" ]; then
+        in_heredoc=1
+        delimiter="$delim_word"
+        strip_tabs="$strip_flag"
+        pending=""
+        pending_first=1
+      fi
+      # else: unquoted delimiter -- do not mask, leave the body fully
+      # visible to the scanners (real bash expands it as live syntax).
     fi
   done <<<"$command_text"
+
+  if [ "$in_heredoc" -eq 1 ] && [ -n "$pending" ]; then
+    # Heredoc never closed -- do not hide the unmatched trailing lines
+    # from the risky-construct/allow/deny scanners.
+    if [ "$first" -eq 1 ]; then
+      out="$pending"
+      first=0
+    else out+=$'\n'"$pending"; fi
+  fi
 
   printf '%s' "$out"
 }

--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -237,139 +237,42 @@ fragment_has_risky_construct() {
   return 1
 }
 
-# Detect a heredoc/here-string operator (`<<`, `<<-`) in a single line,
-# outside quotes, that starts a multi-line body -- as opposed to a `<<<`
-# here-string, which is single-line and has no following body. On success,
-# print "<delimiter>\t<strip_tabs_flag>\t<quoted_flag>" and return 0;
-# otherwise return 1. Only the first such operator in the line is detected;
-# multiple heredocs on one line is a real but rare bash shape and is out of
-# scope here.
+# Extract EVERY heredoc/here-string-operator delimiter from a single line,
+# outside quotes, in the order the operators appear (bash consumes heredoc
+# bodies in that same order when a line carries more than one, e.g.
+# `cmd <<'A' <<B`). Only genuine two-character `<<`/`<<-` runs open a
+# heredoc; a run of three or more (`<<<`, here-string) is single-line, has
+# no following body, and is skipped -- but scanning CONTINUES past it
+# rather than abandoning the line, because a here-string can be followed
+# later on the same line by a real heredoc operator (round 5 finding: an
+# earlier version of this logic lived in two places -- this whole-line
+# scan, and a since-deleted single-operator function that `return`ed empty
+# handed on a here-string instead of skipping past it. The two recognizers
+# disagreed on exactly this shape, and the call site picked between them by
+# counting delimiters, so a line with one real heredoc plus a preceding
+# here-string got a different, wrong answer depending on which one ran.
+# Collapsing to this single recognizer, used for both the one-delimiter and
+# multi-delimiter cases, removes that class of disagreement entirely).
 #
-# <quoted_flag> matters more than it looks: real bash only treats a heredoc
+# Prints one `word<TAB>strip_tabs_flag<TAB>quoted_flag` line per operator
+# found to stdout (not a nameref array -- `set -o posix` at the top of this
+# script disables `local -n` at runtime).
+#
+# `quoted_flag` matters more than it looks: real bash only treats a heredoc
 # BODY as inert literal text when the delimiter word is quoted (single- or
-# double-quoted) or has an escaped character (e.g. `<<\WORD`). An UNQUOTED
-# delimiter (`<<WORD`) means the body undergoes real parameter expansion,
-# command substitution, and backslash processing before the receiving
-# command ever sees it -- a bare `$(...)` or backtick in such a body is live
-# shell syntax, not data. The caller must only mask the body when this flag
-# is 1; an unquoted delimiter must be left fully visible to the scanners.
-# shellcheck disable=SC2329 # invoked indirectly via mask_heredoc_bodies
-detect_heredoc_operator() {
-  local line="$1"
-  local char
-  local index
-  local single_quoted=0 double_quoted=0 escaped=0
-  local len=${#line}
-  local run j rest strip_tabs word opener quoted
-
-  for ((index = 0; index < len; index++)); do
-    char="${line:index:1}"
-
-    if [ "$escaped" -eq 1 ]; then
-      escaped=0
-      continue
-    fi
-    if [ "$single_quoted" -eq 0 ] && [[ $char == \\ ]]; then
-      escaped=1
-      continue
-    fi
-    if [ "$double_quoted" -eq 0 ] && [ "$char" = "'" ]; then
-      if [ "$single_quoted" -eq 1 ]; then single_quoted=0; else single_quoted=1; fi
-      continue
-    fi
-    if [ "$single_quoted" -eq 0 ] && [ "$char" = '"' ]; then
-      if [ "$double_quoted" -eq 1 ]; then double_quoted=0; else double_quoted=1; fi
-      continue
-    fi
-    if [ "$single_quoted" -eq 1 ] || [ "$double_quoted" -eq 1 ]; then
-      continue
-    fi
-
-    if [ "$char" = "<" ] && [ "${line:index+1:1}" = "<" ]; then
-      run=2
-      j=$((index + 2))
-      while [ "${line:j:1}" = "<" ]; do
-        run=$((run + 1))
-        j=$((j + 1))
-      done
-      if [ "$run" -ne 2 ]; then
-        # `<<<` here-string (or a degenerate longer run): single-line, no
-        # body follows, nothing to mask.
-        return 1
-      fi
-
-      rest="${line:j}"
-      strip_tabs=0
-      if [ "${rest:0:1}" = "-" ]; then
-        strip_tabs=1
-        rest="${rest:1}"
-      fi
-      while [ "${rest:0:1}" = " " ] || [ "${rest:0:1}" = $'\t' ]; do
-        rest="${rest:1}"
-      done
-
-      opener="${rest:0:1}"
-      word=""
-      # shellcheck disable=SC1003 # the '\' case pattern below matches a single backslash char, not an escape mistake; shfmt's canonical style prefers this quoting over "\\"
-      case "$opener" in
-      "'" | '"')
-        rest="${rest:1}"
-        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
-          word+="${rest:0:1}"
-          rest="${rest:1}"
-        done
-        # Only genuinely quoted -- i.e. the SAME quote character closes the
-        # word -- disables expansion. An unmatched opener (malformed, or not
-        # actually a quote at all) must not be trusted as quoted.
-        if [ -n "$word" ] && [ "${rest:0:1}" = "$opener" ]; then
-          quoted=1
-        else
-          quoted=0
-        fi
-        ;;
-      '\')
-        rest="${rest:1}"
-        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
-          word+="${rest:0:1}"
-          rest="${rest:1}"
-        done
-        quoted=1
-        ;;
-      *)
-        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
-          word+="${rest:0:1}"
-          rest="${rest:1}"
-        done
-        quoted=0
-        ;;
-      esac
-
-      if [ -z "$word" ]; then
-        return 1
-      fi
-      printf '%s\t%s\t%s' "$word" "$strip_tabs" "$quoted"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-# Extract EVERY heredoc/here-string-operator delimiter word from a single
-# line, in the order the operators appear (bash consumes heredoc bodies in
-# that same order when a line carries more than one, e.g. `cmd <<'A' <<B`).
-# Only genuine two-character `<<`/`<<-` runs count; `<<<` (here-string) is
-# skipped since it has no following body. Prints one `word<TAB>strip_tabs`
-# line per operator found to stdout (not a nameref array -- `set -o posix`
-# at the top of this script disables `local -n` at runtime); quoting is
-# irrelevant here and intentionally not tracked, because the caller
-# (mask_heredoc_bodies) only consults this when a line has more than one
-# operator, and that shape always falls back to never masking any of them
-# regardless of quoting (see the fallback below).
+# double-quoted, with the SAME quote character closing it) or has an
+# escaped character (e.g. `<<\WORD`). An UNQUOTED delimiter (`<<WORD`)
+# means the body undergoes real parameter expansion, command substitution,
+# and backslash processing before the receiving command ever sees it -- a
+# bare `$(...)` or backtick in such a body is live shell syntax, not data.
+# The caller must only mask a single-delimiter body when this flag is 1;
+# an unquoted delimiter must be left fully visible to the scanners. For a
+# multi-delimiter line, the caller ignores this flag and never masks any of
+# them regardless of quoting (see the fallback in mask_heredoc_bodies).
 # shellcheck disable=SC2329 # invoked indirectly via mask_heredoc_bodies
 extract_heredoc_delimiters() {
   local line="$1"
-  local char index run j rest word strip_tabs
+  local char index run j rest word strip_tabs opener quoted
   local single_quoted=0 double_quoted=0 escaped=0
   local len=${#line}
 
@@ -413,19 +316,45 @@ extract_heredoc_delimiters() {
         while [ "${rest:0:1}" = " " ] || [ "${rest:0:1}" = $'\t' ]; do
           rest="${rest:1}"
         done
+
+        opener="${rest:0:1}"
+        word=""
         # shellcheck disable=SC1003 # the '\' case pattern below matches a single backslash char, not an escape mistake; shfmt's canonical style prefers this quoting over "\\"
-        case "${rest:0:1}" in
-        "'" | '"' | '\')
+        case "$opener" in
+        "'" | '"')
           rest="${rest:1}"
+          while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+            word+="${rest:0:1}"
+            rest="${rest:1}"
+          done
+          # Only genuinely quoted -- i.e. the SAME quote character closes
+          # the word -- disables expansion. An unmatched opener (malformed,
+          # or not actually a quote at all) must not be trusted as quoted.
+          if [ -n "$word" ] && [ "${rest:0:1}" = "$opener" ]; then
+            quoted=1
+          else
+            quoted=0
+          fi
+          ;;
+        '\')
+          rest="${rest:1}"
+          while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+            word+="${rest:0:1}"
+            rest="${rest:1}"
+          done
+          quoted=1
+          ;;
+        *)
+          while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+            word+="${rest:0:1}"
+            rest="${rest:1}"
+          done
+          quoted=0
           ;;
         esac
-        word=""
-        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
-          word+="${rest:0:1}"
-          rest="${rest:1}"
-        done
+
         if [ -n "$word" ]; then
-          printf '%s\t%s\n' "$word" "$strip_tabs"
+          printf '%s\t%s\t%s\n' "$word" "$strip_tabs" "$quoted"
         fi
       fi
       index=$((j - 1))
@@ -461,7 +390,7 @@ extract_heredoc_delimiters() {
 # masking must never make the scanned text safer-looking than reality by
 # omission.
 #
-# Only masks when `detect_heredoc_operator` reports a QUOTED delimiter.
+# Only masks when `extract_heredoc_delimiters` reports a QUOTED delimiter.
 # An unquoted delimiter (`<<WORD`, no quotes or escape) means real bash
 # expands `$(...)`/backticks/`$VAR` inside the body as live syntax before
 # the receiving command ever sees it -- that body is exactly as dangerous
@@ -494,7 +423,7 @@ mask_heredoc_bodies() {
   local masking=0
   local strip_tabs=0
   local delimiter=""
-  local detected compare delim_word strip_flag quoted_flag
+  local compare delim_word strip_flag quoted_flag
   local pending="" pending_first=1
   local -a line_delims=()
   local -a fallback_queue=()
@@ -546,7 +475,7 @@ mask_heredoc_bodies() {
       else
         # Unquoted heredoc: pass the body through unmasked (real bash
         # expands it as live syntax) -- and, critically, do NOT run
-        # detect_heredoc_operator on it. Heredoc extent is tracked
+        # extract_heredoc_delimiters on it. Heredoc extent is tracked
         # unconditionally via `in_span` regardless of quoting; only the
         # MASKING decision depends on the quoted flag. A prior version
         # tracked extent only for quoted delimiters, so an unquoted body
@@ -577,8 +506,8 @@ mask_heredoc_bodies() {
     fi
     if [ "${#line_delims[@]}" -ge 2 ]; then
       fallback_queue=("${line_delims[@]}")
-    elif detected="$(detect_heredoc_operator "$line")"; then
-      IFS=$'\t' read -r delim_word strip_flag quoted_flag <<<"$detected"
+    elif [ "${#line_delims[@]}" -eq 1 ]; then
+      IFS=$'\t' read -r delim_word strip_flag quoted_flag <<<"${line_delims[0]}"
       in_span=1
       delimiter="$delim_word"
       strip_tabs="$strip_flag"

--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -394,14 +394,15 @@ mask_heredoc_bodies() {
   local line
   local out=""
   local first=1
-  local in_heredoc=0
+  local in_span=0
+  local masking=0
   local strip_tabs=0
   local delimiter=""
   local detected compare delim_word strip_flag quoted_flag
   local pending="" pending_first=1
 
   while IFS= read -r line || [ -n "$line" ]; do
-    if [ "$in_heredoc" -eq 1 ]; then
+    if [ "$in_span" -eq 1 ]; then
       compare="$line"
       if [ "$strip_tabs" -eq 1 ]; then
         while [ "${compare:0:1}" = $'\t' ]; do
@@ -409,20 +410,37 @@ mask_heredoc_bodies() {
         done
       fi
       if [ "$compare" = "$delimiter" ]; then
-        in_heredoc=0
+        in_span=0
+        masking=0
         pending=""
         pending_first=1
         if [ "$first" -eq 1 ]; then
           out="$line"
           first=0
         else out+=$'\n'"$line"; fi
-      else
+      elif [ "$masking" -eq 1 ]; then
         # Buffer rather than drop: appended back below only if the
         # heredoc turns out never to close.
         if [ "$pending_first" -eq 1 ]; then
           pending="$line"
           pending_first=0
         else pending+=$'\n'"$line"; fi
+      else
+        # Unquoted heredoc: pass the body through unmasked (real bash
+        # expands it as live syntax) -- and, critically, do NOT run
+        # detect_heredoc_operator on it. Heredoc extent is tracked
+        # unconditionally via `in_span` regardless of quoting; only the
+        # MASKING decision depends on the quoted flag. A prior version
+        # tracked extent only for quoted delimiters, so an unquoted body
+        # line that itself looked like a heredoc opener (e.g. a quoted
+        # `<<'EOF'` appearing as plain body text) was misread as a real
+        # nested opener, and text between that false opener and its false
+        # closer was masked away -- even though it was ordinary body text
+        # bash would expand and the receiving command would see verbatim.
+        if [ "$first" -eq 1 ]; then
+          out="$line"
+          first=0
+        else out+=$'\n'"$line"; fi
       fi
       continue
     fi
@@ -434,19 +452,20 @@ mask_heredoc_bodies() {
 
     if detected="$(detect_heredoc_operator "$line")"; then
       IFS=$'\t' read -r delim_word strip_flag quoted_flag <<<"$detected"
+      in_span=1
+      delimiter="$delim_word"
+      strip_tabs="$strip_flag"
+      pending=""
+      pending_first=1
       if [ "$quoted_flag" = "1" ]; then
-        in_heredoc=1
-        delimiter="$delim_word"
-        strip_tabs="$strip_flag"
-        pending=""
-        pending_first=1
+        masking=1
+      else
+        masking=0
       fi
-      # else: unquoted delimiter -- do not mask, leave the body fully
-      # visible to the scanners (real bash expands it as live syntax).
     fi
   done <<<"$command_text"
 
-  if [ "$in_heredoc" -eq 1 ] && [ -n "$pending" ]; then
+  if [ "$in_span" -eq 1 ] && [ "$masking" -eq 1 ] && [ -n "$pending" ]; then
     # Heredoc never closed -- do not hide the unmatched trailing lines
     # from the risky-construct/allow/deny scanners.
     if [ "$first" -eq 1 ]; then

--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -355,6 +355,84 @@ detect_heredoc_operator() {
   return 1
 }
 
+# Extract EVERY heredoc/here-string-operator delimiter word from a single
+# line, in the order the operators appear (bash consumes heredoc bodies in
+# that same order when a line carries more than one, e.g. `cmd <<'A' <<B`).
+# Only genuine two-character `<<`/`<<-` runs count; `<<<` (here-string) is
+# skipped since it has no following body. Prints one `word<TAB>strip_tabs`
+# line per operator found to stdout (not a nameref array -- `set -o posix`
+# at the top of this script disables `local -n` at runtime); quoting is
+# irrelevant here and intentionally not tracked, because the caller
+# (mask_heredoc_bodies) only consults this when a line has more than one
+# operator, and that shape always falls back to never masking any of them
+# regardless of quoting (see the fallback below).
+# shellcheck disable=SC2329 # invoked indirectly via mask_heredoc_bodies
+extract_heredoc_delimiters() {
+  local line="$1"
+  local char index run j rest word strip_tabs
+  local single_quoted=0 double_quoted=0 escaped=0
+  local len=${#line}
+
+  for ((index = 0; index < len; index++)); do
+    char="${line:index:1}"
+
+    if [ "$escaped" -eq 1 ]; then
+      escaped=0
+      continue
+    fi
+    if [ "$single_quoted" -eq 0 ] && [[ $char == \\ ]]; then
+      escaped=1
+      continue
+    fi
+    if [ "$double_quoted" -eq 0 ] && [ "$char" = "'" ]; then
+      if [ "$single_quoted" -eq 1 ]; then single_quoted=0; else single_quoted=1; fi
+      continue
+    fi
+    if [ "$single_quoted" -eq 0 ] && [ "$char" = '"' ]; then
+      if [ "$double_quoted" -eq 1 ]; then double_quoted=0; else double_quoted=1; fi
+      continue
+    fi
+    if [ "$single_quoted" -eq 1 ] || [ "$double_quoted" -eq 1 ]; then
+      continue
+    fi
+
+    if [ "$char" = "<" ] && [ "${line:index+1:1}" = "<" ]; then
+      run=2
+      j=$((index + 2))
+      while [ "${line:j:1}" = "<" ]; do
+        run=$((run + 1))
+        j=$((j + 1))
+      done
+      if [ "$run" -eq 2 ]; then
+        rest="${line:j}"
+        strip_tabs=0
+        if [ "${rest:0:1}" = "-" ]; then
+          strip_tabs=1
+          rest="${rest:1}"
+        fi
+        while [ "${rest:0:1}" = " " ] || [ "${rest:0:1}" = $'\t' ]; do
+          rest="${rest:1}"
+        done
+        # shellcheck disable=SC1003 # the '\' case pattern below matches a single backslash char, not an escape mistake; shfmt's canonical style prefers this quoting over "\\"
+        case "${rest:0:1}" in
+        "'" | '"' | '\')
+          rest="${rest:1}"
+          ;;
+        esac
+        word=""
+        while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+          word+="${rest:0:1}"
+          rest="${rest:1}"
+        done
+        if [ -n "$word" ]; then
+          printf '%s\t%s\n' "$word" "$strip_tabs"
+        fi
+      fi
+      index=$((j - 1))
+    fi
+  done
+}
+
 # Mask heredoc BODY lines out of a raw (possibly multi-line) command before
 # it reaches the fragment-splitting/risky-construct scanners below. A
 # heredoc body is arbitrary literal data -- postman message text in
@@ -389,6 +467,24 @@ detect_heredoc_operator() {
 # the receiving command ever sees it -- that body is exactly as dangerous
 # as any other command text and must stay fully visible to the scanners,
 # never masked.
+#
+# Multiple heredoc operators on one line (e.g. `cmd <<'A' <<B`) fall back
+# to never masking any of them, rather than trying to track several
+# concurrent pending spans (guardian/critic finding, round 4). The
+# single-span model above closes span-tracking after the FIRST operator's
+# delimiter and then has no memory of the second one at all -- a line after
+# that first close which merely LOOKS like a heredoc opener gets misread as
+# a fresh top-level operator, and text between that false opener and its
+# false close (which is actually still the real second heredoc's body) can
+# be masked away even though it may contain a live substitution. Refusing
+# to mask is a false-denial-safe fallback: every line from the
+# multi-operator line onward, until all of its delimiters are consumed in
+# order, is appended to the scanned text unmodified and never buffered,
+# so nothing can be hidden. Critically, heredoc EXTENT is still tracked via
+# `fallback_queue` for exactly that span -- operator detection is
+# suppressed for those lines, so a body line that looks like an opener
+# cannot restart the single-span tracker and reintroduce the same
+# confusion one level later.
 mask_heredoc_bodies() {
   local command_text="$1"
   local line
@@ -400,8 +496,30 @@ mask_heredoc_bodies() {
   local delimiter=""
   local detected compare delim_word strip_flag quoted_flag
   local pending="" pending_first=1
+  local -a line_delims=()
+  local -a fallback_queue=()
+  local fq_word fq_strip fq_compare
+  local line_delims_raw line_delim_entry
 
   while IFS= read -r line || [ -n "$line" ]; do
+    if [ "${#fallback_queue[@]}" -gt 0 ]; then
+      IFS=$'\t' read -r fq_word fq_strip <<<"${fallback_queue[0]}"
+      fq_compare="$line"
+      if [ "$fq_strip" = "1" ]; then
+        while [ "${fq_compare:0:1}" = $'\t' ]; do
+          fq_compare="${fq_compare:1}"
+        done
+      fi
+      if [ "$fq_compare" = "$fq_word" ]; then
+        fallback_queue=("${fallback_queue[@]:1}")
+      fi
+      if [ "$first" -eq 1 ]; then
+        out="$line"
+        first=0
+      else out+=$'\n'"$line"; fi
+      continue
+    fi
+
     if [ "$in_span" -eq 1 ]; then
       compare="$line"
       if [ "$strip_tabs" -eq 1 ]; then
@@ -450,7 +568,16 @@ mask_heredoc_bodies() {
       first=0
     else out+=$'\n'"$line"; fi
 
-    if detected="$(detect_heredoc_operator "$line")"; then
+    line_delims_raw="$(extract_heredoc_delimiters "$line")"
+    line_delims=()
+    if [ -n "$line_delims_raw" ]; then
+      while IFS= read -r line_delim_entry; do
+        line_delims+=("$line_delim_entry")
+      done <<<"$line_delims_raw"
+    fi
+    if [ "${#line_delims[@]}" -ge 2 ]; then
+      fallback_queue=("${line_delims[@]}")
+    elif detected="$(detect_heredoc_operator "$line")"; then
       IFS=$'\t' read -r delim_word strip_flag quoted_flag <<<"$detected"
       in_span=1
       delimiter="$delim_word"

--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -47,6 +47,15 @@ set -o posix
 #
 # Every deny message also appends a hint to request the command through
 # `tmux-a2a-postman execute-bash` instead of retrying it directly.
+#
+# Before any allow path runs, `mask_heredoc_bodies` strips heredoc BODY
+# lines out of the command text (issue #355). Heredoc bodies are literal
+# data -- postman message text in practice -- not live shell syntax; the
+# earlier #352/#354 fix already exempted the `<<`/`<<-`/`<<<` operator
+# marker itself from `fragment_has_risky_construct`, but left body lines
+# unprotected, so a Markdown-formatted body (backticks, `$(`, bare `<`/`>`)
+# still tripped a false deny before the `tmux-a2a-postman` allow entry was
+# ever consulted.
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PATTERNS_FILE="$SCRIPT_DIR/deny-bash-patterns.sh"
@@ -226,6 +235,144 @@ fragment_has_risky_construct() {
   done
 
   return 1
+}
+
+# Detect a heredoc/here-string operator (`<<`, `<<-`) in a single line,
+# outside quotes, that starts a multi-line body -- as opposed to a `<<<`
+# here-string, which is single-line and has no following body. On success,
+# print "<delimiter>\t<strip_tabs_flag>" and return 0; otherwise return 1.
+# Only the first such operator in the line is detected; multiple heredocs on
+# one line is a real but rare bash shape and is out of scope here.
+# shellcheck disable=SC2329 # invoked indirectly via mask_heredoc_bodies
+detect_heredoc_operator() {
+  local line="$1"
+  local char
+  local index
+  local single_quoted=0 double_quoted=0 escaped=0
+  local len=${#line}
+  local run j rest strip_tabs word
+
+  for ((index = 0; index < len; index++)); do
+    char="${line:index:1}"
+
+    if [ "$escaped" -eq 1 ]; then
+      escaped=0
+      continue
+    fi
+    if [ "$single_quoted" -eq 0 ] && [[ $char == \\ ]]; then
+      escaped=1
+      continue
+    fi
+    if [ "$double_quoted" -eq 0 ] && [ "$char" = "'" ]; then
+      if [ "$single_quoted" -eq 1 ]; then single_quoted=0; else single_quoted=1; fi
+      continue
+    fi
+    if [ "$single_quoted" -eq 0 ] && [ "$char" = '"' ]; then
+      if [ "$double_quoted" -eq 1 ]; then double_quoted=0; else double_quoted=1; fi
+      continue
+    fi
+    if [ "$single_quoted" -eq 1 ] || [ "$double_quoted" -eq 1 ]; then
+      continue
+    fi
+
+    if [ "$char" = "<" ] && [ "${line:index+1:1}" = "<" ]; then
+      run=2
+      j=$((index + 2))
+      while [ "${line:j:1}" = "<" ]; do
+        run=$((run + 1))
+        j=$((j + 1))
+      done
+      if [ "$run" -ne 2 ]; then
+        # `<<<` here-string (or a degenerate longer run): single-line, no
+        # body follows, nothing to mask.
+        return 1
+      fi
+
+      rest="${line:j}"
+      strip_tabs=0
+      if [ "${rest:0:1}" = "-" ]; then
+        strip_tabs=1
+        rest="${rest:1}"
+      fi
+      while [ "${rest:0:1}" = " " ] || [ "${rest:0:1}" = $'\t' ]; do
+        rest="${rest:1}"
+      done
+      case "${rest:0:1}" in
+      "'" | '"')
+        rest="${rest:1}"
+        ;;
+      esac
+      word=""
+      while [[ ${rest:0:1} =~ [A-Za-z0-9_] ]]; do
+        word+="${rest:0:1}"
+        rest="${rest:1}"
+      done
+      if [ -z "$word" ]; then
+        return 1
+      fi
+      printf '%s\t%s' "$word" "$strip_tabs"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Mask heredoc BODY lines out of a raw (possibly multi-line) command before
+# it reaches the fragment-splitting/risky-construct scanners below. A
+# heredoc body is arbitrary literal data -- postman message text in
+# practice -- not live shell syntax: a body line containing a bare
+# backtick, `$(`, `<`, or `>` (extremely common in Markdown-formatted
+# message text) must not be mistaken for a chaining/substitution/
+# redirection attempt. The quote-aware `<<`/`<<<` skip inside
+# fragment_has_risky_construct only protects the operator token itself, not
+# the body lines that follow it, which is exactly the gap this closes.
+# Neither `walk_bash_fragments` nor `fragment_has_risky_construct` treats a
+# bare newline as meaningful, so body lines are simply dropped rather than
+# replaced with placeholders -- the surrounding structure (operator line,
+# delimiter line, and anything after) is preserved unchanged.
+mask_heredoc_bodies() {
+  local command_text="$1"
+  local line
+  local out=""
+  local first=1
+  local in_heredoc=0
+  local strip_tabs=0
+  local delimiter=""
+  local detected compare
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$in_heredoc" -eq 1 ]; then
+      compare="$line"
+      if [ "$strip_tabs" -eq 1 ]; then
+        while [ "${compare:0:1}" = $'\t' ]; do
+          compare="${compare:1}"
+        done
+      fi
+      if [ "$compare" = "$delimiter" ]; then
+        in_heredoc=0
+        if [ "$first" -eq 1 ]; then
+          out="$line"
+          first=0
+        else out+=$'\n'"$line"; fi
+      fi
+      # else: this is a body line -- swallow it, do not append.
+      continue
+    fi
+
+    if [ "$first" -eq 1 ]; then
+      out="$line"
+      first=0
+    else out+=$'\n'"$line"; fi
+
+    if detected="$(detect_heredoc_operator "$line")"; then
+      in_heredoc=1
+      delimiter="${detected%%$'\t'*}"
+      strip_tabs="${detected##*$'\t'}"
+    fi
+  done <<<"$command_text"
+
+  printf '%s' "$out"
 }
 
 emit_deny_payload() {
@@ -516,17 +663,23 @@ check_bash_command_for_denials() {
 
 # ── Decision ───────────────────────────────────────────────────────────
 
-if check_grep_rg_allow "$COMMAND"; then
+# Heredoc body lines are literal data, not live shell syntax -- scan the
+# masked form so a Markdown-formatted message body (backticks, $(...), bare
+# </>) cannot trip the risky-construct guard. The original $COMMAND is kept
+# for the final generic deny message so the agent sees exactly what it sent.
+MASKED_COMMAND="$(mask_heredoc_bodies "$COMMAND")"
+
+if check_grep_rg_allow "$MASKED_COMMAND"; then
   emit_allow_payload "Auto-allowed: single read-only grep/rg command, no chaining/substitution/redirection, no sensitive-path or risky-construct indicators."
   exit 0
 fi
 
-if check_bash_command_for_allow "$COMMAND"; then
+if check_bash_command_for_allow "$MASKED_COMMAND"; then
   emit_allow_payload "Auto-allowed: every part of this command matched the read-only/side-effect-free Bash allowlist."
   exit 0
 fi
 
-if check_bash_command_for_denials "$COMMAND"; then
+if check_bash_command_for_denials "$MASKED_COMMAND"; then
   exit 0
 fi
 

--- a/nix/home-manager/agents/shared/bash-commands-allowed.nix
+++ b/nix/home-manager/agents/shared/bash-commands-allowed.nix
@@ -66,7 +66,7 @@ let
   entries = [
     {
       argv = [ "tmux-a2a-postman" ];
-      note = "The postman CLI is the approval channel itself; requiring approval to use it would be circular. Carries data only in --body/--to and does not execute arbitrary commands (see the shared hook's shell-wrapper unwrap, which still recurses into bash -c/sh -c payloads).";
+      note = "The postman CLI is the approval channel itself; requiring approval to use it would be circular. Does not execute arbitrary commands itself (see the shared hook's shell-wrapper unwrap, which still recurses into bash -c/sh -c payloads). A send-heredoc call's --to/--body-carrying heredoc is shell redirection syntax resolved by bash before the CLI ever receives stdin, not CLI-internal data handling -- the shared hook's mask_heredoc_bodies (issue #355) is what keeps a QUOTED heredoc body (<<'DELIM') inert for this allow entry; an unquoted delimiter (<<DELIM) is deliberately left unmasked and fully scanned, because bash itself expands substitutions inside that body as live syntax.";
     }
     {
       argv = [ "ls" ];

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -478,6 +478,39 @@ alone does not cover:
   suppress it. `<` and `>` lose their special meaning inside either quote
   type, so they are not flagged there.
 
+#### 4.2.5. The #355 Fix: Heredoc BODY Content, Not Just The Marker
+
+Issue #352 and PR #354 exempted the `<<`/`<<-`/`<<<` operator *marker* from
+`fragment_has_risky_construct`, but left the heredoc **body** lines that
+follow it unprotected. Since only `;`, `&`, `|` are top-level fragment
+separators, a heredoc's marker line, body lines, and closing delimiter line
+are all one fragment; the risky-construct char-walk continued scanning body
+lines exactly like command text. A postman message body is Markdown-
+formatted, so it routinely contains a bare backtick (inline code spans), a
+literal `<`/`>`, or `$(...)` -- any one of these in the body denied the
+entire `send-heredoc` call before the `tmux-a2a-postman` `ALLOW_PATTERNS`
+entry was ever consulted, forcing operators back to hand-wrapping every such
+call in `execute-bash --command`.
+
+Issue #355 added `mask_heredoc_bodies` (plus the `detect_heredoc_operator`
+helper), run once on `$COMMAND` before all three allow/deny decision paths.
+It line-scans the raw command, recognizes a `<<`/`<<-` operator (excluding
+`<<<` here-strings, which are single-line and have no body) outside quotes,
+and swallows every following line up to and including the line that matches
+the delimiter (tab-stripped first when the operator was `<<-`), while
+leaving the operator line, the delimiter line, and everything else
+unchanged. The masked command -- not the original -- is what
+`check_grep_rg_allow`, `check_bash_command_for_allow`, and
+`check_bash_command_for_denials` all scan; the original `$COMMAND` is still
+what the final generic deny message shows the agent.
+
+This fix does not change fragment splitting: a bare newline still is not a
+top-level fragment separator. That is a separate, known, pre-existing gap
+(a real command placed on the line immediately after a heredoc's closing
+delimiter is not split into its own fragment, so it inherits whatever allow
+decision the heredoc-bearing fragment gets) and is out of scope for #355 --
+tracked as a follow-up rather than folded into this fix.
+
 ### 4.3. Diplomat Node Status
 
 `diplomat_node` is not part of command approval. It is an open

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -591,6 +591,37 @@ visible rather than masked, and clean text still passes the risky-construct
 scan), while a body that would have been masked-and-hidden under the
 single-span model is now visible and, if genuinely risky, correctly denied.
 
+A fifth, human-authorized round found that the round-4 fix itself had
+introduced exactly the class of bug it was meant to prevent, one level
+removed: two separate functions now answered "does this line open a
+heredoc" -- the round-4 multi-operator scanner (`extract_heredoc_delimiters`)
+and the original single-operator detector -- and they disagreed about a
+here-string. The single-operator detector abandoned the whole line the
+moment it saw a run of three or more unquoted `<` (here-string), while the
+multi-operator scanner correctly skipped past it and kept scanning. A line
+with a here-string followed by exactly one real (unquoted) heredoc
+operator therefore produced one delimiter from the multi-operator scanner
+(not enough to trigger the two-or-more fallback) and simultaneously zero
+delimiters from the single-operator detector (which bailed on the
+here-string before ever reaching the real operator) -- so neither code path
+set up tracking for that heredoc at all, reopening the same nested-
+misdetection bug from the earlier rounds one layer down.
+
+Critic diagnosed the root cause as structural, not shape-specific: the
+whole-line scan already computed a correct answer whenever exactly one
+delimiter existed, then discarded it and re-parsed the same line with the
+older, narrower function -- two recognizers with different semantics
+sitting at the same security boundary, selected by counting delimiters.
+The fix collapses to ONE recognizer: `extract_heredoc_delimiters` now also
+carries the quoted flag per delimiter (previously computed only by the
+now-deleted single-operator function), and `mask_heredoc_bodies` drives
+both branches directly from its output -- exactly one delimiter uses that
+record's word/strip-tabs/quoted fields to set up single-span tracking
+exactly as before; two or more still takes the existing refuse-to-mask
+fallback. With only one function ever deciding what a `<<`/`<<-` run
+means, the two-recognizers-disagree bug class is closed by construction
+rather than by patching the specific disagreement found.
+
 ### 4.3. Diplomat Node Status
 
 `diplomat_node` is not part of command approval. It is an open

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -218,6 +218,25 @@ Claude profile.
 
 ## 4. Shared Policy Versus Runtime-Specific Settings
 
+The governing principle for everything in this section, stated explicitly
+here because the command-approval layer is where it matters most: keep the
+deny/allow design as simple as possible, and keep it common between Codex
+and Claude as much as possible. This is the same principle
+`agent-config-philosophy.md` section 1.2 ("Leverage Shared Configuration")
+argues for at the whole-harness level -- one shared module fed into both
+runtime consumers gives one audit point, forces parity by construction, and
+keeps migration cost low -- restated here because command approval is the
+highest-consequence surface it applies to. Default-deny (section 4.2) is
+one consequence of following this principle, not the principle itself: it
+was chosen because a single explicit allow/deny decision tree is simpler to
+reason about and keep in sync across two runtimes than a default-allow
+model layered with ad hoc exceptions would be. Prefer one shared
+implementation (`pretooluse-deny-bash.sh` plus its generated patterns file)
+over parallel Codex- and Claude-specific logic; add runtime-specific code
+only where the underlying product surfaces genuinely differ (see the table
+below), and treat any proposed divergence as a cost to justify, not a
+default.
+
 | Intent                               | Shared home                                                                          | Runtime-specific home                                                                                                                                            | Current design                                                                                                                                                                                           |
 | ------------------------------------ | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dangerous Bash command denies        | `nix/home-manager/agents/shared/bash-commands-denied.nix`; `pretooluse-deny-bash.sh` | Claude additionally receives selected `permissions.deny` globs for non-bypass permission profiles; Codex receives the shared hook patterns                       | Shared SSOT owns command-deny intent. For the bypass-launched Claude critic, verify the PreToolUse hook separately and do not claim `permissions.deny` enforcement without installed-version evidence.   |

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -569,6 +569,28 @@ redirection is shell syntax resolved before the CLI ever receives stdin,
 not CLI-internal data handling the way the entry's original rationale
 implied.
 
+Guardian and critic found one more shape in a fourth, human-authorized
+review round: a line carrying MORE THAN ONE heredoc operator (for example
+an allowlisted command opening a quoted heredoc and an unquoted one on the
+same line). The single-span tracker above closes span-tracking after the
+FIRST operator's delimiter and then has no memory of the second one at
+all, so a later line that merely looks like a heredoc opener is misread as
+a fresh top-level operator, and text between that false opener and its
+false close -- which is actually still the real second heredoc's live body
+-- can be masked away even though it may contain a substitution bash
+genuinely executes. The fix: when `extract_heredoc_delimiters` finds two or
+more operators on one line, `mask_heredoc_bodies` refuses to mask anything
+opened by that line at all, regardless of quoting, but still tracks extent
+via an ordered queue of the delimiter words in the order bash would
+consume them; operator detection is suppressed for every line in that span
+so nothing can restart the single-span tracker and reintroduce the same
+confusion one level later. This is a false-denial-safe fallback, not an
+attempt to model concurrent heredocs precisely: a legitimate multi-heredoc
+line with benign bodies still allows correctly (the bodies are merely
+visible rather than masked, and clean text still passes the risky-construct
+scan), while a body that would have been masked-and-hidden under the
+single-span model is now visible and, if genuinely risky, correctly denied.
+
 ### 4.3. Diplomat Node Status
 
 `diplomat_node` is not part of command approval. It is an open

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -511,6 +511,45 @@ delimiter is not split into its own fragment, so it inherits whatever allow
 decision the heredoc-bearing fragment gets) and is out of scope for #355 --
 tracked as a follow-up rather than folded into this fix.
 
+Two correctness/security findings from the Tier 1 guardian/critic and
+approver review of the initial #355 implementation (commit `e5ab6500`)
+required a follow-up correction before live activation, both fixed in the
+same PR (#356) before merge:
+
+- **Quoted-vs-unquoted delimiter (guardian G1, high, converged with
+  critic):** real bash only treats a heredoc body as inert literal text
+  when the delimiter word is quoted (`<<'DELIM'`, `<<"DELIM"`) or has an
+  escaped character (`<<\DELIM`) -- an **unquoted** delimiter (`<<DELIM`)
+  means bash performs real parameter expansion, command substitution, and
+  backslash processing on the body before the receiving command ever sees
+  it. The initial implementation masked identically regardless of quoting,
+  so a `$(...)` inside an *unquoted* heredoc body -- correctly denied
+  before issue #355 because the risky-construct scan saw it -- became
+  auto-allowed, and bash would have evaluated the substitution for real.
+  `detect_heredoc_operator` now reports whether the delimiter was
+  genuinely quoted (matching closing quote required, not just a leading
+  quote character) or backslash-escaped; `mask_heredoc_bodies` only enters
+  masking mode when that flag is set. An unquoted heredoc's body is left
+  completely unmasked and fully visible to every scanner, exactly as if
+  that issue's fix had never shipped.
+- **Unclosed heredoc (approver, separately confirmed by guardian):** if a
+  detected (quoted) heredoc opener never finds its matching closing
+  delimiter line before the command text ends, the initial implementation
+  silently dropped every buffered body line -- hiding a genuinely dangerous
+  trailing line (one containing a live backtick/`$(`/bare `<`/`>`) from
+  `fragment_has_risky_construct` entirely. `mask_heredoc_bodies` now
+  buffers body lines rather than dropping them immediately, discards the
+  buffer only on a confirmed matching close, and appends the buffer back
+  onto the scanned text if the loop ends while still inside the heredoc --
+  fail safe (scan more) rather than fail open (scan less) on this
+  ambiguous shape.
+
+The `tmux-a2a-postman` entry in `bash-commands-allowed.nix` documents this
+quoted-only masking behavior directly (guardian G6), since heredoc
+redirection is shell syntax resolved before the CLI ever receives stdin,
+not CLI-internal data handling the way the entry's original rationale
+implied.
+
 ### 4.3. Diplomat Node Status
 
 `diplomat_node` is not part of command approval. It is an open


### PR DESCRIPTION
## Summary

Closes #355.

PR #354 (closing #352) exempted the `<<`/`<<-`/`<<<` heredoc/here-string *operator marker* from `fragment_has_risky_construct`, but left heredoc **body** lines that follow it unprotected. Since only `;`/`&`/`|` are top-level fragment separators, a `send-heredoc` call's marker, body, and closing delimiter are all scanned as one fragment. Any body line containing a bare backtick, `$(...)`, `<`, or `>` -- extremely common in Markdown-formatted postman message text -- denied the entire command before the `tmux-a2a-postman` allow entry was ever consulted, forcing operators to hand-wrap every such call in `execute-bash --command`.

## Changes

- Add `mask_heredoc_bodies` + `detect_heredoc_operator` helper to `nix/home-manager/agents/scripts/pretooluse-deny-bash.sh`. Applied to the command before all three allow/deny decision paths. Recognizes a `<<`/`<<-` operator (excluding `<<<` here-strings, which are single-line with no body) outside quotes, and swallows body lines up to the matching delimiter line. Operator/delimiter lines and everything else pass through unchanged; the final generic deny message still shows the original, unmasked command.
- Document the fix and an explicitly out-of-scope, pre-existing related gap (bare newline is not a top-level fragment separator) in `skills/dotfiles/references/agent-command-approval-design.md` section 4.2.5.

Single shared-source fix -- both Claude and Codex install the identical script (Codex symlinks it in `codex/default.nix`), so no separate Codex-side change is needed.

## Verification

- `shellcheck` and `bash -n`: clean.
- `nix fmt` applied; `nix flake check`: all checks passed.
- Functional test harness sourcing the real hook script against the real installed `deny-bash-patterns.sh`, feeding crafted PreToolUse JSON payloads: 8/8 pass --
  - heredoc body with bare `<`, backtick, and `$(...)` all now **allow**
  - genuinely dangerous `$(rm -rf /)` and bare `<` *outside* any heredoc still **deny**
  - here-strings (`<<<`) unaffected (**allow**)
  - existing plain-allowlist and deny-pattern commands unchanged
- Before/after pair on the primary repro case using the pre-fix script extracted via `git show HEAD:...`: **deny** before this change, **allow** after.

## Related

Refs #352, #354