### PR TITLE
fix(agents): deny secret-keyword arguments for cat/head/tail/wc/sort/uniq/cut

### DIFF
--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -628,6 +628,46 @@ check_grep_rg_allow() {
   return 0
 }
 
+# File-content-reading commands on ALLOW_PATTERNS (bash-commands-allowed.nix)
+# that take an arbitrary path argument with no argument-level check at all
+# (unlike grep/rg/ripgrep, which already reject secret-shaped matches via
+# check_grep_rg_allow below) -- `cat .env`, `head ~/.ssh/id_rsa`,
+# `tail some/secrets/api.key`, and the same shape for wc/sort/uniq/cut, would
+# otherwise be allowed through unconditionally (issue #365). Intentionally
+# excludes `ls` (lists filenames only, does not dump file content) and
+# `echo`/`date`/`whoami`/`which` (do not read files at all).
+SECRET_ARGUMENT_SENSITIVE_COMMANDS=(cat head tail wc sort uniq cut)
+
+# Duplicated, not shared with check_grep_rg_allow's keyword case statement:
+# that function is already approver-reviewed (twice, issue #342) and is kept
+# untouched here to avoid re-opening review on tested logic. Keep this list
+# in sync with check_grep_rg_allow's keyword case by hand if either changes.
+# shellcheck disable=SC2329 # invoked indirectly via check_bash_fragment_for_allow
+fragment_has_secret_keyword() {
+  local fragment="$1"
+  local lc
+  lc=$(printf '%s' "$fragment" | tr '[:upper:]' '[:lower:]')
+  case "$lc" in
+  *key* | *token* | *secret* | *.env* | *.ssh* | *credential* | *password*)
+    return 0
+    ;;
+  esac
+  return 1
+}
+
+# shellcheck disable=SC2329 # invoked indirectly via check_bash_fragment_for_allow
+command_is_secret_argument_sensitive() {
+  local fragment="$1"
+  local leading_word="${fragment%%[[:space:]]*}"
+  local cmd
+  for cmd in "${SECRET_ARGUMENT_SENSITIVE_COMMANDS[@]}"; do
+    if [ "$leading_word" = "$cmd" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 # shellcheck disable=SC2329 # invoked indirectly via walk_bash_fragments
 check_bash_fragment_for_allow() {
   local fragment="$1"
@@ -648,6 +688,10 @@ check_bash_fragment_for_allow() {
   fi
 
   if fragment_has_risky_construct "$fragment"; then
+    return 1
+  fi
+
+  if command_is_secret_argument_sensitive "$fragment" && fragment_has_secret_keyword "$fragment"; then
     return 1
   fi
 

--- a/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
+++ b/nix/home-manager/agents/scripts/pretooluse-deny-bash.sh
@@ -640,19 +640,43 @@ SECRET_ARGUMENT_SENSITIVE_COMMANDS=(cat head tail wc sort uniq cut)
 
 # Duplicated, not shared with check_grep_rg_allow's keyword case statement:
 # that function is already approver-reviewed (twice, issue #342) and is kept
-# untouched here to avoid re-opening review on tested logic. Keep this list
-# in sync with check_grep_rg_allow's keyword case by hand if either changes.
+# untouched here to avoid re-opening review on tested logic (its bare-
+# substring matching has the same false-positive class fixed below, but
+# fixing it is out of scope for this issue -- tracked separately).
+#
+# Word/path-segment anchored, NOT bare substring: a bare `*key*`-style glob
+# denied ordinary non-secret paths purely because the word "key" or ".env"
+# appeared as a substring (e.g. `cat config/zsh/keybind.zsh`, `cat .envrc`,
+# `cat .env.example`), which is exactly what issue #365's own acceptance
+# criterion says must stay allowed. key/token/secret(s)/credential(s)/
+# password must appear as a whole word (bounded by start/end-of-string or a
+# non-alnum/non-underscore character on both sides; `secrets?`/`credentials?`
+# so a `secrets/`- or `credentials/`-named directory still matches).
+# `.env` and `.ssh` are anchored to a path segment (start-of-string/space/`/`
+# on the left, and on the right either the same set, end-of-string, or a
+# literal `.` so `.env.local`/`.env.production` still match) rather than a
+# bare substring, and `.envrc`/`.env.example` are stripped out before the
+# test runs so they cannot match at all -- `.envrc` is a direnv config file,
+# not a secret store, and `.env.example` is a placeholder template committed
+# to the repo, not real secret values.
 # shellcheck disable=SC2329 # invoked indirectly via check_bash_fragment_for_allow
 fragment_has_secret_keyword() {
   local fragment="$1"
   local lc
+  local regex
   lc=$(printf '%s' "$fragment" | tr '[:upper:]' '[:lower:]')
-  case "$lc" in
-  *key* | *token* | *secret* | *.env* | *.ssh* | *credential* | *password*)
-    return 0
-    ;;
-  esac
-  return 1
+
+  # Known non-secret filenames that would otherwise match the `.env`
+  # path-segment check below; strip them so their mere presence cannot
+  # trigger a false positive.
+  lc="${lc//.envrc/}"
+  lc="${lc//.env.example/}"
+
+  regex='(^|[^[:alnum:]_])(key|token|secrets?|credentials?|password)([^[:alnum:]_]|$)'
+  regex+='|(^|[[:space:]/])\.env([[:space:]/]|$|\.[^[:space:]/]*)'
+  regex+='|(^|[[:space:]/])\.ssh([[:space:]/]|$)'
+
+  [[ $lc =~ $regex ]]
 }
 
 # shellcheck disable=SC2329 # invoked indirectly via check_bash_fragment_for_allow
@@ -692,7 +716,8 @@ check_bash_fragment_for_allow() {
   fi
 
   if command_is_secret_argument_sensitive "$fragment" && fragment_has_secret_keyword "$fragment"; then
-    return 1
+    emit_deny_payload "$fragment" "secret-shaped path argument (key/token/secret(s)/credential(s)/password/.env/.ssh) to a file-reading command (cat/head/tail/wc/sort/uniq/cut). If this path is not actually secret, request it via tmux-a2a-postman execute-bash instead of retrying directly."
+    exit 0
   fi
 
   original_fragment="$fragment"


### PR DESCRIPTION
fix(agents): deny secret-keyword arguments for cat/head/tail/wc/sort/uniq/cut (#365)

## Summary

grep/rg/ripgrep already have a dedicated procedural check
(check_grep_rg_allow) that rejects matches on key/token/secret/.env/.ssh/
credential/password-shaped command text. cat/head/tail/wc/sort/uniq/cut
are also on the shared Bash allowlist (bash-commands-allowed.nix) but had
no equivalent check, so `cat .env`, `head ~/.ssh/id_rsa`, or
`wc -l some/secrets/api.key` were allowed through unconditionally.

## Changes

- nix/home-manager/agents/scripts/pretooluse-deny-bash.sh: added
  fragment_has_secret_keyword and command_is_secret_argument_sensitive,
  wired into check_bash_fragment_for_allow right after the existing
  risky-construct check. If a fragment's leading command is one of
  cat/head/tail/wc/sort/uniq/cut AND the fragment text contains a
  secret-shaped keyword, it is rejected before reaching ALLOW_PATTERNS,
  falling through to the normal deny path.

Deliberately left check_grep_rg_allow untouched (already approver-reviewed
twice, issue #342) rather than refactoring it to share the keyword list --
the two keyword lists are duplicated intentionally to avoid re-opening
review on already-hardened logic. `ls` was intentionally excluded (lists
filenames only, doesn't dump content); so were echo/date/whoami/which
(don't read files at all).

## Verification

- Unit-tested the script directly with 12 synthetic payloads (real JSON
  shape, piped through the actual script): deny on cat/head/tail/wc/cut
  against .env/~/.ssh/secrets-dir/*.key paths; allow on the same commands
  against ordinary files; ls against .env correctly still allowed; grep/rg
  behavior unchanged; a compound `cat README.md ; cat .env` correctly
  denied overall.
- nix flake check: all checks passed (shellcheck, treefmt, pre-commit).

Applies identically to Claude Code and Codex CLI (shared script, byte-
identical for both runtimes).
