### PR TITLE
fix(agents): remove Claude's Read/Edit secret-path permissions.deny (protection-loss tradeoff)

### DIFF
--- a/nix/home-manager/agents/claude/default.nix
+++ b/nix/home-manager/agents/claude/default.nix
@@ -96,20 +96,31 @@ let
     language = "English";
     outputStyle = "Explanatory";
     permissions = {
-      deny = deniedBash.claudeCode.denyPermissions ++ [
-        # v2.1.200 made AskUserQuestion dialogs no longer auto-continue by
-        # default, so in headless / tmux-a2a-postman panes a question stalls
-        # the turn indefinitely with no human to answer. Deny the tool so the
-        # agent proceeds on its own judgement instead.
-        # (see claude-optimization-tracking.md §1.1)
-        "AskUserQuestion"
-        "Read(**/*key*)"
-        "Read(**/*token*)"
-        "Read(.env*)"
-        "Read(~/.ssh/**)"
-        "Edit(**/secrets/**)"
-        "Edit(.env*)"
-      ];
+      # Read/Edit-scoped secret-path deny entries (Read(**/*key*),
+      # Read(**/*token*), Read(.env*), Read(~/.ssh/**), Edit(**/secrets/**),
+      # Edit(.env*)) were deliberately removed here (issue #362). This is a
+      # confirmed protection-loss tradeoff, not dead-code cleanup: live
+      # testing in-session and current Claude Code documentation/changelog
+      # both confirmed this Read/Edit-tool-level enforcement is still
+      # active as of this change. It was removed anyway, by explicit
+      # informed user decision, in favor of relying solely on the shared
+      # Bash-hook layer (pretooluse-deny-bash.sh, byte-identical across
+      # Claude Code and Codex CLI) for command-level protection -- matching
+      # #363's direction of keeping this surface Bash-deny-only rather than
+      # adding a Codex-side enforcing write hook with no Claude equivalent.
+      # v2.1.200 made AskUserQuestion dialogs no longer auto-continue by
+      # default, so in headless / tmux-a2a-postman panes a question stalls
+      # the turn indefinitely with no human to answer. Denying the tool made
+      # the agent proceed on its own judgement instead.
+      # (see claude-optimization-tracking.md §1.1)
+      # Commented out (not deleted) per issue #362 follow-up instruction: a
+      # deliberate wait-and-see safety margin, user-confirmed -- if nothing
+      # breaks with it disabled, it will be deleted outright in a later
+      # pass. NOTE: disabling this reintroduces the exact headless/postman
+      # stall this entry existed to prevent; unrelated to #362's actual
+      # scope (Read/Edit secret-path deny).
+      # deny = deniedBash.claudeCode.denyPermissions ++ [ "AskUserQuestion" ];
+      deny = deniedBash.claudeCode.denyPermissions;
     };
     showThinkingSummaries = true;
   };


### PR DESCRIPTION
fix(agents): remove Claude's redundant Read/Edit secret-path permissions.deny (#362)

## Summary

Narrows this PR to only the part of #362 that does not conflict with
#363's direction (keep the shared Bash-deny surface as the single
cross-runtime protection layer rather than adding a Codex-only enforcing
write hook). This supersedes the earlier version of this PR, which also
added a new Codex `apply_patch` write-hook and a shared
secret-path-patterns.nix SSOT; both are dropped here per explicit user
decision after #363 merged and removed the equivalent write-tool hook
infrastructure this PR had been building on.

## Changes

- claude/default.nix: removed the Read/Edit secret-path `permissions.deny`
  entries (Read(**/*key*), Read(**/*token*), Read(.env*), Read(~/.ssh/**),
  Edit(**/secrets/**), Edit(.env*)). This is a confirmed protection-loss
  tradeoff, not dead-code cleanup -- live in-session testing and current
  Claude Code documentation/changelog both confirmed this Read/Edit-tool-
  level enforcement is still active. Removed anyway by explicit user
  decision, favoring the shared Bash-hook layer alone (already
  byte-identical across Claude Code and Codex CLI) over a Claude-only
  native mechanism with no Codex equivalent -- consistent with #363's
  removal of the analogous Codex/Claude write-tool hooks.
- Also commented out (not deleted) the pre-existing `AskUserQuestion`
  permissions.deny entry, per explicit user-confirmed wait-and-see
  instruction; unrelated to #362's scope, kept as a documented comment.

## Dropped from the earlier version of this PR

- The new Codex `apply_patch` enforcing write hook
  (codex-pretooluse-deny-write.sh) and its codex/default.nix wiring:
  conflicted with #363's removal of the equivalent Claude/Codex write-tool
  hook infrastructure, and the user chose to keep #363's Bash-deny-only
  direction instead.
- shared/secret-path-patterns.nix: built as the SSOT feeding both the
  now-dropped Codex hook and the Claude Read/Edit deny entries. With both
  consumers gone (the Read/Edit entries are deleted outright here, not
  regenerated from this module), it has zero remaining importers, so it
  is dropped rather than kept as unused scaffolding.

## Verification

- nix-instantiate --parse on the touched file: OK.
- nix flake check: all checks passed (pre-commit + treefmt), rebased onto
  current main (post-#363, post-#365, post-#366, post-#367, post-#369).
