### PR TITLE
fix(agents): split top-level bare newlines as fragment separators

### DIFF
--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -414,6 +414,19 @@ extract_heredoc_delimiters() {
 # suppressed for those lines, so a body line that looks like an opener
 # cannot restart the single-span tracker and reintroduce the same
 # confusion one level later.
+#
+# Also rewrites a bare newline between two TOP-LEVEL lines into a `;`
+# (issue #358). Real bash treats such a newline as a statement separator,
+# exactly like `;` -- but `walk_bash_fragments` (and its duplicate in
+# check_bash_command_for_denials) never did, so a live, non-allowlisted
+# command placed on the line right after a heredoc's closing delimiter was
+# scanned as part of the SAME fragment as the heredoc-bearing prefix, and
+# inherited whatever allow decision that prefix's leading token earned.
+# Newlines strictly inside a heredoc span (an operator line through its own
+# delimiter line inclusive, regardless of quoting, and every line still
+# covered by `fallback_queue`) are left as plain newlines, since that is
+# one syntactic unit from bash's perspective, not two statements; only a
+# newline between genuinely separate top-level lines becomes `;`.
 mask_heredoc_bodies() {
   local command_text="$1"
   local line
@@ -505,7 +518,7 @@ mask_heredoc_bodies() {
     if [ "$first" -eq 1 ]; then
       out="$line"
       first=0
-    else out+=$'\n'"$line"; fi
+    else out+=';'"$line"; fi
 
     line_delims_raw="$(extract_heredoc_delimiters "$line")"
     line_delims=()

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -622,6 +622,56 @@ fallback. With only one function ever deciding what a `<<`/`<<-` run
 means, the two-recognizers-disagree bug class is closed by construction
 rather than by patching the specific disagreement found.
 
+A post-approval finding (guardian, minor, landed before merge) affected
+only the multi-operator fallback's queue: popping the front entry read
+just two of the three tab-separated fields (`word`, `strip_tabs`) that
+`extract_heredoc_delimiters` prints, so bash's `read` folded the third
+field (`quoted`) into the second, leaving the strip-tabs value a string
+that could never equal the literal comparison it was checked against.
+This silently disabled leading-tab stripping for a queued `<<-`
+delimiter's closing line, which could leave the queue permanently
+non-empty and keep later, otherwise-maskable heredocs stuck visible. Fixed
+by reading all three fields; the regression case is built so the final
+allow/deny verdict only matches expectation when the queue pop actually
+succeeds, not merely when a superficially similar case happens to pass
+either way.
+
+#### 4.2.6. Issue #358: A Live Command Right After A Closing Delimiter
+
+Guardian finding G9, filed as a distinct follow-up issue rather than
+folded into the #355/#356 work in progress, to avoid overlapping edits on
+the same file mid-review: `pretooluse-deny-bash.sh` only ever treated `;`,
+`&`, and `|` as top-level fragment separators (see `walk_bash_fragments`
+and the duplicate splitting loop inside `check_bash_command_for_denials`).
+A bare newline was never one, even outside any heredoc, though real bash
+treats a bare newline outside a heredoc body as a statement separator
+equivalent to `;`. A command shaped like an allowlisted-prefix command
+that opens a heredoc, followed on a *later* line -- after the heredoc's
+own closing delimiter -- by a completely different, non-allowlisted,
+genuinely dangerous command, was scanned as a single fragment; because the
+leading token still matched an `ALLOW_PATTERNS` entry, the entire fragment
+was allowed, trailing dangerous command included.
+
+`mask_heredoc_bodies` now rewrites a bare newline between two top-level
+lines into `;` as it builds the scanned text (in the same top-level branch
+that calls `extract_heredoc_delimiters`), reusing the heredoc-extent
+tracking already in place from the #355/#356 rounds above: a newline
+strictly inside a heredoc span (between an operator line and its own
+delimiter line, inclusive, regardless of quoting, and including every line
+still covered by the multi-operator `fallback_queue`) stays a plain
+newline, since that is one syntactic unit from bash's perspective and
+splitting it would produce a bare delimiter-word fragment that matches no
+`ALLOW_PATTERNS` entry, breaking every legitimate heredoc-bearing command.
+Only a newline between genuinely separate top-level lines becomes a real
+separator. No change was needed to `walk_bash_fragments`,
+`check_bash_command_for_allow`, or `check_bash_command_for_denials`: they
+already split correctly on `;`, so injecting real semicolons at genuine
+statement boundaries is sufficient for the existing fragment-by-fragment
+allow/deny logic to isolate and independently evaluate a trailing command
+that previously inherited its predecessor's allow decision. This also
+generalizes correctly to ordinary multi-line commands with no heredoc at
+all, which were subject to the same gap.
+
 ### 4.3. Diplomat Node Status
 
 `diplomat_node` is not part of command approval. It is an open


### PR DESCRIPTION
fix(agents): split top-level bare newlines as fragment separators

Summary
Guardian finding G9, filed as issue #358 and explicitly sequenced after
the #355/#356 rework landed to avoid overlapping edits on the same file.
pretooluse-deny-bash.sh only ever treated `;`, `&`, and `|` as top-level
fragment separators (walk_bash_fragments, and its duplicate splitting
loop inside check_bash_command_for_denials). A bare newline was never
one, even outside any heredoc, though real bash treats a bare newline
outside a heredoc body as a statement separator equivalent to `;`. A
command shaped like an allowlisted-prefix command that opens a heredoc,
followed on a later line -- after the heredoc's own closing delimiter --
by a completely different, non-allowlisted, genuinely dangerous command,
was scanned as a single fragment; because the leading token still matched
an ALLOW_PATTERNS entry, the entire fragment was allowed, trailing
dangerous command included.

Fix
mask_heredoc_bodies now rewrites a bare newline between two top-level
lines into `;` as it builds the scanned text, in the same top-level
branch that calls extract_heredoc_delimiters. This reuses the
heredoc-extent tracking already built for the #355/#356 rounds: a newline
strictly inside a heredoc span (an operator line through its own
delimiter line inclusive, regardless of quoting, and every line still
covered by the multi-operator fallback_queue) stays a plain newline,
since that is one syntactic unit from bash's perspective and splitting it
would produce a bare delimiter-word fragment matching no ALLOW_PATTERNS
entry, breaking every legitimate heredoc-bearing command. Only a newline
between genuinely separate top-level lines becomes a real separator. No
change was needed to walk_bash_fragments, check_bash_command_for_allow,
or check_bash_command_for_denials: they already split correctly on `;`,
so injecting real semicolons at genuine statement boundaries is
sufficient for the existing fragment-by-fragment allow/deny logic to
isolate and independently evaluate a trailing command that previously
inherited its predecessor's allow decision. This also generalizes
correctly to ordinary multi-line commands with no heredoc at all, which
were subject to the same gap.

This branch was reset onto the merged main (b0a97795, PR #356 plus the
post-approval C5 fix) before reapplying this fix, since the functions it
touches were substantially rewritten across five review rounds after this
branch was first started.

Changes
- nix/home-manager/agents/scripts/pretooluse-deny-bash.sh:
  mask_heredoc_bodies's top-level line-append now uses `;` instead of a
  literal newline as the joiner.
- skills/dotfiles/references/agent-command-approval-design.md: added
  section 4.2.6 documenting the finding and fix.

Verification
- bash -n and shellcheck clean.
- nix fmt applied; nix flake check: all checks passed.
- Functional test harness: all 5 G9-specific cases now pass (previously
  expected-fail on the pre-#358 branch), alongside all rounds 1-5 and C5
  cases (36/36 total).

Refs #358, #355, #356, #352, #354

Closes #358