### PR TITLE
docs(agents): document that agents must not run nix run '.#switch' themselves

### DIFF
--- a/skills/dotfiles/references/nix-operations.md
+++ b/skills/dotfiles/references/nix-operations.md
@@ -8,6 +8,18 @@
 | `nix run '.#update'` | Update flake inputs                                                                                                                                                                                              |
 | `nix run '.#check'`  | Check flake configuration                                                                                                                                                                                        |
 
+**Agents must not run `nix run '.#switch'` (or any other system activation
+command) themselves.** On macOS this triggers an interactive `sudo` password
+prompt that no automated agent can supply -- both direct execution and the
+postman `execute-bash` approval lane hang or must be cancelled at the
+prompt, and the activation never completes. This is not merely a permission
+gap to route around; the human running the switch is a durable part of the
+workflow. When a task needs the merged changes live on a machine, hand
+activation off explicitly (e.g. `BLOCKED: awaiting human to run
+nix run '.#switch'` to orchestrator, or ask the human directly outside
+postman) and verify the outcome afterward instead -- do not attempt the
+switch, and do not treat a cancelled/hung attempt as something to retry.
+
 One-off host repair helpers are kept as explicit scripts rather than flake
 apps. For Ubuntu root LVM expansion, run from the dotfiles repository root:
 


### PR DESCRIPTION
docs(agents): document that agents must not run nix run '.#switch' themselves (#369)

## Summary

Agents have twice attempted `nix run '.#switch'` (system activation)
directly this session, both times stalling on an interactive `sudo`
password prompt that no automated agent can supply. This was previously
only recorded as a one-off task-artifact note, not a durable skill rule.

## Changes

- skills/dotfiles/references/nix-operations.md: added a standing rule
  right where `nix run '.#switch'` is first introduced (Daily Usage
  table, section 1), stating agents must not run system activation
  themselves and must hand it off to a human, verifying afterward instead
  of retrying.

## Verification

- nix flake check: all checks passed (markdown formatting/lint).
