### PR TITLE
docs(agents): remove remaining SUBDIR references

### DIFF
--- a/config/tmux-a2a-postman/postman.md
+++ b/config/tmux-a2a-postman/postman.md
@@ -61,9 +61,8 @@ Hard gates:
 - Before editing files, verify the target path is writable and respect issue
   worktree safety; stop if an issue branch tracks a shared base.
 - Non-worker roles must not mutate repository files. This is a role contract,
-  not a current runtime hook guarantee; `${SUBDIR}` is not an exception. Every
-  role must follow this contract even when a runtime can technically write to
-  the path.
+  not a current runtime hook guarantee. Every role must follow this contract
+  even when a runtime can technically write to the path.
 - Do not write to, modify, or delete production data without explicit human
   approval at the time of execution.
 - Public and permanent GitHub surfaces must use repo-relative paths or stable

--- a/skills/dotfiles/references/agent-command-approval-design.md
+++ b/skills/dotfiles/references/agent-command-approval-design.md
@@ -39,14 +39,13 @@ The tmux/vde launcher is the highest-precedence behavior for active panes.
 Today `config/vde/layout.yml` starts Codex panes with:
 
 ```sh
-codex --yolo --add-dir "${SUBDIR}" --model gpt-5.5 --config model_reasoning_effort=xhigh
+codex --yolo --model gpt-5.5 --config model_reasoning_effort=xhigh
 ```
 
 It starts the Claude critic pane with:
 
 ```sh
 claude --allow-dangerously-skip-permissions --dangerously-skip-permissions \
-  --add-dir "${SUBDIR}" \
   --model "opus[1m]" --effort xhigh
 ```
 
@@ -55,9 +54,7 @@ approval prompts and permission-layer prompts are mostly bypassed at launch
 time. Repo-managed PreToolUse hooks are a separate configured guardrail layer
 from runtime permission rules. This design does not count Claude
 `permissions.deny` rules as active for the bypass-launched critic pane unless
-a version-specific verification proves that behavior. The `--add-dir` value
-extends the workspace surface for each session. The exact extra directory is
-chosen by the vde session environment, not by Home Manager agent config.
+a version-specific verification proves that behavior.
 
 The current local tool versions observed during the 2026-07-14 refresh were
 `codex-cli 0.144.3` and `Claude Code 2.1.207`.
@@ -167,12 +164,11 @@ that a specific deny rule still applies in bypass mode.
 
 ### 3.2. Launch Mode And Hooks
 
-The vde launcher starts the Claude critic pane with the two bypass flags
-followed by `--add-dir "${SUBDIR}"`. The allow flag makes bypass mode
-selectable, and the dangerous skip flag selects it. That suppresses normal
-permission prompts and, per the installed help, bypasses permission checks for
-that pane. Do not use the current critic launch as evidence that
-`permissions.deny` is enforced.
+The vde launcher starts the Claude critic pane with the two bypass flags. The
+allow flag makes bypass mode selectable, and the dangerous skip flag selects
+it. That suppresses normal permission prompts and, per the installed help,
+bypasses permission checks for that pane. Do not use the current critic
+launch as evidence that `permissions.deny` is enforced.
 
 The repo configures these Claude hooks:
 

--- a/skills/dotfiles/references/workspace-vde-layout-internals.md
+++ b/skills/dotfiles/references/workspace-vde-layout-internals.md
@@ -22,9 +22,8 @@ Short reference for vde-layout config resolution and preset structure.
 
 ## 3. Key Behavioral Notes
 
-- `${SUBDIR}` in command strings is NOT interpolated by vde-layout — it is
-  passed as-is to `tmux send-keys` and expanded by the destination pane's shell
+- Env var references in command strings are NOT interpolated by vde-layout —
+  they are passed as-is to `tmux send-keys` and expanded by the destination
+  pane's shell
 - `delay` field (ms) is honored before sending agent command per pane
 - Pane title set via `tmux select-pane -T <title>` after split-window
-- No `env:` keys are used in the current layout.yml — `$SUBDIR` expansion relies
-  on shell environment


### PR DESCRIPTION
## Summary
Remove the last `SUBDIR` references from `postman.md` and two skill reference docs, correcting doc text that described launch commands no longer present in `config/vde/layout.yml`.

## Background
The active `SUBDIR`/`--add-dir` launcher wiring was already removed from `config/vde/layout.yml` in commit `b659a884`. PR #363 subsequently removed the two hook scripts that still referenced `SUBDIR`. This closes out the remaining doc-only references.

## Changes
- `config/tmux-a2a-postman/postman.md`: drop the `SUBDIR` exception clause from the non-worker-mutation hard gate; the sentence still holds without it.
- `skills/dotfiles/references/agent-command-approval-design.md`: drop `--add-dir "${SUBDIR}"` from the current Codex/Claude critic launch command examples and the now-false `--add-dir` explanation paragraph, since no pane in `layout.yml` passes `--add-dir` anymore.
- `skills/dotfiles/references/workspace-vde-layout-internals.md`: generalize the env-var-interpolation behavioral note away from the `SUBDIR` example and drop the now-moot `$SUBDIR` expansion bullet.

## Verification
- `rg -n SUBDIR .` on the branch: no hits remain.
- Reviewed the full diff of each edited file for correctness.
- Local `pre-commit` hooks (markdown-formatter, rumdl-check, treefmt, etc.) passed on commit.

Closes #364
